### PR TITLE
fix: recover thread replies during gap fill

### DIFF
--- a/src/lark/channelClient.test.ts
+++ b/src/lark/channelClient.test.ts
@@ -747,6 +747,91 @@ describe("ChannelClient — gap-fill after reconnect (BL-15)", () => {
     vi.resetModules();
   });
 
+  it("dispatches a gap thread reply nested under chat-messages-list thread_replies", async () => {
+    const rootMessageId = "om_thread_root";
+    const replyMessageId = "om_thread_reply";
+
+    vi.resetModules();
+    vi.doMock("node:child_process", () => ({
+      execFile: (
+        _cmd: string,
+        _args: string[],
+        cb: (err: null, result: { stdout: string; stderr: string }) => void,
+      ) => {
+        const items = [
+          {
+            message_id: rootMessageId,
+            chat_id: "oc_1",
+            chat_type: "group",
+            content: JSON.stringify({ text: "@other root task" }),
+            sender: { id: "ou_sender" },
+            create_time: String(Date.now()),
+            mentions: [{ id: { open_id: "ou_other" } }],
+            thread_id: "omt_topic",
+            thread_replies: [
+              {
+                message_id: replyMessageId,
+                chat_id: "oc_1",
+                chat_type: "group",
+                content: JSON.stringify({ text: "@bot 断线期间在旧话题里被@了" }),
+                sender: { id: "ou_sender" },
+                create_time: String(Date.now()),
+                mentions: [{ id: { open_id: "ou_bot" } }],
+                thread_id: "omt_topic",
+                root_id: "",
+              },
+              "malformed-reply",
+            ],
+          },
+        ];
+        cb(null, { stdout: JSON.stringify({ ok: true, data: { messages: items } }), stderr: "" });
+      },
+    }));
+    const chObj = makeFakeChannelWithHandlers();
+    vi.doMock("@larksuiteoapi/node-sdk", () => ({
+      createLarkChannel: () => chObj.ch,
+    }));
+
+    const { ChannelClient } = await import("./channelClient.js");
+    const client = new ChannelClient({
+      allowedChatIds: new Set(["oc_1"]),
+      botOpenId: "ou_bot",
+      appId: "cli_x",
+      appSecret: "secret",
+      connectGraceMs: 0,
+      channelStaleMs: 0,
+      openChatDiscoveryMs: 0,
+    });
+
+    const dispatched: Array<{ messageId: string; rootId?: string }> = [];
+    void (async () => {
+      for await (const ev of client.events()) {
+        dispatched.push({
+          messageId: ev.message_id,
+          rootId: typeof ev.root_id === "string" ? ev.root_id : undefined,
+        });
+      }
+    })();
+    for (let i = 0; i < 100 && !chObj.handlers["reconnected"]; i++) {
+      await new Promise((r) => setTimeout(r, 10));
+    }
+
+    chObj.handlers["reconnecting"]!(undefined);
+    chObj.handlers["reconnected"]!(undefined);
+
+    for (let i = 0; i < 100 && !dispatched.some((ev) => ev.messageId === replyMessageId); i++) {
+      await new Promise((r) => setTimeout(r, 20));
+    }
+
+    expect(dispatched).toContainEqual({ messageId: replyMessageId, rootId: rootMessageId });
+    expect(dispatched.map((ev) => ev.messageId)).not.toContain(rootMessageId);
+
+    await client.close();
+    vi.doUnmock("@larksuiteoapi/node-sdk");
+    vi.doUnmock("node:child_process");
+    vi.resetModules();
+  });
+
   it("uses live-seen chats for gap-fill when allowedChatIds is empty (open bot)", async () => {
     const liveMessageId = "om_live_open";
     const gapMessageId = "om_gap_open";

--- a/src/lark/channelClient.ts
+++ b/src/lark/channelClient.ts
@@ -123,6 +123,11 @@ function stringField(obj: unknown, key: string): string | undefined {
   return typeof value === "string" ? value : undefined;
 }
 
+function nonEmptyStringField(obj: unknown, key: string): string | undefined {
+  const value = stringField(obj, key);
+  return value && value.length > 0 ? value : undefined;
+}
+
 function parseLarkCliMessages(stdout: string): unknown[] | null {
   const parsed = JSON.parse(stdout) as unknown;
   if (Array.isArray(parsed)) return parsed;
@@ -135,6 +140,26 @@ function parseLarkCliMessages(stdout: string): unknown[] | null {
     return arrayField(data, "messages") ?? arrayField(data, "items") ?? arrayField(data, "chats");
   }
   return null;
+}
+
+function expandMessagesWithThreadReplies(messages: unknown[]): unknown[] {
+  const expanded: unknown[] = [];
+  for (const raw of messages) {
+    expanded.push(raw);
+    if (!raw || typeof raw !== "object") continue;
+    const parent = raw as Record<string, unknown>;
+    const parentRootId = nonEmptyStringField(parent, "root_id") ?? nonEmptyStringField(parent, "message_id");
+    const replies = arrayField(parent, "thread_replies") ?? [];
+    for (const replyRaw of replies) {
+      if (!replyRaw || typeof replyRaw !== "object") continue;
+      const reply = replyRaw as Record<string, unknown>;
+      expanded.push({
+        ...reply,
+        root_id: nonEmptyStringField(reply, "root_id") ?? parentRootId,
+      });
+    }
+  }
+  return expanded;
 }
 
 /** A card-button click delivered by the SDK (raw `card.action.trigger`). */
@@ -594,9 +619,10 @@ export class ChannelClient {
           continue;
         }
 
-        totalFetched += messages.length;
+        const messagesWithReplies = expandMessagesWithThreadReplies(messages);
+        totalFetched += messagesWithReplies.length;
 
-        for (const raw of messages) {
+        for (const raw of messagesWithReplies) {
           if (this.closed) break;
           const m = raw as Record<string, unknown>;
           const messageId = m["message_id"] as string | undefined;


### PR DESCRIPTION
## Summary
- expand chat history gap-fill results with nested thread_replies
- preserve parent root_id when Feishu replies omit or return an empty root_id
- skip malformed thread_replies entries before dispatch filtering

## Test
- pnpm vitest run src/lark/channelClient.test.ts
- pnpm typecheck
- pnpm test