### PR TITLE
feat: render agent-declared card image blocks

### DIFF
--- a/src/bridge/handler.test.ts
+++ b/src/bridge/handler.test.ts
@@ -110,6 +110,13 @@ interface FinalizeArgs {
   mentionOpenId?: string;
   titleOverride?: string;
   colorOverride?: string;
+  imageBlocks?: Array<{
+    img_key: string;
+    alt: string;
+    title?: string;
+    mode: "crop_center" | "fit_horizontal";
+    preview: boolean;
+  }>;
 }
 
 /**
@@ -471,6 +478,61 @@ describe("handleOne — thin-channel finalize", () => {
     expect(finalizeArgs[0]?.finalText).toBe("已走灰度,MR 已提");
     expect(finalizeArgs[0]?.mentionOpenId).toBeUndefined();
     expect(finalizeArgs[0]?.failureReason).toBeUndefined();
+  });
+
+  it("passes agent-declared image_blocks from fresh state.json into card.finalize", async () => {
+    const threadId = "om_msg";
+    const finalState = {
+      status: "ready",
+      last_message: "平台正文",
+      image_blocks: [
+        {
+          img_key: "img_v3_preview_001",
+          alt: "平台图片预览",
+          title: "预览图",
+          mode: "fit_horizontal",
+          preview: true,
+        },
+      ],
+      updated_at: "2026-06-25T10:00:00.000Z",
+    };
+    const wt = await seedWorktree(threadId);
+    await seedRepoCachePath();
+
+    runClaudeImpl = () => ({
+      events: (async function* () {
+        yield { type: "system_init", sessionId: "sess_img", raw: {} };
+        await writeFile(
+          stateFileMod.stateFilePathOf(wt),
+          JSON.stringify(finalState, null, 2),
+          "utf8",
+        );
+      })(),
+      done: Promise.resolve({ exitCode: 0, sessionId: "sess_img" }),
+      kill: () => {},
+    });
+
+    const { renderer, finalizeArgs, whenFinalized } = makeCardRenderer();
+    const { store } = makeSessionStore();
+    const { client } = makeClient(makeEvent());
+
+    const handler = new BridgeHandler({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      client: client as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      cardRenderer: renderer as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      sessionStore: store as any,
+      conventions: makeConventions(),
+      botConfig: { id: "frontend", name: "Frontend", turn_taking_limit: 10, backend: "claude" },
+    });
+
+    await handler.run();
+    await whenFinalized;
+
+    expect(finalizeArgs).toHaveLength(1);
+    expect(finalizeArgs[0]?.finalText).toBe("平台正文");
+    expect(finalizeArgs[0]?.imageBlocks).toEqual(finalState.image_blocks);
   });
 
   it("releases the message as unhandled when handleOne throws BEFORE the main try (e.g. addProcessingReaction rejects)", async () => {

--- a/src/bridge/handler.ts
+++ b/src/bridge/handler.ts
@@ -1123,6 +1123,7 @@ export class BridgeHandler {
               // (stale-guard), so stale leftover choices never reappear.
               choices: reportedState?.choices,
               choicePrompt: reportedState?.choice_prompt,
+              imageBlocks: reportedState?.image_blocks,
             });
 
             // Card was finalized successfully — drop its card.json so boot

--- a/src/bridge/stateFile.test.ts
+++ b/src/bridge/stateFile.test.ts
@@ -185,3 +185,62 @@ describe("StateFileSchema — V2 dynamic choices (agent-declared, bridge-opaque)
     expect(r.success).toBe(false);
   });
 });
+
+describe("StateFileSchema — V2 image blocks (agent-declared, bridge-opaque)", () => {
+  it("parses image_blocks and fills safe card-render defaults", () => {
+    const r = StateFileSchema.safeParse({
+      status: "ready",
+      last_message: "平台正文",
+      image_blocks: [
+        { img_key: "img_v3_preview_001" },
+        {
+          img_key: "img_v3_preview_002",
+          alt: "小红书预览图",
+          title: "对应图片",
+          mode: "crop_center",
+          preview: false,
+        },
+      ],
+      updated_at: "2026-06-25T10:00:00Z",
+    });
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.data.image_blocks).toEqual([
+        {
+          img_key: "img_v3_preview_001",
+          alt: "图片预览",
+          mode: "fit_horizontal",
+          preview: true,
+        },
+        {
+          img_key: "img_v3_preview_002",
+          alt: "小红书预览图",
+          title: "对应图片",
+          mode: "crop_center",
+          preview: false,
+        },
+      ]);
+    }
+  });
+
+  it("rejects malformed image blocks without weakening required status", () => {
+    expect(
+      StateFileSchema.safeParse({
+        status: "ready",
+        image_blocks: [{ alt: "missing key" }],
+        updated_at: "x",
+      }).success,
+    ).toBe(false);
+
+    const tooMany = Array.from({ length: 5 }, (_, i) => ({
+      img_key: `img_v3_${i}`,
+    }));
+    expect(
+      StateFileSchema.safeParse({
+        status: "ready",
+        image_blocks: tooMany,
+        updated_at: "x",
+      }).success,
+    ).toBe(false);
+  });
+});

--- a/src/bridge/stateFile.ts
+++ b/src/bridge/stateFile.ts
@@ -38,6 +38,28 @@ const optionalUrl = z.preprocess(
   z.string().optional(),
 );
 
+const imageAlt = z.preprocess(
+  (v) => (typeof v === "string" && v.trim() === "" ? undefined : v),
+  z.string().trim().min(1).max(200).default("图片预览"),
+);
+
+const imageTitle = z.preprocess(
+  (v) => (typeof v === "string" && v.trim() === "" ? undefined : v),
+  z.string().trim().min(1).max(200).optional(),
+);
+
+const ImageBlockSchema = z.object({
+  img_key: z.string().trim().min(1).max(256),
+  alt: imageAlt,
+  title: imageTitle,
+  /**
+   * Agent-facing mode maps directly to Feishu Card JSON 2.0 `scale_type`.
+   * Keep the enum narrow until we have live-card evidence for more modes.
+   */
+  mode: z.enum(["crop_center", "fit_horizontal"]).default("fit_horizontal"),
+  preview: z.boolean().default(true),
+});
+
 export const StateFileSchema = z.object({
   // Thin channel: the bridge only validates `status`. Any other key the bot
   // writes (incl. a legacy `stage`) is a business field — z.object STRIPS
@@ -117,6 +139,13 @@ export const StateFileSchema = z.object({
     .array(z.object({ label: z.string().min(1), value: z.string().min(1) }))
     .max(5)
     .optional(),
+  /**
+   * V2 image blocks (thin-channel). Agents upload or otherwise obtain `img_key`
+   * themselves, then declare generic image previews here. Bridge only renders the
+   * already-declared keys into Feishu Card JSON 2.0 image elements; it does not
+   * download, upload, choose assets, or interpret platform workflows.
+   */
+  image_blocks: z.array(ImageBlockSchema).max(4).optional(),
   /**
    * Optional one-line prompt rendered above the choice buttons (e.g. "选哪个方案?").
    * Rendered VERBATIM, bridge-opaque. Only meaningful alongside `choices`.

--- a/src/claude/prompt.ts
+++ b/src/claude/prompt.ts
@@ -242,6 +242,7 @@ function renderStateContract(stateFilePath?: string): string[] {
     "- error: 失败原因(搭配 status=failed)",
     "- card_title: 卡片标题覆盖(可选)",
     "- card_color: 卡片配色(可选,success/failure/neutral,也可直接写 green/red/grey)",
+    "- image_blocks: 可选图片预览块数组,最多 4 个。每项 `{img_key, alt?, title?, mode?, preview?}`; `img_key` 必须是已上传/可用于卡片的 Feishu 图片 key,`alt` 省略时 bridge 默认“图片预览”,`mode` 只允许 `crop_center`/`fit_horizontal` 并映射到 Card JSON 2.0 `scale_type`,`preview` 默认 true。bridge 不负责下载/上传/选择图片;这些由你用 lark-cli 等工具先完成。",
     "- dev_url / mr_url / 其余业务字段:自由写入,bridge 不感知其业务含义;要让运营看到,请写进 last_message",
     "- updated_at: ISO 8601 timestamp",
     "",

--- a/src/lark/card.test.ts
+++ b/src/lark/card.test.ts
@@ -350,6 +350,51 @@ describe("buildChoiceRow / dynamic choice card (V2)", () => {
   });
 });
 
+describe("CardRenderer — image blocks (V2)", () => {
+  it("finalize renders markdown body and agent-declared image blocks in the same Card 2.0 body", async () => {
+    const { CardRenderer } = await import("./card.js");
+    const fake = new FakeOutbound();
+    const renderer = new CardRenderer({ outbound: fake, patchIntervalMs: 10_000, botName: "Frontend" });
+    const handle = await renderer.start("om_user_msg");
+
+    await handle.finalize({
+      success: true,
+      finalText: "平台正文",
+      imageBlocks: [
+        {
+          img_key: "img_v3_preview_001",
+          alt: "平台图片预览",
+          title: "图片 1",
+          mode: "crop_center",
+          preview: true,
+        },
+      ],
+      choicePrompt: "继续?",
+      choices: [{ label: "开 PR", value: "请开 PR" }],
+    });
+
+    const card = lastPatchedCard(fake) as unknown as ElementsCard;
+    expect(card.body.elements.some((el) =>
+      el["tag"] === "markdown" && String(el["content"]).includes("平台正文")
+    )).toBe(true);
+
+    const imageEl = card.body.elements.find((el) => el["tag"] === "img");
+    expect(imageEl).toEqual({
+      tag: "img",
+      img_key: "img_v3_preview_001",
+      alt: { tag: "plain_text", content: "平台图片预览" },
+      title: { tag: "plain_text", content: "图片 1" },
+      scale_type: "crop_center",
+      preview: true,
+    });
+
+    const imageIndex = card.body.elements.findIndex((el) => el["tag"] === "img");
+    const choicesIndex = card.body.elements.findIndex((el) => el["tag"] === "column_set");
+    expect(imageIndex).toBeGreaterThan(-1);
+    expect(choicesIndex).toBeGreaterThan(imageIndex);
+  });
+});
+
 // ---------------------------------------------------------------------------
 // Injected OutboundCardClient — proves card.ts orchestration (throttle +
 // finalize) is intact and only the leaf network call is swapped.

--- a/src/lark/card.ts
+++ b/src/lark/card.ts
@@ -83,6 +83,11 @@ export interface CardHandle {
     choices?: Choice[];
     /** Optional one-line prompt above the choice buttons. */
     choicePrompt?: string;
+    /**
+     * Agent-declared image previews rendered as Card 2.0 image elements.
+     * The agent owns upload/resource selection; bridge only renders img_key.
+     */
+    imageBlocks?: ImageBlock[];
   }): Promise<void>;
 }
 
@@ -123,6 +128,21 @@ export interface Choice {
   label: string;
   /** String round-tripped back to the agent verbatim as the next turn's text. */
   value: string;
+}
+
+export type ImageScaleType = "crop_center" | "fit_horizontal";
+
+export interface ImageBlock {
+  /** Feishu uploaded image key, usually returned by im.images.create. */
+  img_key: string;
+  /** Plain-text alt content; caller/schema should provide a non-empty default. */
+  alt: string;
+  /** Optional plain-text title above the image. */
+  title?: string;
+  /** Maps directly to Feishu Card JSON 2.0 `scale_type`. */
+  mode: ImageScaleType;
+  /** Whether Feishu should allow image preview on click. */
+  preview: boolean;
 }
 
 /**
@@ -178,6 +198,24 @@ function buildChoiceLegend(choices: Choice[]): string {
   return choices
     .map((c, i) => `**${choiceMarker(i)}.** ${c.label}`)
     .join("\n");
+}
+
+function plainText(content: string): { tag: "plain_text"; content: string } {
+  return { tag: "plain_text", content };
+}
+
+function buildImageElement(block: ImageBlock): Record<string, unknown> {
+  const element: Record<string, unknown> = {
+    tag: "img",
+    img_key: block.img_key,
+    alt: plainText(block.alt || "图片预览"),
+    scale_type: block.mode,
+    preview: block.preview,
+  };
+  if (block.title) {
+    element["title"] = plainText(block.title);
+  }
+  return element;
 }
 
 // ---------------------------------------------------------------------------
@@ -276,6 +314,7 @@ function buildCardJson(opts: {
   choices?: Choice[];
   /** Optional one-line prompt rendered above the choice buttons. */
   choicePrompt?: string;
+  imageBlocks?: ImageBlock[];
   /** Bot-supplied header title override (e.g. "🎉 dev server 起来了"). */
   titleOverride?: string;
   /**
@@ -349,6 +388,18 @@ function buildCardJson(opts: {
       tag: "markdown",
       content: `⚠️ **错误**: ${opts.failureReason}`,
     });
+  }
+
+  // ── Agent-declared image previews ────────────────────────────────────────────
+  // The bridge stays thin: it never uploads or selects images. It only renders
+  // `img_key` values the agent already declared in state.json.
+  if (opts.imageBlocks && opts.imageBlocks.length) {
+    if (bodyWithMention || (opts.status === "failure" && opts.failureReason)) {
+      elements.push({ tag: "hr" });
+    }
+    for (const block of opts.imageBlocks) {
+      elements.push(buildImageElement(block));
+    }
   }
 
   // ── Dynamic choice buttons (V2) ─────────────────────────────────────────────
@@ -510,6 +561,7 @@ class CardHandleImpl implements CardHandle {
     colorOverride?: "success" | "failure" | "neutral";
     choices?: Choice[];
     choicePrompt?: string;
+    imageBlocks?: ImageBlock[];
   }): Promise<void> {
     this.finalized = true;
 
@@ -551,6 +603,7 @@ class CardHandleImpl implements CardHandle {
       // V2 dynamic-choice buttons — agent-declared, only on finalize.
       choices: opts.choices,
       choicePrompt: opts.choicePrompt,
+      imageBlocks: opts.imageBlocks,
       titleOverride: opts.titleOverride,
       // Hide tool-use summary on every finalize — the agent finished, so the
       // Feishu card should present the result/error only. Diagnostics remain in


### PR DESCRIPTION
## Summary

- add agent-declared `image_blocks` to the state schema with safe defaults
- pass image blocks through the bridge handler into card finalization
- render Feishu Card JSON 2.0 `img` elements alongside markdown body and choices
- document the output contract and add targeted tests

## Validation

- `pnpm exec vitest run src/lark/card.test.ts src/bridge/stateFile.test.ts src/bridge/handler.test.ts`
- `pnpm exec vitest run src/claude/prompt.test.ts`
- `pnpm typecheck`

Full `pnpm test` was attempted but still fails in existing config/init path tests unrelated to this change; the focused suites above cover the changed code paths.

## Risk notes

- Feishu image components require clients that support Card JSON 2.0 image rendering; live rollout should account for Feishu/Lark client version compatibility, including 7.20+ requirements noted by review.
- `img_key` ownership, lifecycle, and cross-context reuse are not guaranteed by this bridge; agents must upload/obtain valid keys for the target card context.
- Image upload remains agent-owned and requires the appropriate Feishu image upload scopes such as `im:resource` / `im:resource:upload`; the bridge does not upload assets.
- No deployment/restart is included in this PR.