### PR TITLE
feat: render ordered card sections with adjacent images

### DIFF
--- a/src/bridge/handler.test.ts
+++ b/src/bridge/handler.test.ts
@@ -117,6 +117,17 @@ interface FinalizeArgs {
     mode: "crop_center" | "fit_horizontal";
     preview: boolean;
   }>;
+  cardSections?: Array<{
+    title?: string;
+    body: string;
+    image?: {
+      img_key: string;
+      alt: string;
+      title?: string;
+      mode: "crop_center" | "fit_horizontal";
+      preview: boolean;
+    };
+  }>;
 }
 
 /**
@@ -533,6 +544,84 @@ describe("handleOne — thin-channel finalize", () => {
     expect(finalizeArgs).toHaveLength(1);
     expect(finalizeArgs[0]?.finalText).toBe("平台正文");
     expect(finalizeArgs[0]?.imageBlocks).toEqual(finalState.image_blocks);
+  });
+
+  it("passes agent-declared card_sections from fresh state.json into card.finalize", async () => {
+    const threadId = "om_msg";
+    const finalState = {
+      status: "ready",
+      last_message: "三平台预览如下。",
+      card_sections: [
+        {
+          title: "Jike",
+          body: "即刻正文",
+          image: {
+            img_key: "img_v3_jike",
+            alt: "Jike 图片",
+            mode: "fit_horizontal",
+            preview: true,
+          },
+        },
+        {
+          title: "X",
+          body: "X fallback 正文",
+          image: {
+            img_key: "img_v3_x",
+            alt: "X 图片",
+            mode: "crop_center",
+            preview: true,
+          },
+        },
+        {
+          title: "小红书",
+          body: "小红书正文",
+          image: {
+            img_key: "img_v3_xhs",
+            alt: "小红书图片",
+            mode: "fit_horizontal",
+            preview: true,
+          },
+        },
+      ],
+      updated_at: "2026-06-25T10:00:00.000Z",
+    };
+    const wt = await seedWorktree(threadId);
+    await seedRepoCachePath();
+
+    runClaudeImpl = () => ({
+      events: (async function* () {
+        yield { type: "system_init", sessionId: "sess_sections", raw: {} };
+        await writeFile(
+          stateFileMod.stateFilePathOf(wt),
+          JSON.stringify(finalState, null, 2),
+          "utf8",
+        );
+      })(),
+      done: Promise.resolve({ exitCode: 0, sessionId: "sess_sections" }),
+      kill: () => {},
+    });
+
+    const { renderer, finalizeArgs, whenFinalized } = makeCardRenderer();
+    const { store } = makeSessionStore();
+    const { client } = makeClient(makeEvent());
+
+    const handler = new BridgeHandler({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      client: client as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      cardRenderer: renderer as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      sessionStore: store as any,
+      conventions: makeConventions(),
+      botConfig: { id: "frontend", name: "Frontend", turn_taking_limit: 10, backend: "claude" },
+    });
+
+    await handler.run();
+    await whenFinalized;
+
+    expect(finalizeArgs).toHaveLength(1);
+    expect(finalizeArgs[0]?.finalText).toBe("三平台预览如下。");
+    expect(finalizeArgs[0]?.cardSections).toEqual(finalState.card_sections);
   });
 
   it("releases the message as unhandled when handleOne throws BEFORE the main try (e.g. addProcessingReaction rejects)", async () => {

--- a/src/bridge/handler.ts
+++ b/src/bridge/handler.ts
@@ -1123,6 +1123,7 @@ export class BridgeHandler {
               // (stale-guard), so stale leftover choices never reappear.
               choices: reportedState?.choices,
               choicePrompt: reportedState?.choice_prompt,
+              cardSections: reportedState?.card_sections,
               imageBlocks: reportedState?.image_blocks,
             });
 

--- a/src/bridge/stateFile.test.ts
+++ b/src/bridge/stateFile.test.ts
@@ -244,3 +244,77 @@ describe("StateFileSchema — V2 image blocks (agent-declared, bridge-opaque)", 
     ).toBe(false);
   });
 });
+
+describe("StateFileSchema — ordered card sections with adjacent images", () => {
+  it("parses card_sections and defaults each section image independently", () => {
+    const r = StateFileSchema.safeParse({
+      status: "ready",
+      last_message: "三平台预览如下。",
+      card_sections: [
+        {
+          title: "Jike",
+          body: "即刻正文",
+          image: { img_key: "img_v3_jike" },
+        },
+        {
+          title: "X",
+          body: "X fallback 正文",
+          image: {
+            img_key: "img_v3_x",
+            alt: "X 预览",
+            mode: "crop_center",
+          },
+        },
+      ],
+      updated_at: "2026-06-25T10:00:00Z",
+    });
+
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.data.card_sections).toEqual([
+        {
+          title: "Jike",
+          body: "即刻正文",
+          image: {
+            img_key: "img_v3_jike",
+            alt: "图片预览",
+            mode: "fit_horizontal",
+            preview: true,
+          },
+        },
+        {
+          title: "X",
+          body: "X fallback 正文",
+          image: {
+            img_key: "img_v3_x",
+            alt: "X 预览",
+            mode: "crop_center",
+            preview: true,
+          },
+        },
+      ]);
+    }
+  });
+
+  it("rejects blank section bodies and caps section count", () => {
+    expect(
+      StateFileSchema.safeParse({
+        status: "ready",
+        card_sections: [{ title: "Jike", body: " " }],
+        updated_at: "x",
+      }).success,
+    ).toBe(false);
+
+    const tooMany = Array.from({ length: 9 }, (_, i) => ({
+      title: `section ${i}`,
+      body: "body",
+    }));
+    expect(
+      StateFileSchema.safeParse({
+        status: "ready",
+        card_sections: tooMany,
+        updated_at: "x",
+      }).success,
+    ).toBe(false);
+  });
+});

--- a/src/bridge/stateFile.ts
+++ b/src/bridge/stateFile.ts
@@ -60,6 +60,17 @@ const ImageBlockSchema = z.object({
   preview: z.boolean().default(true),
 });
 
+const CardSectionSchema = z.object({
+  title: imageTitle,
+  body: z.string().trim().min(1).max(12_000),
+  /**
+   * Optional native image shown immediately after this section's markdown body.
+   * This is the strict review-surface path for "text + corresponding thumbnail"
+   * workflows; legacy image_blocks remain available for whole-card appendices.
+   */
+  image: ImageBlockSchema.optional(),
+});
+
 export const StateFileSchema = z.object({
   // Thin channel: the bridge only validates `status`. Any other key the bot
   // writes (incl. a legacy `stage`) is a business field — z.object STRIPS
@@ -146,6 +157,12 @@ export const StateFileSchema = z.object({
    * download, upload, choose assets, or interpret platform workflows.
    */
   image_blocks: z.array(ImageBlockSchema).max(4).optional(),
+  /**
+   * Ordered Card sections (thin-channel). Use when the review surface needs text
+   * and its corresponding native image block to stay adjacent in the same card.
+   * Each section renders as markdown body followed immediately by `image`.
+   */
+  card_sections: z.array(CardSectionSchema).max(8).optional(),
   /**
    * Optional one-line prompt rendered above the choice buttons (e.g. "选哪个方案?").
    * Rendered VERBATIM, bridge-opaque. Only meaningful alongside `choices`.

--- a/src/claude/prompt.ts
+++ b/src/claude/prompt.ts
@@ -242,6 +242,7 @@ function renderStateContract(stateFilePath?: string): string[] {
     "- error: 失败原因(搭配 status=failed)",
     "- card_title: 卡片标题覆盖(可选)",
     "- card_color: 卡片配色(可选,success/failure/neutral,也可直接写 green/red/grey)",
+    "- card_sections: 可选有序内容 section 数组,最多 8 个。每项 `{title?, body, image?}`; `body` 是该 section 的 markdown 正文,`image` 与 `image_blocks` 单项格式相同。bridge 会按顺序渲染每个 section,且把 `image` 原生图片块紧跟在该 section 正文之后。需要“平台正文 + 对应缩略图”相邻展示时优先用它。",
     "- image_blocks: 可选图片预览块数组,最多 4 个。每项 `{img_key, alt?, title?, mode?, preview?}`; `img_key` 必须是已上传/可用于卡片的 Feishu 图片 key,`alt` 省略时 bridge 默认“图片预览”,`mode` 只允许 `crop_center`/`fit_horizontal` 并映射到 Card JSON 2.0 `scale_type`,`preview` 默认 true。bridge 不负责下载/上传/选择图片;这些由你用 lark-cli 等工具先完成。",
     "- dev_url / mr_url / 其余业务字段:自由写入,bridge 不感知其业务含义;要让运营看到,请写进 last_message",
     "- updated_at: ISO 8601 timestamp",

--- a/src/lark/card.test.ts
+++ b/src/lark/card.test.ts
@@ -393,6 +393,67 @@ describe("CardRenderer — image blocks (V2)", () => {
     expect(imageIndex).toBeGreaterThan(-1);
     expect(choicesIndex).toBeGreaterThan(imageIndex);
   });
+
+  it("finalize renders ordered card_sections with each image immediately after its section body", async () => {
+    const { CardRenderer } = await import("./card.js");
+    const fake = new FakeOutbound();
+    const renderer = new CardRenderer({ outbound: fake, patchIntervalMs: 10_000, botName: "Frontend" });
+    const handle = await renderer.start("om_user_msg");
+
+    await handle.finalize({
+      success: true,
+      finalText: "三平台预览",
+      cardSections: [
+        {
+          title: "Jike",
+          body: "即刻正文",
+          image: {
+            img_key: "img_v3_jike",
+            alt: "Jike 图片",
+            mode: "fit_horizontal",
+            preview: true,
+          },
+        },
+        {
+          title: "X",
+          body: "X fallback 正文",
+          image: {
+            img_key: "img_v3_x",
+            alt: "X 图片",
+            mode: "crop_center",
+            preview: true,
+          },
+        },
+        {
+          title: "小红书",
+          body: "小红书正文",
+          image: {
+            img_key: "img_v3_xhs",
+            alt: "小红书图片",
+            mode: "fit_horizontal",
+            preview: true,
+          },
+        },
+      ],
+    });
+
+    const card = lastPatchedCard(fake) as unknown as ElementsCard;
+    const elements = card.body.elements;
+
+    const jikeText = elements.findIndex((el) =>
+      el["tag"] === "markdown" && String(el["content"]).includes("即刻正文")
+    );
+    const xText = elements.findIndex((el) =>
+      el["tag"] === "markdown" && String(el["content"]).includes("X fallback 正文")
+    );
+    const xhsText = elements.findIndex((el) =>
+      el["tag"] === "markdown" && String(el["content"]).includes("小红书正文")
+    );
+
+    expect(elements[jikeText + 1]).toMatchObject({ tag: "img", img_key: "img_v3_jike" });
+    expect(elements[xText + 1]).toMatchObject({ tag: "img", img_key: "img_v3_x" });
+    expect(elements[xhsText + 1]).toMatchObject({ tag: "img", img_key: "img_v3_xhs" });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/lark/card.ts
+++ b/src/lark/card.ts
@@ -88,6 +88,12 @@ export interface CardHandle {
      * The agent owns upload/resource selection; bridge only renders img_key.
      */
     imageBlocks?: ImageBlock[];
+    /**
+     * Agent-declared ordered sections. Each section's image, when present,
+     * renders immediately after that section body so review cards can show
+     * "platform copy + matching thumbnail" as adjacent native blocks.
+     */
+    cardSections?: CardSection[];
   }): Promise<void>;
 }
 
@@ -143,6 +149,15 @@ export interface ImageBlock {
   mode: ImageScaleType;
   /** Whether Feishu should allow image preview on click. */
   preview: boolean;
+}
+
+export interface CardSection {
+  /** Optional section title rendered above the markdown body. */
+  title?: string;
+  /** Markdown body for this section. */
+  body: string;
+  /** Optional native image rendered immediately after this section body. */
+  image?: ImageBlock;
 }
 
 /**
@@ -216,6 +231,22 @@ function buildImageElement(block: ImageBlock): Record<string, unknown> {
     element["title"] = plainText(block.title);
   }
   return element;
+}
+
+function sectionMarkdown(section: CardSection): string {
+  return [section.title ? `**${section.title}**` : "", section.body]
+    .filter(Boolean)
+    .join("\n\n");
+}
+
+function pushMarkdown(elements: unknown[], markdown: string): void {
+  const chunks = chunkMarkdown(markdown);
+  for (let i = 0; i < chunks.length; i++) {
+    elements.push({
+      tag: "markdown",
+      content: i === 0 ? chunks[i] : `(续 ${i + 1})\n${chunks[i]}`,
+    });
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -315,6 +346,7 @@ function buildCardJson(opts: {
   /** Optional one-line prompt rendered above the choice buttons. */
   choicePrompt?: string;
   imageBlocks?: ImageBlock[];
+  cardSections?: CardSection[];
   /** Bot-supplied header title override (e.g. "🎉 dev server 起来了"). */
   titleOverride?: string;
   /**
@@ -367,13 +399,7 @@ function buildCardJson(opts: {
   if (bodyWithMention) {
     // Split into chunks to stay within Feishu's ~3000-char markdown element
     // limit; each chunk becomes its own markdown element.
-    const chunks = chunkMarkdown(bodyWithMention);
-    for (let i = 0; i < chunks.length; i++) {
-      elements.push({
-        tag: "markdown",
-        content: i === 0 ? chunks[i] : `(续 ${i + 1})\n${chunks[i]}`,
-      });
-    }
+    pushMarkdown(elements, bodyWithMention);
   } else if (opts.status === "thinking") {
     elements.push({
       tag: "markdown",
@@ -390,11 +416,31 @@ function buildCardJson(opts: {
     });
   }
 
+  // ── Agent-declared ordered sections ────────────────────────────────────────
+  // Use this when native image adjacency matters. Each section body is pushed
+  // as markdown, then its image element is pushed immediately after it. Section
+  // boundaries get an hr only before the next section, never between a section
+  // body and its corresponding image.
+  if (opts.cardSections && opts.cardSections.length) {
+    if (bodyWithMention || (opts.status === "failure" && opts.failureReason)) {
+      elements.push({ tag: "hr" });
+    }
+    opts.cardSections.forEach((section, index) => {
+      if (index > 0) elements.push({ tag: "hr" });
+      pushMarkdown(elements, sectionMarkdown(section));
+      if (section.image) elements.push(buildImageElement(section.image));
+    });
+  }
+
   // ── Agent-declared image previews ────────────────────────────────────────────
   // The bridge stays thin: it never uploads or selects images. It only renders
   // `img_key` values the agent already declared in state.json.
   if (opts.imageBlocks && opts.imageBlocks.length) {
-    if (bodyWithMention || (opts.status === "failure" && opts.failureReason)) {
+    if (
+      bodyWithMention ||
+      (opts.status === "failure" && opts.failureReason) ||
+      (opts.cardSections && opts.cardSections.length)
+    ) {
       elements.push({ tag: "hr" });
     }
     for (const block of opts.imageBlocks) {
@@ -562,6 +608,7 @@ class CardHandleImpl implements CardHandle {
     choices?: Choice[];
     choicePrompt?: string;
     imageBlocks?: ImageBlock[];
+    cardSections?: CardSection[];
   }): Promise<void> {
     this.finalized = true;
 
@@ -603,6 +650,7 @@ class CardHandleImpl implements CardHandle {
       // V2 dynamic-choice buttons — agent-declared, only on finalize.
       choices: opts.choices,
       choicePrompt: opts.choicePrompt,
+      cardSections: opts.cardSections,
       imageBlocks: opts.imageBlocks,
       titleOverride: opts.titleOverride,
       // Hide tool-use summary on every finalize — the agent finished, so the


### PR DESCRIPTION
## Summary

- add `card_sections` to the agent state contract for ordered markdown sections with adjacent native image blocks
- render each section as markdown followed immediately by its `img` Card JSON 2.0 element
- keep existing `image_blocks` behavior for whole-card appendix images
- document the new field in the injected prompt contract and cover schema/handler/card rendering with tests

## Verification

- `pnpm vitest run src/bridge/stateFile.test.ts src/lark/card.test.ts src/bridge/handler.test.ts`
- `pnpm typecheck`

## Notes

- `pnpm test` still has existing failures in CLI init/hostConfig isolation tests unrelated to the card renderer path. Focused tests and typecheck pass.
- No deploy, restart, merge, release, or public social action performed.