### PR TITLE
test: clarify v0.3 readiness gate

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,9 +22,11 @@ pnpm test          # run all unit tests (vitest)
 pnpm typecheck     # TypeScript strict check (no emit)
 ```
 
-Tests are pure unit tests (no subprocess spawning, no network). The full
-acceptance suite (`pnpm test:v0.3`) requires a live Feishu app credential and
-is intended for maintainers.
+Tests are pure unit tests (no subprocess spawning, no network). The v0.3 local
+readiness gate (`pnpm test:v0.3`) is also safe to run without live Feishu
+credentials; it combines local checks and synthetic smoke fixtures. Real Feishu
+E2E smoke testing is maintainer-only and requires a separately approved test
+environment; see [docs/phase0-readiness.md](docs/phase0-readiness.md).
 
 ## Releasing (maintainers)
 

--- a/bin/v0.3-local-acceptance.sh
+++ b/bin/v0.3-local-acceptance.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
-# One-command local acceptance for v0.3 Phase 1.
+# One-command local readiness gate for v0.3 Phase 0.
 #
-# This is the last local gate before real Feishu dogfood. It intentionally does
-# not use production Feishu credentials and does not touch the real ~/.larkway.
+# This gate is intentionally local-only. It must not start a bridge, subscribe
+# to Feishu events, send messages/cards, upload images, or require private
+# app/chat credentials. Real Feishu E2E is a separate owner-authorized smoke
+# path; see docs/phase0-readiness.md.
 set -euo pipefail
 
 REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -13,26 +15,27 @@ step() {
   echo "=== $* ==="
 }
 
+run_local() {
+  (
+    unset LARKWAY_HOME
+    unset LARKWAY_BOTS_DIR
+    "$@"
+  )
+}
+
 step "1. unit tests"
-pnpm test
+run_local pnpm test
 
 step "2. typecheck"
-pnpm typecheck
+run_local pnpm typecheck
 
 step "3. doc links"
-pnpm check:links
+run_local pnpm check:links
 
-step "4. normal dogfood creation path"
-./bin/v0.3-dogfood-normal-path-smoke.sh
-
-step "5. startup preconditions and permission audit"
-./bin/v0.3-dogfood-startup-smoke.sh
-
-step "6. dogfood verify helper"
-./bin/v0.3-dogfood-e2e-verify-smoke.sh
-
-step "7. Claude backend smoke"
-./bin/v0.3-claude-backend-smoke.sh
+step "4. Claude backend dry-run smoke"
+run_local ./bin/v0.3-claude-backend-smoke.sh
 
 echo
-echo "✓ v0.3 local acceptance passed"
+echo "✓ v0.3 Phase 0 local readiness passed"
+echo "  Real Feishu E2E remains gated on an owner-authorized test app, test chat,"
+echo "  isolated LARKWAY_HOME, and controlled bridge lifecycle."

--- a/docs/phase0-readiness.md
+++ b/docs/phase0-readiness.md
@@ -1,0 +1,99 @@
+# Phase 0 Readiness Gate
+
+This document defines the public, local-only readiness gate for v0.3 and the
+separate prerequisites for real Feishu E2E smoke testing.
+
+## Decision
+
+`pnpm test:v0.3` is a local readiness gate. It verifies the repository can pass
+the safe checks that do not require private Feishu resources:
+
+- `pnpm test`
+- `pnpm typecheck`
+- `pnpm check:links`
+- `bin/v0.3-claude-backend-smoke.sh`
+
+The gate must not start a bridge, subscribe to Feishu events, send messages or
+cards, upload files or images, mutate `~/.larkway`, or rely on private app/chat
+credentials.
+
+Real Feishu E2E is not part of `pnpm test:v0.3`. It is a separate smoke test
+that requires explicit maintainer authorization and an isolated test
+environment.
+
+## What Phase 0 Proves
+
+The local gate proves:
+
+- unit and targeted tests pass without network calls;
+- TypeScript still typechecks;
+- documented repository links are valid;
+- the Claude backend dogfood preflight and dry-run startup path can execute
+  against synthetic local fixtures.
+
+It does not prove:
+
+- Feishu WebSocket delivery;
+- live bridge startup or shutdown behavior;
+- card PATCH behavior against Feishu;
+- client-side Card JSON 2.0 rendering;
+- image upload, `image_key` ownership, lifecycle, or reuse;
+- thread continuation behavior in a real chat.
+
+## Real E2E Prerequisites
+
+A real smoke environment should be created and approved before any test that
+talks to Feishu:
+
+- a dedicated test Feishu app and bot, separate from production bots;
+- a dedicated test chat that contains only authorized reviewers and the test
+  bot;
+- a dedicated local workspace slot and isolated `LARKWAY_HOME` /
+  `LARKWAY_BOTS_DIR`;
+- a safe bridge lifecycle plan that cannot stop or restart an active production
+  bridge;
+- the minimum app scopes needed for the scenario, such as receiving mentions,
+  sending bot messages/cards, updating card messages, reading target messages,
+  and uploading message images when the scenario covers image blocks;
+- a known user identity for triggering test mentions and replies;
+- test-only images or pre-created test `image_key` values owned by the same app
+  and tenant;
+- a reviewer-visible evidence path for logs, message IDs, card payloads, and
+  screenshots.
+
+## Recommended E2E Path
+
+For a card-rendering feature such as markdown/image interleaving, the complete
+acceptance path should be:
+
+1. Implement the feature PR with unit tests and card JSON snapshots.
+2. Run `pnpm test:v0.3` in the repository.
+3. With owner approval, deploy or run the PR build in the isolated test bridge
+   environment only.
+4. Send one test card to the dedicated test chat with an ordered
+   markdown-image-markdown-image body.
+5. Capture API readback, renderer payload, message ID, log ID, and screenshots
+   from supported clients.
+6. Have an independent reviewer verify element order, fallback text, image
+   visibility, and client compatibility.
+
+## Compatibility
+
+Existing local unit tests and card snapshot tests remain the first-line gate.
+Existing state formats should continue to parse unless a feature PR explicitly
+introduces a versioned schema migration. Any future E2E helper should fail
+closed when required test app, chat, image, or bridge lifecycle configuration is
+missing.
+
+## Risks
+
+- A script that controls a bridge can affect an active local or production
+  process if it is not isolated.
+- A real Feishu smoke can pass API validation but still render differently on
+  unsupported clients.
+- `image_key` values are scoped to app and tenant ownership; reuse across apps
+  or tenants may fail.
+- Upload scopes and send/update scopes are separate; a test app may be able to
+  send cards but not upload or reuse images.
+- Public repository docs must not contain private app IDs, chat IDs, user IDs,
+  tokens, hostnames, or internal runbook details.


### PR DESCRIPTION
## Summary
- make `pnpm test:v0.3` an explicit local-only Phase 0 readiness gate
- remove calls to missing dogfood helper scripts from the local gate
- document the owner-authorized real Feishu E2E prerequisites and evidence path

## Verification
- `bash -n bin/v0.3-local-acceptance.sh`
- `pnpm test:v0.3`

## Boundaries
No deploy, no restart, no bridge startup, no test card/image send, no image upload. Real Feishu E2E remains blocked on a separately approved isolated test app, test chat, bridge lifecycle, scopes, and test image resources.