### PR TITLE
Add default-off response surface foundation

### DIFF
--- a/docs/prompt-contract.md
+++ b/docs/prompt-contract.md
@@ -153,12 +153,14 @@ Agent 通过工作区里的 `.larkway/state.json` 或 v0.3 session state artifac
 - `card_title` / `card_color`: 可选的标题和色彩语义。
 - `choices` / `choice_prompt`: 可选的离散选择。按钮点击只把 value 作为新一轮文本交回 Agent。
 - `content_blocks`: 可选的有序 markdown/image 正文块。需要平台正文与匹配图片在同一 review card 里相邻展示时使用;优先级和示例见 [Review Card Content Blocks](review-card-content-blocks.md)。
+- `response_surface`: 可选原型声明,用于未来 `card` / `post` / `hybrid` surface。PR1/PR2 只提供默认关闭的 schema/config/controller 基础层;真实 post outbound、ledger、peer at 和 E2E 不在此阶段。协议和门禁见 [Response Surface Prototype](response-surface-prototype.md)。
 
 关键边界:
 
 - Agent **绝不**自己 `lark-cli api PATCH .../im/v1/messages/...` 改卡片。
 - bridge 不从 Agent 输出里正则抓 MR URL、预览 URL、业务阶段或下一步动作。
 - bridge 不规定正文必须分成固定几个业务区块;它只提供稳定外壳和安全渲染。
+- 在 `response_surface` prototype 中,surface 选择仍由 Agent 声明;bridge 只做门禁、机械降级和可见 fallback。PR3 真实 post outbound/ledger 未实现前,即使命中 dark-launch 配置,也必须保留现有 card 可见路径,不得制造“无 card、无 post”的不可见回复。
 - 如果 Agent 需要用户补充多字段信息,默认让用户在话题里文字回复;按钮只适合一次点击能完整表达的单选。
 
 最终消息建议清楚,但不是强格式:

--- a/docs/response-surface-prototype.md
+++ b/docs/response-surface-prototype.md
@@ -1,0 +1,127 @@
+# Response Surface Prototype
+
+Status: PR1/PR2 foundation only. Default disabled.
+
+This document defines the dark-launch foundation for future `card` / `post` /
+`hybrid` response surfaces. It does not implement real IM post outbound, peer
+`at`, post ledger, visible post failure fallback, Feishu E2E, deployment, or
+production enablement.
+
+## Principles
+
+- The Agent chooses the response surface by writing `response_surface` in
+  `state.json`.
+- The bridge provides channel infrastructure only: validation, mechanical
+  degradation, idempotency/fallback/reconcile plumbing, and safe rendering.
+- The bridge must not encode business rules such as "short task = post" or
+  "long task = card".
+- Existing bots keep the legacy visible card path unless a bot is explicitly
+  configured for this prototype and the current chat/thread is allowlisted.
+
+## State Protocol
+
+Agents may write:
+
+```json
+{
+  "status": "ready",
+  "last_message": "Operator-facing fallback body.",
+  "response_surface": {
+    "mode": "card",
+    "primary": "card",
+    "post": {
+      "mentions": [{ "user_id": "<open_id>", "label": "Peer bot" }]
+    },
+    "card": {
+      "compact": false,
+      "capabilities": ["choices", "content_blocks", "fallback"]
+    }
+  },
+  "updated_at": "2026-06-26T00:00:00.000Z"
+}
+```
+
+Supported narrow fields:
+
+- `mode`: `card`, `post`, or `hybrid`.
+- `primary`: `card` or `post`.
+- `post.mentions[]`: future post mention targets. These are declarations only
+  until PR3 implements real post outbound.
+- `card.compact`: whether the card is intended as a compact secondary surface.
+- `card.capabilities[]`: `choices`, `image_blocks`, `content_blocks`,
+  `fallback`, or `audit`.
+
+The schema soft-fails this prototype field. A malformed `response_surface`
+becomes `undefined` and must not discard `status`, `last_message`, choices, or
+other legacy card fields needed to finalize the existing card.
+
+## Bot Config Gate
+
+Per-bot YAML may opt into the prototype:
+
+```yaml
+response_surface_prototype:
+  enabled: true
+  allowed_chats:
+    - <chat_id>
+  allowed_threads:
+    - <thread_id>
+  lazy_card_creation: true
+  text_threshold_chars: 1200
+```
+
+Defaults:
+
+- `enabled: false`
+- `allowed_chats: []`
+- `allowed_threads: []`
+- `lazy_card_creation: false`
+- `text_threshold_chars: 1200`
+
+`enabled: true` alone is insufficient. A current chat or thread must match the
+allowlist before the prototype can affect runtime behavior.
+
+## PR2 SurfaceController Foundation
+
+`SurfaceController` centralizes the card-start decision. In this PR it is wired
+with `postOutboundAvailable: false`, because real post outbound and ledger are
+explicitly out of scope.
+
+Therefore all production paths still create the legacy visible card before the
+Agent runs:
+
+- prototype disabled -> card immediately
+- not allowlisted -> card immediately
+- lazy card disabled -> card immediately
+- lazy card enabled but post outbound unavailable -> card immediately
+
+The future lazy branch only becomes eligible after a later PR supplies real post
+outbound, idempotency, ledger, and visible failure fallback.
+
+## PR3 Idempotency Reservation
+
+PR3 must derive post idempotency keys in the bridge, not trust arbitrary
+Agent-authored strings.
+
+Reserved rule:
+
+- deterministic input: bot id, stable thread/session id, trigger message id,
+  response surface role, and a bounded content digest;
+- output: a compact ASCII key no longer than 64 characters;
+- retries for the same logical post must reuse the same key;
+- a changed logical post must derive a different key;
+- the key must never include secrets or raw message body text.
+
+Reason: live dogfood found that overly long Feishu idempotency keys can trigger
+`99992402 field validation failed`. The card path already uses compact derived
+UUIDs for card replies; PR3 should follow that shape.
+
+## Non-Goals In PR1/PR2
+
+- No real IM post outbound.
+- No real peer `at`.
+- No `post.json` / post ledger.
+- No visible post failure fallback.
+- No Feishu E2E or test cards.
+- No deployment, restart, or production bridge touch.
+- No expansion of dogfood surface.

--- a/src/bridge/handler.test.ts
+++ b/src/bridge/handler.test.ts
@@ -435,6 +435,48 @@ describe("handleOne — thin-channel finalize", () => {
     expect(callOrder.at(-1)).toBe("ack:om_msg");
   });
 
+  it("keeps visible card fallback when response-surface prototype is dark-launched before post outbound exists", async () => {
+    const { renderer, startArgs, finalizeArgs, whenFinalized } = makeCardRenderer();
+    const { store } = makeSessionStore();
+    const { client } = makeClient(makeEvent());
+    stubRunClaude("sess_surface", 0);
+
+    const handler = new BridgeHandler({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      client: client as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      cardRenderer: renderer as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      sessionStore: store as any,
+      conventions: makeConventions(),
+      botConfig: {
+        id: "frontend",
+        name: "Frontend",
+        turn_taking_limit: 10,
+        backend: "claude",
+        response_surface_prototype: {
+          enabled: true,
+          allowed_chats: ["oc_chat"],
+          allowed_threads: [],
+          lazy_card_creation: true,
+          text_threshold_chars: 900,
+        },
+      },
+    });
+
+    await seedRepoCachePath();
+    await handler.run();
+    await whenFinalized;
+
+    expect(startArgs).toHaveLength(1);
+    expect(startArgs[0]).toMatchObject({
+      messageId: "om_msg",
+      threadId: "om_msg",
+    });
+    expect(finalizeArgs).toHaveLength(1);
+    expect(finalizeArgs[0]?.success).toBe(true);
+  });
+
   it("late-stage state.json WITHOUT dev_url is NOT probed and NOT demoted (status=ready → success)", async () => {
     // parseMessage derives threadId from root_id || message_id; makeEvent() has
     // no root_id, so the per-thread worktree dir is named after message_id.

--- a/src/bridge/handler.ts
+++ b/src/bridge/handler.ts
@@ -33,8 +33,10 @@ import { ensureSessionArtifacts } from "../agent/sessionArtifacts.js";
 import { ensureAgentWorkspace } from "../agent/workspaceStore.js";
 import { ensureStateFile, readStateFile, stateFilePathOf } from "./stateFile.js";
 import { writeCardFile, deleteCardFile } from "./cardFile.js";
+import { SurfaceController } from "./surfaceController.js";
 import type { RuntimeEventPatch } from "./eventLog.js";
 import type { RuntimeRequirement } from "../runtimeRequirements.js";
+import type { ResponseSurfacePrototypeConfig } from "../responseSurface.js";
 
 // ---------------------------------------------------------------------------
 // Private helpers — worktree bootstrap
@@ -457,6 +459,7 @@ export interface BridgeHandlerDeps {
     runtime?: "legacy" | "agent_workspace";
     git_token_env?: string;       // preferred: generic git PAT env-var name
     gitlab_token_env?: string;    // compat alias (legacy)
+    response_surface_prototype?: ResponseSurfacePrototypeConfig;
   };
   /**
    * V2: L2 Agent Memory content (职能定义) — loaded from the bot's memory_file by
@@ -646,27 +649,44 @@ export class BridgeHandler {
     // anchored on the user's message. Thread-replies pass false.
     const isTopLevel = !(typeof parsed.raw.root_id === "string" && parsed.raw.root_id);
     const replyInThread = isTopLevel;
+    const surfaceController = SurfaceController.create({
+      prototypeConfig: this.deps.botConfig?.response_surface_prototype,
+      chatId: parsed.chatId,
+      threadId,
+      // PR3 owns real post outbound + ledger + visible post failure fallback.
+      // Until then every runtime path keeps the legacy visible card fallback.
+      postOutboundAvailable: false,
+    });
     let card: import("../lark/card.js").CardHandle | undefined;
-    try {
-      card = await this.deps.cardRenderer.start(messageId, { replyInThread, threadId });
+    if (surfaceController.shouldStartCardImmediately()) {
+      try {
+        card = await this.deps.cardRenderer.start(messageId, { replyInThread, threadId });
+        await recordEvent({
+          status: "running",
+          startedAt: new Date().toISOString(),
+          appendPath: "已创建卡片",
+          reason: "已交给本地 Agent 处理。",
+        });
+      } catch (err) {
+        console.error("[bridge.handler] Failed to start card for thread", threadId, err);
+        await recordEvent({
+          status: "running",
+          startedAt: new Date().toISOString(),
+          appendPath: "卡片创建失败，继续执行",
+          reason: "卡片创建失败，但 bridge 会继续启动本地 Agent。",
+        });
+        // Without a card we can still run Claude, but operator won't see output.
+        // Proceed — sessionStore still needs updating.
+      } finally {
+        await this.deps.client.removeProcessingReaction?.(messageId);
+      }
+    } else {
       await recordEvent({
         status: "running",
         startedAt: new Date().toISOString(),
-        appendPath: "已创建卡片",
-        reason: "已交给本地 Agent 处理。",
+        appendPath: "延迟创建卡片",
+        reason: "response_surface prototype lazy card creation is enabled.",
       });
-    } catch (err) {
-      console.error("[bridge.handler] Failed to start card for thread", threadId, err);
-      await recordEvent({
-        status: "running",
-        startedAt: new Date().toISOString(),
-        appendPath: "卡片创建失败，继续执行",
-        reason: "卡片创建失败，但 bridge 会继续启动本地 Agent。",
-      });
-      // Without a card we can still run Claude, but operator won't see output.
-      // Proceed — sessionStore still needs updating.
-    } finally {
-      await this.deps.client.removeProcessingReaction?.(messageId);
     }
 
     try {

--- a/src/bridge/stateFile.test.ts
+++ b/src/bridge/stateFile.test.ts
@@ -186,6 +186,82 @@ describe("StateFileSchema — V2 dynamic choices (agent-declared, bridge-opaque)
   });
 });
 
+describe("StateFileSchema — response_surface prototype declaration", () => {
+  it("parses a card response surface declaration without changing legacy fields", () => {
+    const r = StateFileSchema.safeParse({
+      status: "ready",
+      last_message: "still rendered by the legacy card path",
+      response_surface: {
+        mode: "card",
+        primary: "card",
+        card: {
+          compact: false,
+          capabilities: ["choices", "content_blocks"],
+        },
+      },
+      updated_at: "2026-06-26T09:00:00.000Z",
+    });
+
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.data.last_message).toBe("still rendered by the legacy card path");
+      expect(r.data.response_surface).toEqual({
+        mode: "card",
+        primary: "card",
+        card: {
+          compact: false,
+          capabilities: ["choices", "content_blocks"],
+        },
+      });
+    }
+  });
+
+  it("parses a hybrid declaration with post mentions and compact card metadata", () => {
+    const r = StateFileSchema.safeParse({
+      status: "ready",
+      response_surface: {
+        mode: "hybrid",
+        primary: "post",
+        post: {
+          mentions: [{ user_id: "ou_peer", label: "Peer bot" }],
+        },
+        card: {
+          compact: true,
+          capabilities: ["audit", "fallback"],
+        },
+      },
+      updated_at: "2026-06-26T09:00:00.000Z",
+    });
+
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.data.response_surface?.post?.mentions).toEqual([
+        { user_id: "ou_peer", label: "Peer bot" },
+      ]);
+      expect(r.data.response_surface?.card?.compact).toBe(true);
+    }
+  });
+
+  it("soft-fails malformed response_surface so status is still usable", () => {
+    const r = StateFileSchema.safeParse({
+      status: "ready",
+      last_message: "must survive a bad prototype field",
+      response_surface: {
+        mode: "card",
+        primary: "post",
+      },
+      updated_at: "2026-06-26T09:00:00.000Z",
+    });
+
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.data.status).toBe("ready");
+      expect(r.data.last_message).toBe("must survive a bad prototype field");
+      expect(r.data.response_surface).toBeUndefined();
+    }
+  });
+});
+
 describe("StateFileSchema — V2 image blocks (agent-declared, bridge-opaque)", () => {
   it("parses image_blocks and fills safe card-render defaults", () => {
     const r = StateFileSchema.safeParse({

--- a/src/bridge/stateFile.ts
+++ b/src/bridge/stateFile.ts
@@ -16,6 +16,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { z } from "zod";
+import { ResponseSurfaceStateSchema } from "../responseSurface.js";
 
 // ---------------------------------------------------------------------------
 // Schema
@@ -188,6 +189,13 @@ export const StateFileSchema = z.object({
    * Rendered VERBATIM, bridge-opaque. Only meaningful alongside `choices`.
    */
   choice_prompt: z.string().optional(),
+  /**
+   * Prototype response-surface declaration. Soft-failed by schema design: a bad
+   * prototype field becomes undefined and must not discard status/last_message.
+   * Runtime behavior is gated by bot config; when disabled, this field is
+   * ignored and the legacy card path remains authoritative.
+   */
+  response_surface: ResponseSurfaceStateSchema.optional(),
   updated_at: z.string(),
 });
 

--- a/src/bridge/surfaceController.test.ts
+++ b/src/bridge/surfaceController.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { SurfaceController } from "./surfaceController.js";
+
+const allowlistedConfig = {
+  enabled: true,
+  allowed_chats: ["oc_allowed"],
+  allowed_threads: [],
+  lazy_card_creation: true,
+  text_threshold_chars: 1200,
+};
+
+describe("SurfaceController", () => {
+  it("keeps legacy eager card creation when the prototype is disabled", () => {
+    const controller = SurfaceController.create({
+      prototypeConfig: {
+        enabled: false,
+        allowed_chats: [],
+        allowed_threads: [],
+        lazy_card_creation: false,
+        text_threshold_chars: 1200,
+      },
+      chatId: "oc_allowed",
+      threadId: "om_thread",
+      postOutboundAvailable: false,
+    });
+
+    expect(controller.shouldStartCardImmediately()).toBe(true);
+    expect(controller.decision.reason).toBe("prototype-disabled");
+  });
+
+  it("keeps legacy card creation outside the dark-launch allowlist", () => {
+    const controller = SurfaceController.create({
+      prototypeConfig: allowlistedConfig,
+      chatId: "oc_other",
+      threadId: "om_thread",
+      postOutboundAvailable: false,
+    });
+
+    expect(controller.shouldStartCardImmediately()).toBe(true);
+    expect(controller.decision.reason).toBe("not-allowlisted");
+  });
+
+  it("keeps card fallback before PR3 post outbound exists", () => {
+    const controller = SurfaceController.create({
+      prototypeConfig: allowlistedConfig,
+      chatId: "oc_allowed",
+      threadId: "om_thread",
+      postOutboundAvailable: false,
+    });
+
+    expect(controller.shouldStartCardImmediately()).toBe(true);
+    expect(controller.decision.reason).toBe("post-outbound-unavailable-card-fallback");
+  });
+
+  it("has a future lazy-ready path only when post outbound is available", () => {
+    const controller = SurfaceController.create({
+      prototypeConfig: allowlistedConfig,
+      chatId: "oc_allowed",
+      threadId: "om_thread",
+      postOutboundAvailable: true,
+    });
+
+    expect(controller.shouldStartCardImmediately()).toBe(false);
+    expect(controller.decision.reason).toBe("lazy-card-ready");
+  });
+});

--- a/src/bridge/surfaceController.ts
+++ b/src/bridge/surfaceController.ts
@@ -1,0 +1,94 @@
+import {
+  isResponseSurfacePrototypeAllowlisted,
+  type ResponseSurfacePrototypeConfig,
+} from "../responseSurface.js";
+
+export interface SurfaceControllerInput {
+  prototypeConfig?: ResponseSurfacePrototypeConfig;
+  chatId: string;
+  threadId: string;
+  /**
+   * PR3+ hook. This PR deliberately keeps it false in production wiring because
+   * real post outbound, ledger, and visible failure fallback are out of scope.
+   */
+  postOutboundAvailable: boolean;
+}
+
+export interface SurfaceControllerDecision {
+  /**
+   * Whether handler must create the legacy processing card before running the
+   * agent. PR1/PR2 production wiring keeps this true in every path.
+   */
+  startCardImmediately: boolean;
+  prototypeEnabled: boolean;
+  lazyCardCreationEnabled: boolean;
+  reason:
+    | "prototype-disabled"
+    | "not-allowlisted"
+    | "lazy-card-disabled"
+    | "post-outbound-unavailable-card-fallback"
+    | "lazy-card-ready";
+}
+
+export class SurfaceController {
+  readonly decision: SurfaceControllerDecision;
+
+  private constructor(decision: SurfaceControllerDecision) {
+    this.decision = decision;
+  }
+
+  static create(input: SurfaceControllerInput): SurfaceController {
+    const cfg = input.prototypeConfig;
+    if (!cfg?.enabled) {
+      return new SurfaceController({
+        startCardImmediately: true,
+        prototypeEnabled: false,
+        lazyCardCreationEnabled: false,
+        reason: "prototype-disabled",
+      });
+    }
+
+    if (
+      !isResponseSurfacePrototypeAllowlisted(cfg, {
+        chatId: input.chatId,
+        threadId: input.threadId,
+      })
+    ) {
+      return new SurfaceController({
+        startCardImmediately: true,
+        prototypeEnabled: false,
+        lazyCardCreationEnabled: false,
+        reason: "not-allowlisted",
+      });
+    }
+
+    if (!cfg.lazy_card_creation) {
+      return new SurfaceController({
+        startCardImmediately: true,
+        prototypeEnabled: true,
+        lazyCardCreationEnabled: false,
+        reason: "lazy-card-disabled",
+      });
+    }
+
+    if (!input.postOutboundAvailable) {
+      return new SurfaceController({
+        startCardImmediately: true,
+        prototypeEnabled: true,
+        lazyCardCreationEnabled: false,
+        reason: "post-outbound-unavailable-card-fallback",
+      });
+    }
+
+    return new SurfaceController({
+      startCardImmediately: false,
+      prototypeEnabled: true,
+      lazyCardCreationEnabled: true,
+      reason: "lazy-card-ready",
+    });
+  }
+
+  shouldStartCardImmediately(): boolean {
+    return this.decision.startCardImmediately;
+  }
+}

--- a/src/claude/prompt.test.ts
+++ b/src/claude/prompt.test.ts
@@ -93,6 +93,9 @@ describe("renderPrompt — V2 mode (botName set)", () => {
     expect(prompt).toContain("<state-contract>");
     expect(prompt).toContain("status: in_progress / ready / failed");
     expect(prompt).toContain("content_blocks");
+    expect(prompt).toContain("response_surface");
+    expect(prompt).toContain("PR3 真实 post outbound/ledger 未实现前");
+    expect(prompt).toContain("不要写 raw Feishu post/card JSON");
     expect(prompt).toContain("markdown -> image -> markdown -> image");
     expect(prompt).toContain("若 `content_blocks` 非空");
     expect(prompt).toContain("scheduled reply / daily social ops review card");

--- a/src/claude/prompt.ts
+++ b/src/claude/prompt.ts
@@ -244,6 +244,7 @@ function renderStateContract(stateFilePath?: string): string[] {
     "- card_color: 卡片配色(可选,success/failure/neutral,也可直接写 green/red/grey)",
     "- image_blocks: 可选图片预览块数组,最多 4 个。每项 `{img_key, alt?, title?, mode?, preview?}`; `img_key` 必须是已上传/可用于卡片的 Feishu 图片 key,`alt` 省略时 bridge 默认“图片预览”,`mode` 只允许 `crop_center`/`fit_horizontal` 并映射到 Card JSON 2.0 `scale_type`,`preview` 默认 true。bridge 不负责下载/上传/选择图片;这些由你用 lark-cli 等工具先完成。",
     "- content_blocks: 可选有序正文块数组,最多 12 个 block、最多 4 个 image block。只支持窄 union:`{type:\"markdown\", content}` 和 `{type:\"image\", img_key, alt?, title?, mode?, preview?}`;不支持 raw card JSON。用于正文与图片交错排版,例如 markdown -> image -> markdown -> image。若 `content_blocks` 非空,bridge 以它作为主正文并忽略 `last_message` + `image_blocks` 的正文渲染,避免重复;若省略则保持旧 `last_message` + `image_blocks` 行为。",
+    "- response_surface: 可选原型字段,形如 `{mode:\"card\"|\"post\"|\"hybrid\", primary?:\"card\"|\"post\", post?:{mentions:[{user_id,label?}]}, card?:{compact?:boolean, capabilities?:[...]}}`。当前仅在 bot 配置显式启用且命中白名单时才可能被 bridge 读取;PR3 真实 post outbound/ledger 未实现前,bridge 必须保留现有可见 card 兜底。不要写 raw Feishu post/card JSON。",
     "- scheduled reply / daily social ops review card 等需要“平台正文 + 匹配图片”同段相邻展示的场景,应先取得各图片 `img_key`,再写 `content_blocks` 为 `平台 markdown -> 对应 image -> 下个平台 markdown -> 对应 image`;不要用单独话题图片消息或尾部 `image_blocks` 代替验收面。",
     "- dev_url / mr_url / 其余业务字段:自由写入,bridge 不感知其业务含义;要让运营看到,请写进 last_message",
     "- updated_at: ISO 8601 timestamp",

--- a/src/cli/botsStore.test.ts
+++ b/src/cli/botsStore.test.ts
@@ -8,6 +8,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import type { BotConfig } from "../config/botLoader.js";
+import { DEFAULT_RESPONSE_SURFACE_PROTOTYPE } from "../responseSurface.js";
 
 let tmp: string;
 let store: typeof import("./botsStore.js");
@@ -25,6 +26,7 @@ const sampleBot = (): BotConfig =>
     repos: [{ slug: "group/repo", branch: "master" }],
     turn_taking_limit: 10,
     read_only: false,
+    response_surface_prototype: DEFAULT_RESPONSE_SURFACE_PROTOTYPE,
     runtime: "legacy",
     backend: "claude",
   }) as BotConfig;

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -36,6 +36,7 @@ import {
 import { ensureAgentWorkspace, resetAgentWorkspacePermissions } from "../../agent/workspaceStore.js";
 import { permissionItemsFromCapabilities } from "../../agent/permissionPlan.js";
 import { resolveAgentWorkspacePathFromHome } from "../../config/paths.js";
+import { DEFAULT_RESPONSE_SURFACE_PROTOTYPE } from "../../responseSurface.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -631,6 +632,7 @@ async function runCreateBot(
     repos: basics.repos,
     turn_taking_limit: basics.turnLimit ?? 10,
     read_only: false,
+    response_surface_prototype: DEFAULT_RESPONSE_SURFACE_PROTOTYPE,
     runtime: "agent_workspace",
     backend: basics.backend,
     memory_file: memoryFile,

--- a/src/cli/commands/memory.test.ts
+++ b/src/cli/commands/memory.test.ts
@@ -20,6 +20,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import type { BotConfig } from "../../config/botLoader.js";
 import type { CliContext, CommandRun } from "../types.js";
+import { DEFAULT_RESPONSE_SURFACE_PROTOTYPE } from "../../responseSurface.js";
 
 // ---------------------------------------------------------------------------
 // Shared test infrastructure
@@ -43,6 +44,7 @@ const sampleBot = (id = "test-bot"): BotConfig =>
     repos: [{ slug: "group/repo", branch: "master" }],
     turn_taking_limit: 10,
     read_only: false,
+    response_surface_prototype: DEFAULT_RESPONSE_SURFACE_PROTOTYPE,
     runtime: "legacy",
     backend: "claude",
   }) as BotConfig;

--- a/src/config/botLoader.test.ts
+++ b/src/config/botLoader.test.ts
@@ -545,6 +545,64 @@ read_only: false
     expect(bots[0]?.read_only).toBe(false);
   });
 
+  it("response_surface_prototype defaults disabled for existing bot yamls", async () => {
+    await createBotsDir();
+    await writeYaml(
+      "surface-default.yaml",
+      `
+id: surface-default-bot
+name: Surface Default Bot
+description: response surface unset
+app_id: cli_surface_default
+app_secret_env: SURFACE_DEFAULT_SECRET
+bot_open_id: ou_surface_default
+`,
+    );
+
+    const bots = await loadBots(botsDir());
+    expect(bots).toHaveLength(1);
+    expect(bots[0]?.response_surface_prototype).toEqual({
+      enabled: false,
+      allowed_chats: [],
+      allowed_threads: [],
+      lazy_card_creation: false,
+      text_threshold_chars: 1200,
+    });
+  });
+
+  it("parses response_surface_prototype dark-launch config", async () => {
+    await createBotsDir();
+    await writeYaml(
+      "surface-prototype.yaml",
+      `
+id: surface-prototype-bot
+name: Surface Prototype Bot
+description: response surface dark launch
+app_id: cli_surface
+app_secret_env: SURFACE_SECRET
+bot_open_id: ou_surface
+response_surface_prototype:
+  enabled: true
+  allowed_chats:
+    - oc_test
+  allowed_threads:
+    - om_thread
+  lazy_card_creation: true
+  text_threshold_chars: 900
+`,
+    );
+
+    const bots = await loadBots(botsDir());
+    expect(bots).toHaveLength(1);
+    expect(bots[0]?.response_surface_prototype).toEqual({
+      enabled: true,
+      allowed_chats: ["oc_test"],
+      allowed_threads: ["om_thread"],
+      lazy_card_creation: true,
+      text_threshold_chars: 900,
+    });
+  });
+
   it("runtime 默认为 legacy,避免现有 bot yaml 改变行为", async () => {
     await createBotsDir();
     await writeYaml(

--- a/src/config/botLoader.ts
+++ b/src/config/botLoader.ts
@@ -17,6 +17,7 @@ import { readdir, readFile } from "node:fs/promises";
 import path from "node:path";
 import { z } from "zod";
 import yaml from "js-yaml";
+import { ResponseSurfacePrototypeConfigSchema } from "../responseSurface.js";
 
 // ---------------------------------------------------------------------------
 // Zod schema
@@ -200,6 +201,15 @@ export const BotConfigSchema = z.object({
    * @default false  — 所有现存 bot yaml 未设此字段时行为字节级不变。
    */
   read_only: z.boolean().default(false),
+
+  /**
+   * Dark-launch gate for the response-surface prototype.
+   *
+   * Default stays disabled so existing bots keep the legacy card-only path.
+   * Even when enabled, PR1/PR2 only prepare schema/controller plumbing; post
+   * outbound is not implemented here, so handler keeps a visible card fallback.
+   */
+  response_surface_prototype: ResponseSurfacePrototypeConfigSchema,
 
   /**
    * Runtime layout used by the bridge.

--- a/src/main.ts
+++ b/src/main.ts
@@ -347,6 +347,7 @@ async function runV2Mode({
         runtime: bot.runtime,
         git_token_env: bot.git_token_env,
         gitlab_token_env: bot.gitlab_token_env,
+        response_surface_prototype: bot.response_surface_prototype,
       },
       gitlabToken: effectiveGitlabToken,
       agentMemory: bot.agent_memory,

--- a/src/responseSurface.ts
+++ b/src/responseSurface.ts
@@ -1,0 +1,124 @@
+import { z } from "zod";
+
+const NonEmptyString = z.string().trim().min(1);
+
+export function defaultResponseSurfacePrototypeConfig() {
+  return {
+    enabled: false,
+    allowed_chats: [] as string[],
+    allowed_threads: [] as string[],
+    lazy_card_creation: false,
+    text_threshold_chars: 1200,
+  };
+}
+
+export const DEFAULT_RESPONSE_SURFACE_PROTOTYPE = defaultResponseSurfacePrototypeConfig();
+
+const responseSurfacePrototypeConfigDefaults = () => ({
+  enabled: false,
+  allowed_chats: [] as string[],
+  allowed_threads: [] as string[],
+  lazy_card_creation: false,
+  text_threshold_chars: 1200,
+});
+
+export const ResponseSurfaceModeSchema = z.enum(["card", "post", "hybrid"]);
+export const ResponseSurfacePrimarySchema = z.enum(["card", "post"]);
+
+export const ResponseSurfaceCapabilitySchema = z.enum([
+  "choices",
+  "image_blocks",
+  "content_blocks",
+  "fallback",
+  "audit",
+]);
+
+const MentionTargetSchema = z.object({
+  user_id: NonEmptyString.max(128),
+  label: z.string().trim().min(1).max(80).optional(),
+});
+
+const ResponseSurfacePostSchema = z.object({
+  mentions: z.array(MentionTargetSchema).max(5).default([]),
+});
+
+const ResponseSurfaceCardSchema = z.object({
+  compact: z.boolean().default(false),
+  capabilities: z.array(ResponseSurfaceCapabilitySchema).max(8).default([]),
+});
+
+const StrictResponseSurfaceStateSchema = z
+  .object({
+    mode: ResponseSurfaceModeSchema,
+    primary: ResponseSurfacePrimarySchema.optional(),
+    post: ResponseSurfacePostSchema.optional(),
+    card: ResponseSurfaceCardSchema.optional(),
+  })
+  .superRefine((surface, ctx) => {
+    if (surface.mode === "card" && surface.primary === "post") {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["primary"],
+        message: "response_surface.primary=post is incompatible with mode=card",
+      });
+    }
+  });
+
+/**
+ * Agent-authored response_surface is intentionally soft-failed. A typo in this
+ * prototype field must never discard the status/last_message fields needed to
+ * finalize the legacy card path.
+ */
+export const ResponseSurfaceStateSchema = z.preprocess((value) => {
+  if (value === undefined) return undefined;
+  const result = StrictResponseSurfaceStateSchema.safeParse(value);
+  return result.success ? result.data : undefined;
+}, StrictResponseSurfaceStateSchema.optional());
+
+export type ResponseSurfaceState = z.infer<typeof StrictResponseSurfaceStateSchema>;
+
+export const ResponseSurfacePrototypeConfigSchema = z
+  .object({
+    /**
+     * Master gate. Default false keeps the legacy card-only response path.
+     */
+    enabled: z.boolean().default(false),
+    /**
+     * Optional chat allowlist for dark-launch experiments. Empty means no chat
+     * is allowlisted by this gate.
+     */
+    allowed_chats: z.array(z.string().min(1)).default([]),
+    /**
+     * Optional Larkway session/thread allowlist for narrow dogfood topics.
+     * Empty means no thread is allowlisted by this gate.
+     */
+    allowed_threads: z.array(z.string().min(1)).default([]),
+    /**
+     * Dark-launch hook for PR2. This does not enable post-only output by itself;
+     * the bridge still requires a visible card fallback until post outbound
+     * exists and is explicitly enabled in a later PR.
+     */
+    lazy_card_creation: z.boolean().default(false),
+    /**
+     * Future channel threshold for lazy card creation. Reserved for PR3+; bounded
+     * now so config cannot grow unbounded or encode business rules.
+     */
+    text_threshold_chars: z.number().int().min(1).max(20_000).default(1200),
+  })
+  .default(responseSurfacePrototypeConfigDefaults);
+
+export type ResponseSurfacePrototypeConfig = z.infer<
+  typeof ResponseSurfacePrototypeConfigSchema
+>;
+
+export function isResponseSurfacePrototypeAllowlisted(
+  config: ResponseSurfacePrototypeConfig | undefined,
+  facts: { chatId: string; threadId: string },
+): boolean {
+  if (!config?.enabled) return false;
+  const chatAllowed =
+    config.allowed_chats.length > 0 && config.allowed_chats.includes(facts.chatId);
+  const threadAllowed =
+    config.allowed_threads.length > 0 && config.allowed_threads.includes(facts.threadId);
+  return chatAllowed || threadAllowed;
+}

--- a/src/web/onboardSession.ts
+++ b/src/web/onboardSession.ts
@@ -38,6 +38,7 @@ import type { BotConfig } from "../config/botLoader.js";
 import { ensureAgentWorkspace } from "../agent/workspaceStore.js";
 import { permissionItemsFromCapabilities } from "../agent/permissionPlan.js";
 import { resolveAgentWorkspacePathFromHome } from "../config/paths.js";
+import { DEFAULT_RESPONSE_SURFACE_PROTOTYPE } from "../responseSurface.js";
 
 // ---------------------------------------------------------------------------
 // registerApp SDK slice (Lark SDK has no bundled .d.ts for registerApp;
@@ -453,6 +454,7 @@ export async function createBotFromCreds(
     ...(git_token_env ? { git_token_env } : {}),
     memory_file: memoryFile,
     read_only: false,
+    response_surface_prototype: DEFAULT_RESPONSE_SURFACE_PROTOTYPE,
     runtime: "agent_workspace",
     backend: form.backend && form.backend.trim() ? form.backend.trim() : "codex",
     // Persist the Feishu avatar URL so the Web 管理面 can show an avatar before


### PR DESCRIPTION
## Summary
- Add a default-off response_surface state protocol schema and response_surface_prototype bot config gate for PR1.
- Add SurfaceController foundation for PR2 lazy card creation decisions, wired with postOutboundAvailable: false so every production path still creates the legacy visible card before PR3.
- Document response surface protocol, dark-launch gate, PR3 idempotency key reservation, and explicit non-goals.

## Scope and compatibility
- Existing bots default to card-only behavior: response_surface_prototype.enabled is false, allowlists are empty, and lazy_card_creation is false.
- Non-allowlisted or disabled bots ignore the new response_surface declaration and keep the existing card finalization path.
- Even when dark-launched and allowlisted, PR2 keeps a visible card fallback because real post outbound is not available in this PR.
- The bridge still does not encode business rules such as short task = post or long task = card; the Agent declares the desired surface and bridge only handles gating/mechanical fallback.

## Explicitly not included
- No real IM post outbound.
- No real peer at.
- No post.json ledger.
- No visible post failure fallback.
- No Feishu E2E, no test cards, no deployment, no restart, and no dogfood surface expansion.

## Validation
- pnpm vitest run src/bridge/stateFile.test.ts src/config/botLoader.test.ts src/bridge/surfaceController.test.ts src/bridge/handler.test.ts src/claude/prompt.test.ts
- pnpm typecheck
- git diff --check
- env -u LARKWAY_HOME pnpm test
- pnpm check:links
- pnpm build

Note: the local shell has LARKWAY_HOME pointing at a real workspace; full tests were run with LARKWAY_HOME unset so CLI init/host config tests use their temp homes instead of real local config.