### PR TITLE
feat: add response surface dispatch foundation

### DIFF
--- a/docs/response-surface-prototype.md
+++ b/docs/response-surface-prototype.md
@@ -1,12 +1,13 @@
 # Response Surface Prototype
 
-Status: PR1/PR3 foundation only. Default disabled.
+Status: PR1/PR4 foundation only. Default disabled.
 
 This document defines the dark-launch foundation for future `card` / `post` /
-`hybrid` response surfaces. PR3 adds post transport, post payload construction,
-idempotency helpers, and `post.json` ledger primitives, but they remain
-default-off and are not wired into production surface dispatch. It does not
-enable real IM post outbound, peer `at`, visible post failure fallback, Feishu
+`hybrid` response surfaces. PR3 added post transport, post payload construction,
+idempotency helpers, and `post.json` ledger primitives. PR4 adds the default-off
+surface dispatcher for `card` / `post` / `hybrid` planning, compact secondary
+cards, and fake-channel tests. Production wiring still keeps post outbound
+unavailable, so this does not enable real IM post outbound, peer `at`, Feishu
 E2E, deployment, or production enablement.
 
 ## Principles
@@ -47,8 +48,8 @@ Supported narrow fields:
 
 - `mode`: `card`, `post`, or `hybrid`.
 - `primary`: `card` or `post`.
-- `post.mentions[]`: future post mention targets. These are declarations only
-  until PR3 implements real post outbound.
+- `post.mentions[]`: future post mention targets. PR4 can validate/build these
+  in fake-channel tests, but production dispatch still does not send them.
 - `card.compact`: whether the card is intended as a compact secondary surface.
 - `card.capabilities[]`: `choices`, `image_blocks`, `content_blocks`,
   `fallback`, or `audit`.
@@ -91,22 +92,30 @@ Defaults:
 `enabled: true` alone is insufficient. A current chat or thread must match the
 allowlist before the prototype can affect runtime behavior.
 
-## PR2 SurfaceController Foundation
+## PR2 / PR4 SurfaceController Foundation
 
-`SurfaceController` centralizes the card-start decision. In this PR it is wired
-with `postOutboundAvailable: false`, because real post outbound and ledger are
-explicitly out of scope.
+`SurfaceController` centralizes the card-start decision. Production wiring still
+passes `postOutboundAvailable: false`, so every production path creates the
+legacy visible card before the Agent runs.
 
-Therefore all production paths still create the legacy visible card before the
-Agent runs:
+The lazy branch is eligible only when all of these are true:
+
+- prototype enabled
+- chat/thread allowlisted
+- `lazy_card_creation: true`
+- `post_outbound_enabled: true`
+- post outbound transport available
+- post ledger available
+- visible failure fallback available
+
+Otherwise the controller starts the legacy card immediately:
 
 - prototype disabled -> card immediately
 - not allowlisted -> card immediately
 - lazy card disabled -> card immediately
-- lazy card enabled but post outbound unavailable -> card immediately
-
-The future lazy branch only becomes eligible after a later PR supplies real post
-outbound, idempotency, ledger, and visible failure fallback.
+- post outbound disabled/unavailable -> card immediately
+- post ledger unavailable -> card immediately
+- visible fallback unavailable -> card immediately
 
 ## PR3 Idempotency Reservation
 
@@ -138,9 +147,29 @@ PR3 adds default-off primitives only:
 - Retry classification for future post sends: only 5xx responses are retryable.
 - Config gates for post outbound and mention target allowlisting.
 
+## PR4 Surface Dispatcher Foundation
+
+PR4 adds `SurfaceDispatcher` and wires `BridgeHandler` finalization through it.
+The handler still passes `postOutboundAvailable: false` and no production post
+client, so live runs continue to finalize the legacy visible card.
+
+The dispatcher is covered with unit/fake-channel tests for:
+
+- `mode=card`: legacy card finalization.
+- `mode=post`: fake post send when every gate is explicitly ready.
+- `mode=hybrid`: fake post primary plus compact secondary card.
+- non-allowlisted or disabled gates: mechanical fallback to the visible card.
+- post failure: ledger marks `fallback_visible` and a visible failure card is
+  returned.
+- choices/content/image card-only capabilities: keep the legacy card path so
+  interaction controls are not lost.
+
+The compact secondary card is intentionally audit-only. It records status,
+post message id, and idempotency key; it does not repeat the primary post body.
+
 Production wiring still passes `postOutboundAvailable: false` in
-`BridgeHandler`. PR3 therefore cannot create a live post unless a future PR
-explicitly connects the transport to surface dispatch and enables the gates.
+`BridgeHandler`. PR4 therefore cannot create a live post unless a future PR
+explicitly connects the transport to production dispatch and enables the gates.
 
 ## Non-Goals Until Later PRs
 

--- a/src/bridge/handler.test.ts
+++ b/src/bridge/handler.test.ts
@@ -481,6 +481,73 @@ describe("handleOne — thin-channel finalize", () => {
     expect(finalizeArgs[0]?.success).toBe(true);
   });
 
+  it("finalizes the legacy card when the agent declares post but production post outbound is unavailable", async () => {
+    const threadId = "om_msg";
+    const finalState = {
+      status: "ready",
+      last_message: "post 声明下的正文仍必须可见",
+      response_surface: {
+        mode: "post",
+        primary: "post",
+      },
+      updated_at: "2026-06-26T10:00:00.000Z",
+    };
+    const wt = await seedWorktree(threadId);
+    await seedRepoCachePath();
+
+    runClaudeImpl = () => ({
+      events: (async function* () {
+        yield { type: "system_init", sessionId: "sess_surface_post", raw: {} };
+        await writeFile(
+          stateFileMod.stateFilePathOf(wt),
+          JSON.stringify(finalState, null, 2),
+          "utf8",
+        );
+      })(),
+      done: Promise.resolve({ exitCode: 0, sessionId: "sess_surface_post" }),
+      kill: () => {},
+    });
+
+    const { renderer, startArgs, finalizeArgs, whenFinalized } = makeCardRenderer();
+    const { store } = makeSessionStore();
+    const { client } = makeClient(makeEvent());
+
+    const handler = new BridgeHandler({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      client: client as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      cardRenderer: renderer as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      sessionStore: store as any,
+      conventions: makeConventions(),
+      botConfig: {
+        id: "frontend",
+        name: "Frontend",
+        turn_taking_limit: 10,
+        backend: "claude",
+        response_surface_prototype: {
+          enabled: true,
+          allowed_chats: ["oc_chat"],
+          allowed_threads: [],
+          lazy_card_creation: true,
+          post_outbound_enabled: true,
+          allowed_mention_open_ids: [],
+          max_posts_per_turn: 1,
+          max_post_attempts: 3,
+          text_threshold_chars: 900,
+        },
+      },
+    });
+
+    await handler.run();
+    await whenFinalized;
+
+    expect(startArgs).toHaveLength(1);
+    expect(finalizeArgs).toHaveLength(1);
+    expect(finalizeArgs[0]?.success).toBe(true);
+    expect(finalizeArgs[0]?.finalText).toBe("post 声明下的正文仍必须可见");
+  });
+
   it("late-stage state.json WITHOUT dev_url is NOT probed and NOT demoted (status=ready → success)", async () => {
     // parseMessage derives threadId from root_id || message_id; makeEvent() has
     // no root_id, so the per-thread worktree dir is named after message_id.

--- a/src/bridge/handler.ts
+++ b/src/bridge/handler.ts
@@ -34,6 +34,7 @@ import { ensureAgentWorkspace } from "../agent/workspaceStore.js";
 import { ensureStateFile, readStateFile, stateFilePathOf } from "./stateFile.js";
 import { writeCardFile, deleteCardFile } from "./cardFile.js";
 import { SurfaceController } from "./surfaceController.js";
+import { dispatchResponseSurface } from "./surfaceDispatcher.js";
 import type { RuntimeEventPatch } from "./eventLog.js";
 import type { RuntimeRequirement } from "../runtimeRequirements.js";
 import type { ResponseSurfacePrototypeConfig } from "../responseSurface.js";
@@ -656,6 +657,8 @@ export class BridgeHandler {
       // PR3 owns real post outbound + ledger + visible post failure fallback.
       // Until then every runtime path keeps the legacy visible card fallback.
       postOutboundAvailable: false,
+      postLedgerAvailable: true,
+      visibleFallbackAvailable: true,
     });
     let card: import("../lark/card.js").CardHandle | undefined;
     if (surfaceController.shouldStartCardImmediately()) {
@@ -1133,7 +1136,7 @@ export class BridgeHandler {
                 ? "💬 已回复"
                 : undefined;
 
-            await card.finalize({
+            const baseCardPayload = {
               finalText: cardBody,
               success,
               failureReason,
@@ -1147,7 +1150,31 @@ export class BridgeHandler {
               choicePrompt: reportedState?.choice_prompt,
               imageBlocks: reportedState?.image_blocks,
               contentBlocks: reportedState?.content_blocks,
+            };
+            const surfaceDispatch = await dispatchResponseSurface({
+              state: reportedState,
+              prototypeConfig: this.deps.botConfig?.response_surface_prototype,
+              facts: {
+                botId: this.deps.botConfig?.id ?? "v1-default",
+                chatId: parsed.chatId,
+                threadId,
+                triggerMessageId: messageId,
+                replyToMessageId: messageId,
+                replyInThread,
+              },
+              worktreePath,
+              baseCard: baseCardPayload,
+              cardStarted: true,
+              // PR4 wires the dispatcher but keeps production post outbound
+              // unavailable. Real post transport remains behind a later,
+              // separately-authorized PR and explicit bot config gates.
+              postOutboundAvailable: false,
+              postLedgerAvailable: true,
+              visibleFallbackAvailable: true,
             });
+            if (surfaceDispatch.card) {
+              await card.finalize(surfaceDispatch.card);
+            }
 
             // Card was finalized successfully — drop its card.json so boot
             // reconcile doesn't re-finalize an already-finalized card.

--- a/src/bridge/surfaceController.test.ts
+++ b/src/bridge/surfaceController.test.ts
@@ -3,7 +3,7 @@ import { SurfaceController } from "./surfaceController.js";
 
 const allowlistedConfig = {
   enabled: true,
-  allowed_chats: ["oc_allowed"],
+  allowed_chats: ["chat_allowed"],
   allowed_threads: [],
   lazy_card_creation: true,
   post_outbound_enabled: false,
@@ -11,6 +11,11 @@ const allowlistedConfig = {
   max_posts_per_turn: 1,
   max_post_attempts: 3,
   text_threshold_chars: 1200,
+};
+
+const postEnabledConfig = {
+  ...allowlistedConfig,
+  post_outbound_enabled: true,
 };
 
 describe("SurfaceController", () => {
@@ -27,7 +32,7 @@ describe("SurfaceController", () => {
         max_post_attempts: 3,
         text_threshold_chars: 1200,
       },
-      chatId: "oc_allowed",
+      chatId: "chat_allowed",
       threadId: "om_thread",
       postOutboundAvailable: false,
     });
@@ -39,7 +44,7 @@ describe("SurfaceController", () => {
   it("keeps legacy card creation outside the dark-launch allowlist", () => {
     const controller = SurfaceController.create({
       prototypeConfig: allowlistedConfig,
-      chatId: "oc_other",
+      chatId: "chat_other",
       threadId: "om_thread",
       postOutboundAvailable: false,
     });
@@ -48,10 +53,22 @@ describe("SurfaceController", () => {
     expect(controller.decision.reason).toBe("not-allowlisted");
   });
 
-  it("keeps card fallback before PR3 post outbound exists", () => {
+  it("keeps card fallback when post outbound is disabled by config", () => {
     const controller = SurfaceController.create({
       prototypeConfig: allowlistedConfig,
-      chatId: "oc_allowed",
+      chatId: "chat_allowed",
+      threadId: "om_thread",
+      postOutboundAvailable: false,
+    });
+
+    expect(controller.shouldStartCardImmediately()).toBe(true);
+    expect(controller.decision.reason).toBe("post-outbound-disabled");
+  });
+
+  it("keeps card fallback before post outbound transport is available", () => {
+    const controller = SurfaceController.create({
+      prototypeConfig: postEnabledConfig,
+      chatId: "chat_allowed",
       threadId: "om_thread",
       postOutboundAvailable: false,
     });
@@ -60,12 +77,40 @@ describe("SurfaceController", () => {
     expect(controller.decision.reason).toBe("post-outbound-unavailable-card-fallback");
   });
 
-  it("has a future lazy-ready path only when post outbound is available", () => {
+  it("keeps card fallback when post ledger is unavailable", () => {
     const controller = SurfaceController.create({
-      prototypeConfig: allowlistedConfig,
-      chatId: "oc_allowed",
+      prototypeConfig: postEnabledConfig,
+      chatId: "chat_allowed",
       threadId: "om_thread",
       postOutboundAvailable: true,
+      postLedgerAvailable: false,
+    });
+
+    expect(controller.shouldStartCardImmediately()).toBe(true);
+    expect(controller.decision.reason).toBe("post-ledger-unavailable-card-fallback");
+  });
+
+  it("keeps card fallback when visible failure fallback is unavailable", () => {
+    const controller = SurfaceController.create({
+      prototypeConfig: postEnabledConfig,
+      chatId: "chat_allowed",
+      threadId: "om_thread",
+      postOutboundAvailable: true,
+      visibleFallbackAvailable: false,
+    });
+
+    expect(controller.shouldStartCardImmediately()).toBe(true);
+    expect(controller.decision.reason).toBe("visible-fallback-unavailable-card-fallback");
+  });
+
+  it("has a future lazy-ready path only when post outbound is available", () => {
+    const controller = SurfaceController.create({
+      prototypeConfig: postEnabledConfig,
+      chatId: "chat_allowed",
+      threadId: "om_thread",
+      postOutboundAvailable: true,
+      postLedgerAvailable: true,
+      visibleFallbackAvailable: true,
     });
 
     expect(controller.shouldStartCardImmediately()).toBe(false);

--- a/src/bridge/surfaceController.ts
+++ b/src/bridge/surfaceController.ts
@@ -8,16 +8,19 @@ export interface SurfaceControllerInput {
   chatId: string;
   threadId: string;
   /**
-   * PR3+ hook. This PR deliberately keeps it false in production wiring because
-   * real post outbound, ledger, and visible failure fallback are out of scope.
+   * PR4 dispatch hook. Production wiring deliberately keeps this false until a
+   * later, separately-authorized PR enables real post outbound.
    */
   postOutboundAvailable: boolean;
+  postLedgerAvailable?: boolean;
+  visibleFallbackAvailable?: boolean;
 }
 
 export interface SurfaceControllerDecision {
   /**
    * Whether handler must create the legacy processing card before running the
-   * agent. PR1/PR2 production wiring keeps this true in every path.
+   * agent. PR4 production wiring keeps this true because post outbound remains
+   * unavailable.
    */
   startCardImmediately: boolean;
   prototypeEnabled: boolean;
@@ -26,7 +29,10 @@ export interface SurfaceControllerDecision {
     | "prototype-disabled"
     | "not-allowlisted"
     | "lazy-card-disabled"
+    | "post-outbound-disabled"
     | "post-outbound-unavailable-card-fallback"
+    | "post-ledger-unavailable-card-fallback"
+    | "visible-fallback-unavailable-card-fallback"
     | "lazy-card-ready";
 }
 
@@ -71,12 +77,39 @@ export class SurfaceController {
       });
     }
 
+    if (!cfg.post_outbound_enabled) {
+      return new SurfaceController({
+        startCardImmediately: true,
+        prototypeEnabled: true,
+        lazyCardCreationEnabled: false,
+        reason: "post-outbound-disabled",
+      });
+    }
+
     if (!input.postOutboundAvailable) {
       return new SurfaceController({
         startCardImmediately: true,
         prototypeEnabled: true,
         lazyCardCreationEnabled: false,
         reason: "post-outbound-unavailable-card-fallback",
+      });
+    }
+
+    if (input.postLedgerAvailable === false) {
+      return new SurfaceController({
+        startCardImmediately: true,
+        prototypeEnabled: true,
+        lazyCardCreationEnabled: false,
+        reason: "post-ledger-unavailable-card-fallback",
+      });
+    }
+
+    if (input.visibleFallbackAvailable === false) {
+      return new SurfaceController({
+        startCardImmediately: true,
+        prototypeEnabled: true,
+        lazyCardCreationEnabled: false,
+        reason: "visible-fallback-unavailable-card-fallback",
       });
     }
 

--- a/src/bridge/surfaceDispatcher.test.ts
+++ b/src/bridge/surfaceDispatcher.test.ts
@@ -1,0 +1,258 @@
+import { describe, expect, it } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import {
+  dispatchResponseSurface,
+  type CardFinalizePayload,
+  type SurfaceDispatchInput,
+} from "./surfaceDispatcher.js";
+import { readPostFile } from "./postFile.js";
+import type { StateFile } from "./stateFile.js";
+import type { OutboundPostClient } from "../lark/outboundPostClient.js";
+
+const enabledConfig = {
+  enabled: true,
+  allowed_chats: ["chat_allowed"],
+  allowed_threads: [],
+  lazy_card_creation: true,
+  post_outbound_enabled: true,
+  allowed_mention_open_ids: ["user_allowed"],
+  max_posts_per_turn: 1,
+  max_post_attempts: 3,
+  text_threshold_chars: 1200,
+};
+
+const defaultOffConfig = {
+  ...enabledConfig,
+  enabled: false,
+  allowed_chats: [],
+  allowed_threads: [],
+  post_outbound_enabled: false,
+  allowed_mention_open_ids: [],
+};
+
+function baseCard(text = "主回复正文"): CardFinalizePayload {
+  return {
+    finalText: text,
+    success: true,
+    titleOverride: "完成",
+    colorOverride: "success",
+  };
+}
+
+function state(surface: NonNullable<StateFile["response_surface"]>, extra = {}): StateFile {
+  return {
+    status: "ready",
+    last_message: "主回复正文",
+    response_surface: surface,
+    updated_at: "2026-06-26T00:00:00.000Z",
+    ...extra,
+  };
+}
+
+function baseInput(overrides: Partial<SurfaceDispatchInput> = {}): SurfaceDispatchInput {
+  return {
+    state: state({ mode: "post", primary: "post" }),
+    prototypeConfig: enabledConfig,
+    facts: {
+      botId: "tech-lead",
+      chatId: "chat_allowed",
+      threadId: "om_thread",
+      triggerMessageId: "om_trigger",
+      replyToMessageId: "om_trigger",
+      replyInThread: true,
+    },
+    baseCard: baseCard(),
+    cardStarted: true,
+    postOutboundAvailable: true,
+    postLedgerAvailable: true,
+    visibleFallbackAvailable: true,
+    now: () => "2026-06-26T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function fakePostClient(opts: { fail?: boolean } = {}) {
+  const calls: Array<{
+    replyToMessageId: string;
+    content: string;
+    idempotencyKey: string;
+    replyInThread: boolean;
+  }> = [];
+  const client: OutboundPostClient = {
+    async createPostReply(replyToMessageId, content, callOpts) {
+      calls.push({
+        replyToMessageId,
+        content,
+        idempotencyKey: callOpts.idempotencyKey,
+        replyInThread: callOpts.replyInThread,
+      });
+      if (opts.fail) throw new Error("fake transport failed");
+      return { messageId: "om_post" };
+    },
+  };
+  return { client, calls };
+}
+
+async function withTemp<T>(fn: (dir: string) => Promise<T>): Promise<T> {
+  const dir = await mkdtemp(path.join(tmpdir(), "larkway-surface-dispatch-"));
+  try {
+    return await fn(dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+describe("dispatchResponseSurface", () => {
+  it("keeps mode=card on the legacy visible card path", async () => {
+    const { client, calls } = fakePostClient();
+    const result = await dispatchResponseSurface(
+      baseInput({
+        state: state({ mode: "card", primary: "card" }),
+        prototypeConfig: defaultOffConfig,
+        postClient: client,
+      }),
+    );
+
+    expect(result.reason).toBe("legacy-card-mode");
+    expect(result.card?.finalText).toBe("主回复正文");
+    expect(result.visible).toBe(true);
+    expect(calls).toHaveLength(0);
+  });
+
+  it("sends a post-only response through a fake post client when every PR4 gate is ready", async () =>
+    withTemp(async (dir) => {
+      const { client, calls } = fakePostClient();
+      const result = await dispatchResponseSurface(
+        baseInput({
+          worktreePath: dir,
+          cardStarted: false,
+          postClient: client,
+        }),
+      );
+
+      expect(result.reason).toBe("post-sent");
+      expect(result.card).toBeNull();
+      expect(result.visible).toBe(true);
+      expect(calls).toHaveLength(1);
+      expect(calls[0]?.content).toContain("主回复正文");
+      expect(calls[0]?.idempotencyKey).toMatch(/^lw-p-[A-Za-z0-9_-]+$/);
+      expect(calls[0]?.idempotencyKey.length).toBeLessThanOrEqual(64);
+
+      const ledger = await readPostFile(dir);
+      expect(ledger?.posts).toHaveLength(1);
+      expect(ledger?.posts[0]?.status).toBe("sent");
+      expect(ledger?.posts[0]?.postMessageId).toBe("om_post");
+    }));
+
+  it("uses a compact secondary card for hybrid without repeating the main post body", async () =>
+    withTemp(async (dir) => {
+      const { client } = fakePostClient();
+      const result = await dispatchResponseSurface(
+        baseInput({
+          worktreePath: dir,
+          postClient: client,
+          state: state({
+            mode: "hybrid",
+            primary: "post",
+            card: { compact: true, capabilities: ["audit", "fallback"] },
+          }),
+        }),
+      );
+
+      expect(result.reason).toBe("hybrid-post-sent-compact-card");
+      expect(result.visible).toBe(true);
+      expect(result.card?.finalText).toContain("主回复已通过 post 发出");
+      expect(result.card?.finalText).toContain("idempotency_key:");
+      expect(result.card?.finalText).not.toContain("主回复正文");
+      expect(result.card?.choices).toBeUndefined();
+      expect(result.card?.contentBlocks).toBeUndefined();
+    }));
+
+  it("degrades non-allowlisted topics to the legacy visible card and does not send post", async () => {
+    const { client, calls } = fakePostClient();
+    const result = await dispatchResponseSurface(
+      baseInput({
+        postClient: client,
+        facts: {
+          botId: "tech-lead",
+          chatId: "chat_other",
+          threadId: "om_thread",
+          triggerMessageId: "om_trigger",
+          replyToMessageId: "om_trigger",
+          replyInThread: true,
+        },
+      }),
+    );
+
+    expect(result.reason).toBe("not-allowlisted");
+    expect(result.card?.finalText).toBe("主回复正文");
+    expect(result.visible).toBe(true);
+    expect(calls).toHaveLength(0);
+  });
+
+  it("falls back to a visible failure card and ledger status when post send fails", async () =>
+    withTemp(async (dir) => {
+      const { client } = fakePostClient({ fail: true });
+      const result = await dispatchResponseSurface(
+        baseInput({
+          worktreePath: dir,
+          postClient: client,
+        }),
+      );
+
+      expect(result.reason).toBe("post-failed-fallback-card");
+      expect(result.visible).toBe(true);
+      expect(result.card?.success).toBe(false);
+      expect(result.card?.finalText).toBe("主回复正文");
+      expect(result.card?.failureReason).toContain("visible card fallback used");
+
+      const ledger = await readPostFile(dir);
+      expect(ledger?.posts).toHaveLength(1);
+      expect(ledger?.posts[0]?.status).toBe("fallback_visible");
+      expect(ledger?.posts[0]?.attempts[0]?.status).toBe("failed");
+    }));
+
+  it("keeps choices on the old card path instead of losing card-only capabilities to post", async () => {
+    const { client, calls } = fakePostClient();
+    const result = await dispatchResponseSurface(
+      baseInput({
+        postClient: client,
+        state: state(
+          { mode: "post", primary: "post" },
+          {
+            choices: [{ label: "继续", value: "继续处理" }],
+            choice_prompt: "选下一步",
+          },
+        ),
+        baseCard: {
+          ...baseCard(),
+          choices: [{ label: "继续", value: "继续处理" }],
+          choicePrompt: "选下一步",
+        },
+      }),
+    );
+
+    expect(result.reason).toBe("card-capability-required");
+    expect(result.visible).toBe(true);
+    expect(result.card?.choices).toEqual([{ label: "继续", value: "继续处理" }]);
+    expect(calls).toHaveLength(0);
+  });
+
+  it("refuses post and keeps the existing card visible when fallback readiness is missing", async () => {
+    const { client, calls } = fakePostClient();
+    const result = await dispatchResponseSurface(
+      baseInput({
+        cardStarted: true,
+        visibleFallbackAvailable: false,
+        postClient: client,
+      }),
+    );
+
+    expect(result.reason).toBe("visible-fallback-unavailable");
+    expect(result.card?.finalText).toBe("主回复正文");
+    expect(result.visible).toBe(true);
+    expect(calls).toHaveLength(0);
+  });
+});

--- a/src/bridge/surfaceDispatcher.ts
+++ b/src/bridge/surfaceDispatcher.ts
@@ -1,0 +1,404 @@
+import type { StateFile } from "./stateFile.js";
+import type { ResponseSurfacePrototypeConfig } from "../responseSurface.js";
+import { isResponseSurfacePrototypeAllowlisted } from "../responseSurface.js";
+import { buildPostContent } from "../lark/postContent.js";
+import type { OutboundPostClient } from "../lark/outboundPostClient.js";
+import {
+  derivePostIdempotencyKey,
+  digestPostContent,
+  type PostSurfaceRole,
+} from "../lark/idempotency.js";
+import {
+  upsertPostLedgerEntry,
+  type PostLedgerEntry,
+} from "./postFile.js";
+import type { Choice, ContentBlock, ImageBlock } from "../lark/card.js";
+
+export interface CardFinalizePayload {
+  finalText?: string;
+  success: boolean;
+  failureReason?: string;
+  titleOverride?: string;
+  colorOverride?: "success" | "failure" | "neutral";
+  choices?: Choice[];
+  choicePrompt?: string;
+  imageBlocks?: ImageBlock[];
+  contentBlocks?: ContentBlock[];
+}
+
+export type SurfaceDispatchReason =
+  | "legacy-card-mode"
+  | "prototype-disabled"
+  | "not-allowlisted"
+  | "post-outbound-disabled"
+  | "post-outbound-unavailable"
+  | "post-ledger-unavailable"
+  | "visible-fallback-unavailable"
+  | "card-capability-required"
+  | "mention-policy-blocked"
+  | "post-sent"
+  | "hybrid-post-sent-compact-card"
+  | "post-failed-fallback-card";
+
+export interface SurfaceDispatchInput {
+  state: StateFile | null;
+  prototypeConfig?: ResponseSurfacePrototypeConfig;
+  facts: {
+    botId: string;
+    chatId: string;
+    threadId: string;
+    triggerMessageId: string;
+    replyToMessageId: string;
+    replyInThread: boolean;
+  };
+  worktreePath?: string;
+  baseCard: CardFinalizePayload;
+  cardStarted: boolean;
+  postOutboundAvailable: boolean;
+  postLedgerAvailable: boolean;
+  visibleFallbackAvailable: boolean;
+  postClient?: OutboundPostClient;
+  now?: () => string;
+}
+
+export interface SurfaceDispatchResult {
+  card: CardFinalizePayload | null;
+  reason: SurfaceDispatchReason;
+  visible: boolean;
+  post?: {
+    idempotencyKey: string;
+    messageId?: string;
+    role: PostSurfaceRole;
+  };
+}
+
+function fullCard(
+  input: SurfaceDispatchInput,
+  reason: SurfaceDispatchReason,
+): SurfaceDispatchResult {
+  return {
+    card: input.baseCard,
+    reason,
+    visible: input.cardStarted || input.visibleFallbackAvailable,
+  };
+}
+
+function hasCardOnlyPayload(state: StateFile | null): boolean {
+  return !!(
+    state?.choices?.length ||
+    state?.image_blocks?.length ||
+    state?.content_blocks?.length
+  );
+}
+
+function compactAuditCard(
+  input: SurfaceDispatchInput,
+  post: { idempotencyKey: string; messageId: string },
+): CardFinalizePayload {
+  const status = input.state?.status ?? (input.baseCard.success ? "ready" : "failed");
+  const title = input.baseCard.titleOverride ?? "Post 已发送";
+  return {
+    success: input.baseCard.success,
+    failureReason: input.baseCard.failureReason,
+    titleOverride: title,
+    colorOverride: input.baseCard.colorOverride ?? "neutral",
+    finalText:
+      `主回复已通过 post 发出。\n` +
+      `status: ${status}\n` +
+      `post_message_id: ${post.messageId}\n` +
+      `idempotency_key: ${post.idempotencyKey}`,
+  };
+}
+
+function fallbackFailureCard(
+  input: SurfaceDispatchInput,
+  error: unknown,
+): CardFinalizePayload {
+  const reason = error instanceof Error ? error.message : String(error);
+  return {
+    ...input.baseCard,
+    success: false,
+    failureReason: `post outbound failed; visible card fallback used: ${reason}`,
+  };
+}
+
+function policyBlockedCard(input: SurfaceDispatchInput): CardFinalizePayload {
+  return {
+    ...input.baseCard,
+    success: false,
+    failureReason:
+      "response_surface post mention target is not in allowed_mention_open_ids; visible card fallback used",
+  };
+}
+
+function postText(input: SurfaceDispatchInput): string {
+  const text = input.baseCard.finalText?.trim() || input.state?.last_message?.trim();
+  if (text) return text;
+  if (input.baseCard.success) return "完成";
+  return input.baseCard.failureReason ?? "执行失败";
+}
+
+function postRole(input: SurfaceDispatchInput): PostSurfaceRole {
+  const surface = input.state?.response_surface;
+  if (surface?.mode === "hybrid") return "primary";
+  return "primary";
+}
+
+function newLedgerEntry(input: {
+  status: PostLedgerEntry["status"];
+  idempotencyKey: string;
+  now: string;
+  facts: SurfaceDispatchInput["facts"];
+  role: PostSurfaceRole;
+  logicalIndex: number;
+  contentDigest: string;
+  mentionCount: number;
+  postMessageId?: string;
+  error?: string;
+  attempts?: PostLedgerEntry["attempts"];
+}): PostLedgerEntry {
+  return {
+    idempotencyKey: input.idempotencyKey,
+    status: input.status,
+    botId: input.facts.botId,
+    chatId: input.facts.chatId,
+    threadId: input.facts.threadId,
+    replyToMessageId: input.facts.replyToMessageId,
+    role: input.role,
+    logicalIndex: input.logicalIndex,
+    contentDigest: input.contentDigest,
+    mentionCount: input.mentionCount,
+    postMessageId: input.postMessageId,
+    error: input.error,
+    attempts: input.attempts ?? [],
+    createdAt: input.now,
+    updatedAt: input.now,
+  };
+}
+
+async function writeLedger(
+  input: SurfaceDispatchInput,
+  entry: PostLedgerEntry,
+): Promise<void> {
+  if (!input.worktreePath) return;
+  await upsertPostLedgerEntry(input.worktreePath, entry);
+}
+
+export async function dispatchResponseSurface(
+  input: SurfaceDispatchInput,
+): Promise<SurfaceDispatchResult> {
+  const surface = input.state?.response_surface;
+  if (!surface || surface.mode === "card" || surface.primary === "card") {
+    return fullCard(input, "legacy-card-mode");
+  }
+
+  const cfg = input.prototypeConfig;
+  if (!cfg?.enabled) return fullCard(input, "prototype-disabled");
+  if (
+    !isResponseSurfacePrototypeAllowlisted(cfg, {
+      chatId: input.facts.chatId,
+      threadId: input.facts.threadId,
+    })
+  ) {
+    return fullCard(input, "not-allowlisted");
+  }
+  if (!cfg.post_outbound_enabled) return fullCard(input, "post-outbound-disabled");
+  if (cfg.max_posts_per_turn < 1) return fullCard(input, "post-outbound-disabled");
+  if (!input.postOutboundAvailable || !input.postClient) {
+    return fullCard(input, "post-outbound-unavailable");
+  }
+  if (!input.visibleFallbackAvailable) {
+    return fullCard(input, "visible-fallback-unavailable");
+  }
+  if (hasCardOnlyPayload(input.state)) {
+    return fullCard(input, "card-capability-required");
+  }
+  if (!input.postLedgerAvailable || !input.worktreePath) {
+    return fullCard(input, "post-ledger-unavailable");
+  }
+
+  const mentions = surface.post?.mentions ?? [];
+  const blockedMention = mentions.find(
+    (mention) => !cfg.allowed_mention_open_ids.includes(mention.user_id),
+  );
+  const text = postText(input);
+  const policyDigest = digestPostContent(text);
+  const role = postRole(input);
+  const logicalIndex = 0;
+  const policyIdempotencyKey = derivePostIdempotencyKey({
+    botId: input.facts.botId,
+    threadId: input.facts.threadId,
+    triggerMessageId: input.facts.triggerMessageId,
+    role,
+    logicalIndex,
+    contentDigest: policyDigest,
+  });
+  const now = input.now?.() ?? new Date().toISOString();
+
+  if (blockedMention) {
+    await writeLedger(
+      input,
+      newLedgerEntry({
+        status: "policy_blocked",
+        idempotencyKey: policyIdempotencyKey,
+        now,
+        facts: input.facts,
+        role,
+        logicalIndex,
+        contentDigest: policyDigest,
+        mentionCount: mentions.length,
+        error: `mention target is not allowed: ${blockedMention.user_id}`,
+      }),
+    );
+    return {
+      card: policyBlockedCard(input),
+      reason: "mention-policy-blocked",
+      visible: true,
+      post: { idempotencyKey: policyIdempotencyKey, role },
+    };
+  }
+
+  const content = buildPostContent({
+    text,
+    mentions: mentions.map((mention) => ({
+      userId: mention.user_id,
+      label: mention.label,
+    })),
+  });
+  const contentDigest = digestPostContent(content);
+  const idempotencyKey = derivePostIdempotencyKey({
+    botId: input.facts.botId,
+    threadId: input.facts.threadId,
+    triggerMessageId: input.facts.triggerMessageId,
+    role,
+    logicalIndex,
+    contentDigest,
+  });
+
+  await writeLedger(
+    input,
+    newLedgerEntry({
+      status: "planned",
+      idempotencyKey,
+      now,
+      facts: input.facts,
+      role,
+      logicalIndex,
+      contentDigest,
+      mentionCount: mentions.length,
+    }),
+  );
+  await writeLedger(
+    input,
+    newLedgerEntry({
+      status: "pending",
+      idempotencyKey,
+      now,
+      facts: input.facts,
+      role,
+      logicalIndex,
+      contentDigest,
+      mentionCount: mentions.length,
+    }),
+  );
+
+  try {
+    const sent = await input.postClient.createPostReply(input.facts.replyToMessageId, content, {
+      replyInThread: input.facts.replyInThread,
+      idempotencyKey,
+    });
+    await writeLedger(
+      input,
+      newLedgerEntry({
+        status: "sent",
+        idempotencyKey,
+        now: input.now?.() ?? new Date().toISOString(),
+        facts: input.facts,
+        role,
+        logicalIndex,
+        contentDigest,
+        mentionCount: mentions.length,
+        postMessageId: sent.messageId,
+        attempts: [
+          {
+            attemptedAt: input.now?.() ?? new Date().toISOString(),
+            status: "sent",
+            retryable: false,
+          },
+        ],
+      }),
+    );
+
+    const post = { idempotencyKey, messageId: sent.messageId, role };
+    if (surface.mode === "hybrid" || input.cardStarted) {
+      return {
+        card: compactAuditCard(input, post),
+        reason:
+          surface.mode === "hybrid"
+            ? "hybrid-post-sent-compact-card"
+            : "post-sent",
+        visible: true,
+        post,
+      };
+    }
+    return {
+      card: null,
+      reason: "post-sent",
+      visible: true,
+      post,
+    };
+  } catch (err) {
+    const failedAt = input.now?.() ?? new Date().toISOString();
+    const error = err instanceof Error ? err.message : String(err);
+    await writeLedger(
+      input,
+      newLedgerEntry({
+        status: "failed",
+        idempotencyKey,
+        now: failedAt,
+        facts: input.facts,
+        role,
+        logicalIndex,
+        contentDigest,
+        mentionCount: mentions.length,
+        error,
+        attempts: [
+          {
+            attemptedAt: failedAt,
+            status: "failed",
+            retryable: false,
+            error,
+          },
+        ],
+      }),
+    );
+    await writeLedger(
+      input,
+      newLedgerEntry({
+        status: "fallback_visible",
+        idempotencyKey,
+        now: input.now?.() ?? new Date().toISOString(),
+        facts: input.facts,
+        role,
+        logicalIndex,
+        contentDigest,
+        mentionCount: mentions.length,
+        error,
+        attempts: [
+          {
+            attemptedAt: failedAt,
+            status: "failed",
+            retryable: false,
+            error,
+          },
+        ],
+      }),
+    );
+    return {
+      card: fallbackFailureCard(input, err),
+      reason: "post-failed-fallback-card",
+      visible: true,
+      post: { idempotencyKey, role },
+    };
+  }
+}

--- a/src/responseSurface.ts
+++ b/src/responseSurface.ts
@@ -109,7 +109,7 @@ export const ResponseSurfacePrototypeConfigSchema = z
     lazy_card_creation: z.boolean().default(false),
     /**
      * PR3 dark-launch gate for real post outbound. This must stay false by
-     * default and is not wired into production dispatch in PR3.
+     * default. PR4's dispatcher also requires this gate before any post path.
      */
     post_outbound_enabled: z.boolean().default(false),
     /**
@@ -119,8 +119,8 @@ export const ResponseSurfacePrototypeConfigSchema = z
      */
     allowed_mention_open_ids: z.array(z.string().min(1)).default([]),
     /**
-     * Hard cap for future surface dispatch. PR3 only persists the config; it
-     * does not connect this to handler routing.
+     * Hard cap for surface dispatch. PR4 still keeps production post outbound
+     * unavailable, but fake-channel dispatch tests enforce this bounded shape.
      */
     max_posts_per_turn: z.number().int().min(0).max(10).default(1),
     /**
@@ -129,8 +129,8 @@ export const ResponseSurfacePrototypeConfigSchema = z
      */
     max_post_attempts: z.number().int().min(1).max(5).default(3),
     /**
-     * Future channel threshold for lazy card creation. Reserved for PR3+; bounded
-     * now so config cannot grow unbounded or encode business rules.
+     * Future channel threshold for lazy card creation. Bounded so config cannot
+     * grow unbounded or encode business rules.
      */
     text_threshold_chars: z.number().int().min(1).max(20_000).default(1200),
   })


### PR DESCRIPTION
## Summary

PR4 foundation for the response surface prototype:

- add a default-off `SurfaceDispatcher` for agent-declared `card` / `post` / `hybrid` response surfaces
- route `BridgeHandler` final card finalization through the dispatcher while keeping production `postOutboundAvailable=false`
- tighten `SurfaceController` lazy-card eligibility so post mode requires prototype enablement, allowlist, `post_outbound_enabled`, post transport readiness, post ledger readiness, and visible fallback readiness
- support fake-channel post dispatch with `post.json` ledger status updates and compact audit-only secondary cards for hybrid
- document PR4 boundaries and non-goals

## Default-off / compatibility

- `response_surface_prototype.enabled` remains default `false`
- `post_outbound_enabled` remains default `false`
- allowlists remain default empty
- production handler still passes `postOutboundAvailable: false`
- no production post client is wired into `BridgeHandler`
- legacy card-only path remains the visible fallback for disabled, non-allowlisted, unavailable, or card-capability-required cases

## No invisible reply proof

- `SurfaceController` starts the legacy card unless every future post prerequisite is ready
- `SurfaceDispatcher` refuses post when visible fallback is unavailable
- choices / image_blocks / content_blocks stay on the legacy card path so card-only interactive capabilities are not lost
- handler integration test proves an agent-declared `mode=post` still finalizes the legacy visible card because production post outbound is unavailable

## Tests

Local checks passed:

- `pnpm exec vitest run src/bridge/surfaceDispatcher.test.ts src/bridge/surfaceController.test.ts src/bridge/handler.test.ts` — 37 tests passed
- `pnpm typecheck` — passed
- `git diff --check HEAD` — passed
- `pnpm check:links` — passed
- `env -u LARKWAY_HOME pnpm test` — 47 files / 758 tests passed
- `pnpm build` — passed

## Explicit non-goals

- no real IM post outbound
- no real peer at
- no test cards
- no Feishu E2E
- no deployment or bridge restart
- no prototype enablement
- no PR5 / rich orphan reconcile
- no member-scope request or roster verification
