### PR TITLE
feat: reconcile response surface orphans

### DIFF
--- a/docs/response-surface-prototype.md
+++ b/docs/response-surface-prototype.md
@@ -188,6 +188,10 @@ PR5 extends boot-time reconcile without enabling post outbound:
     visible fallback card. Reconcile creates and finalizes that card, then marks
     the ledger `fallback_visible` with `fallbackCardMessageId` and an
     `orphan_reconcile` attempt.
+  - if the same worktree already has a recoverable `card.json` + `state.json`,
+    reconcile finalizes that existing card first, then marks the post ledger
+    `fallback_visible` with that existing card message id. A second boot must
+    not create another fallback card for the same orphan.
   - if the fallback card cannot be created/finalized, the ledger stays
     non-terminal and reconcile logs the failure; it must not silently mark
     `fallback_visible`.

--- a/docs/response-surface-prototype.md
+++ b/docs/response-surface-prototype.md
@@ -1,14 +1,15 @@
 # Response Surface Prototype
 
-Status: PR1/PR4 foundation only. Default disabled.
+Status: PR1/PR5 foundation only. Default disabled.
 
 This document defines the dark-launch foundation for future `card` / `post` /
 `hybrid` response surfaces. PR3 added post transport, post payload construction,
-idempotency helpers, and `post.json` ledger primitives. PR4 adds the default-off
-surface dispatcher for `card` / `post` / `hybrid` planning, compact secondary
-cards, and fake-channel tests. Production wiring still keeps post outbound
-unavailable, so this does not enable real IM post outbound, peer `at`, Feishu
-E2E, deployment, or production enablement.
+idempotency helpers, and `post.json` ledger primitives. PR4 added the
+default-off surface dispatcher for `card` / `post` / `hybrid` planning,
+compact secondary cards, and fake-channel tests. PR5 adds rich boot reconcile
+for card fields plus post-ledger orphan reconciliation. Production wiring still
+keeps post outbound unavailable, so this does not enable real IM post outbound,
+peer `at`, Feishu E2E, deployment, or production enablement.
 
 ## Principles
 
@@ -171,11 +172,35 @@ Production wiring still passes `postOutboundAvailable: false` in
 `BridgeHandler`. PR4 therefore cannot create a live post unless a future PR
 explicitly connects the transport to production dispatch and enables the gates.
 
+## PR5 Rich Orphan Reconcile
+
+PR5 extends boot-time reconcile without enabling post outbound:
+
+- Fresh orphaned cards preserve rich state fields when finalized after a bridge
+  restart: `choices`, `choice_prompt`, `image_blocks`, and `content_blocks`.
+- Stale state remains suppressed. If `state.updated_at` is older than the
+  persisted `card.json`, reconcile finalizes a failure card and does not reuse
+  stale rich fields from a previous turn.
+- Old `post.json` entries for the current bot are reconciled when the worktree
+  has no live runner process:
+  - `pending` or `planned` with `postMessageId` -> `sent`
+  - `planned`, `pending`, or `failed` without `postMessageId` ->
+    `fallback_visible` with an `orphan_reconcile` attempt
+  - terminal `sent`, `fallback_visible`, and `policy_blocked` entries are left
+    untouched
+- Dispatcher re-entry is also idempotent. If the same logical post key is
+  already `sent`, the dispatcher reuses the ledger message id and does not call
+  the post client. If it finds an orphaned non-terminal entry, it reconciles to
+  visible fallback instead of resending.
+
+This is a conservative reconcile policy. It never queries or sends real Feishu
+post messages in PR5, and it never repeats an outbound post during recovery.
+
 ## Non-Goals Until Later PRs
 
 - No production-wired real IM post outbound.
 - No production-wired real peer `at`.
-- No visible post failure fallback.
+- No production-wired visible post failure fallback.
 - No Feishu E2E or test cards.
 - No deployment, restart, or production bridge touch.
 - No expansion of dogfood surface.

--- a/docs/response-surface-prototype.md
+++ b/docs/response-surface-prototype.md
@@ -184,8 +184,13 @@ PR5 extends boot-time reconcile without enabling post outbound:
 - Old `post.json` entries for the current bot are reconciled when the worktree
   has no live runner process:
   - `pending` or `planned` with `postMessageId` -> `sent`
-  - `planned`, `pending`, or `failed` without `postMessageId` ->
-    `fallback_visible` with an `orphan_reconcile` attempt
+  - `planned`, `pending`, or `failed` without `postMessageId` first require a
+    visible fallback card. Reconcile creates and finalizes that card, then marks
+    the ledger `fallback_visible` with `fallbackCardMessageId` and an
+    `orphan_reconcile` attempt.
+  - if the fallback card cannot be created/finalized, the ledger stays
+    non-terminal and reconcile logs the failure; it must not silently mark
+    `fallback_visible`.
   - terminal `sent`, `fallback_visible`, and `policy_blocked` entries are left
     untouched
 - Dispatcher re-entry is also idempotent. If the same logical post key is
@@ -194,7 +199,8 @@ PR5 extends boot-time reconcile without enabling post outbound:
   visible fallback instead of resending.
 
 This is a conservative reconcile policy. It never queries or sends real Feishu
-post messages in PR5, and it never repeats an outbound post during recovery.
+post messages in PR5, never repeats an outbound post during recovery, and never
+marks `fallback_visible` unless a visible fallback artifact exists.
 
 ## Non-Goals Until Later PRs
 

--- a/src/bridge/postFile.test.ts
+++ b/src/bridge/postFile.test.ts
@@ -6,6 +6,8 @@ import {
   assertPostStatusTransition,
   postFilePathOf,
   readPostFile,
+  reconcilePostFileOrphans,
+  reconcilePostLedgerEntries,
   upsertPostLedgerEntry,
   writePostFile,
   type PostLedgerEntry,
@@ -24,7 +26,10 @@ async function tempWorktree(): Promise<string> {
   return dir;
 }
 
-function entry(status: PostLedgerEntry["status"]): PostLedgerEntry {
+function entry(
+  status: PostLedgerEntry["status"],
+  overrides: Partial<PostLedgerEntry> = {},
+): PostLedgerEntry {
   return {
     idempotencyKey: "lw-p-entry",
     status,
@@ -39,6 +44,7 @@ function entry(status: PostLedgerEntry["status"]): PostLedgerEntry {
     attempts: [],
     createdAt: "2026-06-26T00:00:00.000Z",
     updatedAt: "2026-06-26T00:00:00.000Z",
+    ...overrides,
   };
 }
 
@@ -82,8 +88,101 @@ describe("postFile ledger", () => {
     expect(read?.posts[0]?.status).toBe("pending");
     expect(read?.posts[0]?.attempts[0]?.retryable).toBe(true);
 
+    expect(() => assertPostStatusTransition("planned", "fallback_visible")).not.toThrow();
     expect(() => assertPostStatusTransition("sent", "pending")).toThrow(
       /invalid post ledger transition/,
     );
+  });
+
+  it("reconciles old planned or pending entries to visible fallback without resend", () => {
+    const { file, result } = reconcilePostLedgerEntries(
+      {
+        version: 1,
+        posts: [
+          entry("planned"),
+          entry("pending", { idempotencyKey: "lw-p-pending" }),
+        ],
+      },
+      {
+        botId: "bot-a",
+        minAgeMs: 60_000,
+        now: () => "2026-06-26T00:02:00.000Z",
+      },
+    );
+
+    expect(result).toEqual({
+      changed: true,
+      sent: 0,
+      fallbackVisible: 2,
+      skippedLive: 0,
+    });
+    expect(file.posts.map((post) => post.status)).toEqual([
+      "fallback_visible",
+      "fallback_visible",
+    ]);
+    expect(file.posts[0]?.attempts[0]?.code).toBe("orphan_reconcile");
+    expect(file.posts[1]?.error).toContain("without resend");
+  });
+
+  it("reconciles pending entries with a recorded postMessageId to sent", () => {
+    const { file, result } = reconcilePostLedgerEntries(
+      {
+        version: 1,
+        posts: [entry("pending", { postMessageId: "om_post" })],
+      },
+      {
+        botId: "bot-a",
+        now: () => "2026-06-26T00:02:00.000Z",
+      },
+    );
+
+    expect(result.sent).toBe(1);
+    expect(result.fallbackVisible).toBe(0);
+    expect(file.posts[0]?.status).toBe("sent");
+    expect(file.posts[0]?.postMessageId).toBe("om_post");
+    expect(file.posts[0]?.attempts[0]?.status).toBe("sent");
+  });
+
+  it("leaves young, terminal, and other-bot post entries untouched", () => {
+    const young = entry("pending", {
+      idempotencyKey: "lw-p-young",
+      updatedAt: "2026-06-26T00:01:30.000Z",
+    });
+    const sent = entry("sent", {
+      idempotencyKey: "lw-p-sent",
+      postMessageId: "om_post",
+    });
+    const otherBot = entry("pending", {
+      idempotencyKey: "lw-p-other",
+      botId: "bot-b",
+    });
+    const { file, result } = reconcilePostLedgerEntries(
+      { version: 1, posts: [young, sent, otherBot] },
+      {
+        botId: "bot-a",
+        minAgeMs: 60_000,
+        now: () => "2026-06-26T00:02:00.000Z",
+      },
+    );
+
+    expect(result.changed).toBe(false);
+    expect(result.skippedLive).toBe(1);
+    expect(file.posts).toEqual([young, sent, otherBot]);
+  });
+
+  it("reconciles post.json on disk atomically", async () => {
+    const wt = await tempWorktree();
+    await writePostFile(wt, { version: 1, posts: [entry("failed", { error: "crashed" })] });
+
+    const result = await reconcilePostFileOrphans(wt, {
+      botId: "bot-a",
+      now: () => "2026-06-26T00:02:00.000Z",
+    });
+
+    expect(result.changed).toBe(true);
+    expect(result.fallbackVisible).toBe(1);
+    const read = await readPostFile(wt);
+    expect(read?.posts[0]?.status).toBe("fallback_visible");
+    expect(read?.posts[0]?.error).toBe("crashed");
   });
 });

--- a/src/bridge/postFile.test.ts
+++ b/src/bridge/postFile.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import {
   assertPostStatusTransition,
+  markPostLedgerFallbackVisible,
   postFilePathOf,
   readPostFile,
   reconcilePostFileOrphans,
@@ -94,8 +95,8 @@ describe("postFile ledger", () => {
     );
   });
 
-  it("reconciles old planned or pending entries to visible fallback without resend", () => {
-    const { file, result } = reconcilePostLedgerEntries(
+  it("selects old planned or pending entries as needing visible fallback without marking them", () => {
+    const { file, result, visibleFallbackCandidates } = reconcilePostLedgerEntries(
       {
         version: 1,
         posts: [
@@ -111,17 +112,17 @@ describe("postFile ledger", () => {
     );
 
     expect(result).toEqual({
-      changed: true,
+      changed: false,
       sent: 0,
-      fallbackVisible: 2,
+      fallbackVisible: 0,
+      needsVisibleFallback: 2,
       skippedLive: 0,
     });
-    expect(file.posts.map((post) => post.status)).toEqual([
-      "fallback_visible",
-      "fallback_visible",
+    expect(file.posts.map((post) => post.status)).toEqual(["planned", "pending"]);
+    expect(visibleFallbackCandidates.map((post) => post.idempotencyKey)).toEqual([
+      "lw-p-entry",
+      "lw-p-pending",
     ]);
-    expect(file.posts[0]?.attempts[0]?.code).toBe("orphan_reconcile");
-    expect(file.posts[1]?.error).toContain("without resend");
   });
 
   it("reconciles pending entries with a recorded postMessageId to sent", () => {
@@ -179,10 +180,28 @@ describe("postFile ledger", () => {
       now: () => "2026-06-26T00:02:00.000Z",
     });
 
-    expect(result.changed).toBe(true);
-    expect(result.fallbackVisible).toBe(1);
+    expect(result.changed).toBe(false);
+    expect(result.fallbackVisible).toBe(0);
+    expect(result.needsVisibleFallback).toBe(1);
+    expect(result.visibleFallbackCandidates[0]?.status).toBe("failed");
     const read = await readPostFile(wt);
-    expect(read?.posts[0]?.status).toBe("fallback_visible");
+    expect(read?.posts[0]?.status).toBe("failed");
     expect(read?.posts[0]?.error).toBe("crashed");
+  });
+
+  it("marks fallback_visible only after a visible fallback card exists", async () => {
+    const wt = await tempWorktree();
+    await writePostFile(wt, { version: 1, posts: [entry("pending")] });
+
+    const next = await markPostLedgerFallbackVisible(wt, "lw-p-entry", {
+      fallbackCardMessageId: "om_card_fallback",
+      error: "visible card finalized",
+      now: () => "2026-06-26T00:02:00.000Z",
+    });
+
+    expect(next.posts[0]?.status).toBe("fallback_visible");
+    expect(next.posts[0]?.fallbackCardMessageId).toBe("om_card_fallback");
+    expect(next.posts[0]?.attempts[0]?.code).toBe("orphan_reconcile");
+    expect(next.posts[0]?.error).toBe("visible card finalized");
   });
 });

--- a/src/bridge/postFile.ts
+++ b/src/bridge/postFile.ts
@@ -14,7 +14,7 @@ export const PostLedgerStatusSchema = z.enum([
 export type PostLedgerStatus = z.infer<typeof PostLedgerStatusSchema>;
 
 export const POST_LEDGER_TRANSITIONS: Record<PostLedgerStatus, PostLedgerStatus[]> = {
-  planned: ["pending", "policy_blocked"],
+  planned: ["pending", "fallback_visible", "policy_blocked"],
   pending: ["sent", "failed", "fallback_visible", "policy_blocked"],
   sent: [],
   failed: ["fallback_visible"],
@@ -148,4 +148,146 @@ export async function upsertPostLedgerEntry(
   const next = { version: 1 as const, posts: nextPosts };
   await writePostFile(worktreePath, next);
   return next;
+}
+
+export interface ReconcilePostLedgerOpts {
+  botId: string;
+  minAgeMs?: number;
+  now?: () => string;
+}
+
+export interface ReconcilePostLedgerResult {
+  changed: boolean;
+  sent: number;
+  fallbackVisible: number;
+  skippedLive: number;
+}
+
+const DEFAULT_POST_RECONCILE_MIN_AGE_MS = 60_000;
+
+function timestampAgeMs(iso: string, nowMs: number): number | null {
+  if (!Number.isFinite(nowMs)) return null;
+  const then = Date.parse(iso);
+  if (!Number.isFinite(then)) return null;
+  return nowMs - then;
+}
+
+function reconcilePostEntry(
+  entry: PostLedgerEntry,
+  opts: Required<ReconcilePostLedgerOpts>,
+): { entry: PostLedgerEntry; changed: boolean; sent: boolean; fallbackVisible: boolean } {
+  if (entry.botId !== opts.botId) {
+    return { entry, changed: false, sent: false, fallbackVisible: false };
+  }
+
+  if (
+    entry.status === "sent" ||
+    entry.status === "fallback_visible" ||
+    entry.status === "policy_blocked"
+  ) {
+    return { entry, changed: false, sent: false, fallbackVisible: false };
+  }
+
+  const now = opts.now();
+  const ageMs = timestampAgeMs(entry.updatedAt, Date.parse(now));
+  if (ageMs == null || ageMs < opts.minAgeMs) {
+    return { entry, changed: false, sent: false, fallbackVisible: false };
+  }
+
+  if (entry.postMessageId) {
+    return {
+      entry: {
+        ...entry,
+        status: "sent",
+        error: undefined,
+        updatedAt: now,
+        attempts: [
+          ...entry.attempts,
+          {
+            attemptedAt: now,
+            status: "sent",
+            retryable: false,
+          },
+        ],
+      },
+      changed: true,
+      sent: true,
+      fallbackVisible: false,
+    };
+  }
+
+  const error =
+    entry.status === "failed" && entry.error
+      ? entry.error
+      : "orphaned post ledger entry reconciled without resend; visible card fallback required";
+  return {
+    entry: {
+      ...entry,
+      status: "fallback_visible",
+      error,
+      updatedAt: now,
+      attempts: [
+        ...entry.attempts,
+        {
+          attemptedAt: now,
+          status: "failed",
+          retryable: false,
+          code: "orphan_reconcile",
+          error,
+        },
+      ],
+    },
+    changed: true,
+    sent: false,
+    fallbackVisible: true,
+  };
+}
+
+export function reconcilePostLedgerEntries(
+  data: PostFile,
+  opts: ReconcilePostLedgerOpts,
+): { file: PostFile; result: ReconcilePostLedgerResult } {
+  const normalizedOpts: Required<ReconcilePostLedgerOpts> = {
+    botId: opts.botId,
+    minAgeMs: opts.minAgeMs ?? DEFAULT_POST_RECONCILE_MIN_AGE_MS,
+    now: opts.now ?? (() => new Date().toISOString()),
+  };
+
+  let sent = 0;
+  let fallbackVisible = 0;
+  let skippedLive = 0;
+  const posts = data.posts.map((post) => {
+    const reconciled = reconcilePostEntry(post, normalizedOpts);
+    if (reconciled.changed) {
+      if (reconciled.sent) sent += 1;
+      if (reconciled.fallbackVisible) fallbackVisible += 1;
+    } else if (
+      post.botId === normalizedOpts.botId &&
+      (post.status === "planned" || post.status === "pending" || post.status === "failed")
+    ) {
+      skippedLive += 1;
+    }
+    return reconciled.entry;
+  });
+  const changed = sent > 0 || fallbackVisible > 0;
+  return {
+    file: changed ? { version: 1, posts } : data,
+    result: { changed, sent, fallbackVisible, skippedLive },
+  };
+}
+
+export async function reconcilePostFileOrphans(
+  worktreePath: string,
+  opts: ReconcilePostLedgerOpts,
+): Promise<ReconcilePostLedgerResult> {
+  const existing = await readPostFile(worktreePath);
+  if (!existing) {
+    return { changed: false, sent: 0, fallbackVisible: 0, skippedLive: 0 };
+  }
+
+  const { file, result } = reconcilePostLedgerEntries(existing, opts);
+  if (result.changed) {
+    await writePostFile(worktreePath, file);
+  }
+  return result;
 }

--- a/src/bridge/postFile.ts
+++ b/src/bridge/postFile.ts
@@ -160,6 +160,7 @@ export interface ReconcilePostLedgerResult {
   changed: boolean;
   sent: number;
   fallbackVisible: number;
+  needsVisibleFallback: number;
   skippedLive: number;
 }
 
@@ -175,9 +176,14 @@ function timestampAgeMs(iso: string, nowMs: number): number | null {
 function reconcilePostEntry(
   entry: PostLedgerEntry,
   opts: Required<ReconcilePostLedgerOpts>,
-): { entry: PostLedgerEntry; changed: boolean; sent: boolean; fallbackVisible: boolean } {
+): {
+  entry: PostLedgerEntry;
+  changed: boolean;
+  sent: boolean;
+  needsVisibleFallback: boolean;
+} {
   if (entry.botId !== opts.botId) {
-    return { entry, changed: false, sent: false, fallbackVisible: false };
+    return { entry, changed: false, sent: false, needsVisibleFallback: false };
   }
 
   if (
@@ -185,13 +191,13 @@ function reconcilePostEntry(
     entry.status === "fallback_visible" ||
     entry.status === "policy_blocked"
   ) {
-    return { entry, changed: false, sent: false, fallbackVisible: false };
+    return { entry, changed: false, sent: false, needsVisibleFallback: false };
   }
 
   const now = opts.now();
   const ageMs = timestampAgeMs(entry.updatedAt, Date.parse(now));
   if (ageMs == null || ageMs < opts.minAgeMs) {
-    return { entry, changed: false, sent: false, fallbackVisible: false };
+    return { entry, changed: false, sent: false, needsVisibleFallback: false };
   }
 
   if (entry.postMessageId) {
@@ -212,41 +218,26 @@ function reconcilePostEntry(
       },
       changed: true,
       sent: true,
-      fallbackVisible: false,
+      needsVisibleFallback: false,
     };
   }
 
-  const error =
-    entry.status === "failed" && entry.error
-      ? entry.error
-      : "orphaned post ledger entry reconciled without resend; visible card fallback required";
   return {
-    entry: {
-      ...entry,
-      status: "fallback_visible",
-      error,
-      updatedAt: now,
-      attempts: [
-        ...entry.attempts,
-        {
-          attemptedAt: now,
-          status: "failed",
-          retryable: false,
-          code: "orphan_reconcile",
-          error,
-        },
-      ],
-    },
-    changed: true,
+    entry,
+    changed: false,
     sent: false,
-    fallbackVisible: true,
+    needsVisibleFallback: true,
   };
 }
 
 export function reconcilePostLedgerEntries(
   data: PostFile,
   opts: ReconcilePostLedgerOpts,
-): { file: PostFile; result: ReconcilePostLedgerResult } {
+): {
+  file: PostFile;
+  result: ReconcilePostLedgerResult;
+  visibleFallbackCandidates: PostLedgerEntry[];
+} {
   const normalizedOpts: Required<ReconcilePostLedgerOpts> = {
     botId: opts.botId,
     minAgeMs: opts.minAgeMs ?? DEFAULT_POST_RECONCILE_MIN_AGE_MS,
@@ -254,13 +245,17 @@ export function reconcilePostLedgerEntries(
   };
 
   let sent = 0;
-  let fallbackVisible = 0;
+  const fallbackVisible = 0;
+  let needsVisibleFallback = 0;
   let skippedLive = 0;
+  const visibleFallbackCandidates: PostLedgerEntry[] = [];
   const posts = data.posts.map((post) => {
     const reconciled = reconcilePostEntry(post, normalizedOpts);
     if (reconciled.changed) {
       if (reconciled.sent) sent += 1;
-      if (reconciled.fallbackVisible) fallbackVisible += 1;
+    } else if (reconciled.needsVisibleFallback) {
+      needsVisibleFallback += 1;
+      visibleFallbackCandidates.push(reconciled.entry);
     } else if (
       post.botId === normalizedOpts.botId &&
       (post.status === "planned" || post.status === "pending" || post.status === "failed")
@@ -272,22 +267,72 @@ export function reconcilePostLedgerEntries(
   const changed = sent > 0 || fallbackVisible > 0;
   return {
     file: changed ? { version: 1, posts } : data,
-    result: { changed, sent, fallbackVisible, skippedLive },
+    result: { changed, sent, fallbackVisible, needsVisibleFallback, skippedLive },
+    visibleFallbackCandidates,
   };
 }
 
 export async function reconcilePostFileOrphans(
   worktreePath: string,
   opts: ReconcilePostLedgerOpts,
-): Promise<ReconcilePostLedgerResult> {
+): Promise<ReconcilePostLedgerResult & { visibleFallbackCandidates: PostLedgerEntry[] }> {
   const existing = await readPostFile(worktreePath);
   if (!existing) {
-    return { changed: false, sent: 0, fallbackVisible: 0, skippedLive: 0 };
+    return {
+      changed: false,
+      sent: 0,
+      fallbackVisible: 0,
+      needsVisibleFallback: 0,
+      skippedLive: 0,
+      visibleFallbackCandidates: [],
+    };
   }
 
-  const { file, result } = reconcilePostLedgerEntries(existing, opts);
+  const { file, result, visibleFallbackCandidates } = reconcilePostLedgerEntries(existing, opts);
   if (result.changed) {
     await writePostFile(worktreePath, file);
   }
-  return result;
+  return { ...result, visibleFallbackCandidates };
+}
+
+export async function markPostLedgerFallbackVisible(
+  worktreePath: string,
+  idempotencyKey: string,
+  opts: {
+    fallbackCardMessageId: string;
+    error: string;
+    now?: () => string;
+  },
+): Promise<PostFile> {
+  const existing = (await readPostFile(worktreePath)) ?? emptyPostFile();
+  const idx = existing.posts.findIndex((post) => post.idempotencyKey === idempotencyKey);
+  if (idx < 0) {
+    throw new Error(`post ledger entry not found: ${idempotencyKey}`);
+  }
+
+  const current = existing.posts[idx];
+  assertPostStatusTransition(current.status, "fallback_visible");
+  const now = opts.now?.() ?? new Date().toISOString();
+  const nextPosts = [...existing.posts];
+  nextPosts[idx] = {
+    ...current,
+    status: "fallback_visible",
+    fallbackCardMessageId: opts.fallbackCardMessageId,
+    error: opts.error,
+    updatedAt: now,
+    attempts: [
+      ...current.attempts,
+      {
+        attemptedAt: now,
+        status: "failed",
+        retryable: false,
+        code: "orphan_reconcile",
+        error: opts.error,
+      },
+    ],
+  };
+
+  const next = { version: 1 as const, posts: nextPosts };
+  await writePostFile(worktreePath, next);
+  return next;
 }

--- a/src/bridge/reconcile.test.ts
+++ b/src/bridge/reconcile.test.ts
@@ -10,7 +10,7 @@
  *      and that a finalize rejection does NOT throw + bumps retryCount.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { mkdtemp, rm, mkdir, utimes } from "node:fs/promises";
+import { chmod, mkdtemp, rm, mkdir, utimes } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -159,7 +159,11 @@ interface SpyHandle extends CardHandle {
   finalizeArgs: Parameters<CardHandle["finalize"]>[0][];
 }
 
-function makeFakeRenderer(opts?: { rejectFinalize?: boolean; rejectStart?: boolean }) {
+function makeFakeRenderer(opts?: {
+  rejectFinalize?: boolean;
+  rejectStart?: boolean;
+  onFinalize?: (messageId: string) => Promise<void> | void;
+}) {
   const handlesByMessageId = new Map<string, SpyHandle>();
   const startCalls: Array<{
     replyToMessageId: string;
@@ -176,6 +180,7 @@ function makeFakeRenderer(opts?: { rejectFinalize?: boolean; rejectStart?: boole
       finalize: vi.fn(async (a) => {
         finalizeArgs.push(a);
         if (opts?.rejectFinalize) throw new Error("PATCH 230001 not the sender");
+        await opts?.onFinalize?.(messageId);
       }) as unknown as CardHandle["finalize"],
     };
     handlesByMessageId.set(messageId, handle);
@@ -439,6 +444,68 @@ describe("reconcileOrphanedCards — integration", () => {
     const ledgerAfterSecond = await readPostFile(wt);
     expect(ledgerAfterSecond?.posts[0]?.status).toBe("fallback_visible");
     expect(ledgerAfterSecond?.posts[0]?.fallbackCardMessageId).toBe("om_existing_card");
+  });
+
+  it("keeps card.json when post ledger mark fails after finalize even past retry cap", async () => {
+    const wt = await seedWorktree(
+      "om_mark_fails_at_cap",
+      card({
+        messageId: "om_existing_card_cap",
+        threadId: "om_mark_fails_at_cap",
+        retryCount: 3,
+      }),
+      state("ready", { last_message: "existing card is visible" }),
+    );
+    await writePostFile(wt, {
+      version: 1,
+      posts: [postEntry({ threadId: "om_mark_fails_at_cap" })],
+    });
+    const larkwayDir = join(wt, ".larkway");
+    let failMarkOnce = true;
+    const logs: string[] = [];
+    const { renderer, startCalls, handlesByMessageId } = makeFakeRenderer({
+      onFinalize: async (messageId) => {
+        if (messageId !== "om_existing_card_cap" || !failMarkOnce) return;
+        failMarkOnce = false;
+        await chmod(larkwayDir, 0o500);
+      },
+    });
+
+    await expect(
+      reconcileOrphanedCards({
+        botId: "gitlab",
+        worktreesDir: root,
+        cardRenderer: renderer,
+        minAgeMs: 60_000,
+        log: (message) => logs.push(message),
+      }),
+    ).resolves.toBeUndefined();
+
+    const cardAfterMarkFailure = await readCardFile(wt);
+    expect(cardAfterMarkFailure).not.toBeNull();
+    expect(cardAfterMarkFailure?.retryCount).toBe(3);
+    const ledgerAfterMarkFailure = await readPostFile(wt);
+    expect(ledgerAfterMarkFailure?.posts[0]?.status).toBe("pending");
+    expect(ledgerAfterMarkFailure?.posts[0]?.fallbackCardMessageId).toBeUndefined();
+    expect(logs.some((message) => message.includes("post ledger mark failed"))).toBe(true);
+    expect(logs.some((message) => message.includes("finalize FAILED"))).toBe(false);
+
+    await chmod(larkwayDir, 0o700);
+
+    await reconcileOrphanedCards({
+      botId: "gitlab",
+      worktreesDir: root,
+      cardRenderer: renderer,
+      minAgeMs: 60_000,
+      log: () => {},
+    });
+
+    expect(startCalls).toEqual([]);
+    expect(handlesByMessageId.has("om_started_1")).toBe(false);
+    const ledgerAfterRetry = await readPostFile(wt);
+    expect(ledgerAfterRetry?.posts[0]?.status).toBe("fallback_visible");
+    expect(ledgerAfterRetry?.posts[0]?.fallbackCardMessageId).toBe("om_existing_card_cap");
+    expect(await readCardFile(wt)).toBeNull();
   });
 
   it("leaves a post-only orphan non-terminal when fallback card creation fails", async () => {

--- a/src/bridge/reconcile.test.ts
+++ b/src/bridge/reconcile.test.ts
@@ -396,6 +396,51 @@ describe("reconcileOrphanedCards — integration", () => {
     expect(await readCardFile(wt)).toBeNull();
   });
 
+  it("marks a card+state post orphan visible via the existing card and stays idempotent", async () => {
+    const wt = await seedWorktree(
+      "om_card_and_post",
+      card({ messageId: "om_existing_card", threadId: "om_card_and_post" }),
+      state("ready", { last_message: "existing card became visible" }),
+    );
+    await writePostFile(wt, {
+      version: 1,
+      posts: [postEntry({ threadId: "om_card_and_post" })],
+    });
+    const { renderer, handlesByMessageId, startCalls } = makeFakeRenderer();
+
+    await reconcileOrphanedCards({
+      botId: "gitlab",
+      worktreesDir: root,
+      cardRenderer: renderer,
+      minAgeMs: 60_000,
+      log: () => {},
+    });
+
+    expect(startCalls).toEqual([]);
+    const existingHandle = handlesByMessageId.get("om_existing_card");
+    expect(existingHandle?.finalizeArgs).toHaveLength(1);
+    const ledgerAfterFirst = await readPostFile(wt);
+    expect(ledgerAfterFirst?.posts[0]?.status).toBe("fallback_visible");
+    expect(ledgerAfterFirst?.posts[0]?.fallbackCardMessageId).toBe("om_existing_card");
+    expect(ledgerAfterFirst?.posts[0]?.attempts[0]?.code).toBe("orphan_reconcile");
+    expect(await readCardFile(wt)).toBeNull();
+
+    await reconcileOrphanedCards({
+      botId: "gitlab",
+      worktreesDir: root,
+      cardRenderer: renderer,
+      minAgeMs: 60_000,
+      log: () => {},
+    });
+
+    expect(startCalls).toEqual([]);
+    expect(handlesByMessageId.has("om_started_1")).toBe(false);
+    expect(handlesByMessageId.get("om_existing_card")?.finalizeArgs).toHaveLength(1);
+    const ledgerAfterSecond = await readPostFile(wt);
+    expect(ledgerAfterSecond?.posts[0]?.status).toBe("fallback_visible");
+    expect(ledgerAfterSecond?.posts[0]?.fallbackCardMessageId).toBe("om_existing_card");
+  });
+
   it("leaves a post-only orphan non-terminal when fallback card creation fails", async () => {
     const wt = join(root, "om_post_only_start_fail");
     await mkdir(join(wt, ".larkway"), { recursive: true });

--- a/src/bridge/reconcile.test.ts
+++ b/src/bridge/reconcile.test.ts
@@ -159,25 +159,46 @@ interface SpyHandle extends CardHandle {
   finalizeArgs: Parameters<CardHandle["finalize"]>[0][];
 }
 
-function makeFakeRenderer(opts?: { rejectFinalize?: boolean }) {
+function makeFakeRenderer(opts?: { rejectFinalize?: boolean; rejectStart?: boolean }) {
   const handlesByMessageId = new Map<string, SpyHandle>();
+  const startCalls: Array<{
+    replyToMessageId: string;
+    replyInThread?: boolean;
+    threadId?: string;
+  }> = [];
+  let nextStartedCard = 1;
+  function makeHandle(messageId: string): SpyHandle {
+    const finalizeArgs: Parameters<CardHandle["finalize"]>[0][] = [];
+    const handle: SpyHandle = {
+      messageId,
+      finalizeArgs,
+      handle: () => {},
+      finalize: vi.fn(async (a) => {
+        finalizeArgs.push(a);
+        if (opts?.rejectFinalize) throw new Error("PATCH 230001 not the sender");
+      }) as unknown as CardHandle["finalize"],
+    };
+    handlesByMessageId.set(messageId, handle);
+    return handle;
+  }
   const renderer = {
+    async start(
+      replyToMessageId: string,
+      startOpts?: { replyInThread?: boolean; threadId?: string },
+    ): Promise<CardHandle> {
+      startCalls.push({
+        replyToMessageId,
+        replyInThread: startOpts?.replyInThread,
+        threadId: startOpts?.threadId,
+      });
+      if (opts?.rejectStart) throw new Error("create card failed");
+      return makeHandle(`om_started_${nextStartedCard++}`);
+    },
     handleFor(messageId: string): CardHandle {
-      const finalizeArgs: Parameters<CardHandle["finalize"]>[0][] = [];
-      const handle: SpyHandle = {
-        messageId,
-        finalizeArgs,
-        handle: () => {},
-        finalize: vi.fn(async (a) => {
-          finalizeArgs.push(a);
-          if (opts?.rejectFinalize) throw new Error("PATCH 230001 not the sender");
-        }) as unknown as CardHandle["finalize"],
-      };
-      handlesByMessageId.set(messageId, handle);
-      return handle;
+      return makeHandle(messageId);
     },
   };
-  return { renderer, handlesByMessageId };
+  return { renderer, handlesByMessageId, startCalls };
 }
 
 let root: string;
@@ -347,11 +368,39 @@ describe("reconcileOrphanedCards — integration", () => {
     expect(await readCardFile(wt)).toBeNull();
   });
 
-  it("reconciles an old post ledger orphan even when no card.json exists", async () => {
+  it("creates and finalizes a visible fallback card before marking a post-only orphan fallback_visible", async () => {
     const wt = join(root, "om_post_only");
     await mkdir(join(wt, ".larkway"), { recursive: true });
     await writePostFile(wt, { version: 1, posts: [postEntry()] });
-    const { renderer, handlesByMessageId } = makeFakeRenderer();
+    const { renderer, handlesByMessageId, startCalls } = makeFakeRenderer();
+
+    await reconcileOrphanedCards({
+      botId: "gitlab",
+      worktreesDir: root,
+      cardRenderer: renderer,
+      minAgeMs: 60_000,
+      log: () => {},
+    });
+
+    expect(startCalls).toEqual([
+      { replyToMessageId: "om_trigger", replyInThread: true, threadId: "om_thread" },
+    ]);
+    const handle = handlesByMessageId.get("om_started_1");
+    expect(handle?.finalizeArgs).toHaveLength(1);
+    expect(handle?.finalizeArgs[0]?.success).toBe(false);
+    expect(handle?.finalizeArgs[0]?.finalText).toContain("visible fallback card");
+    const ledger = await readPostFile(wt);
+    expect(ledger?.posts[0]?.status).toBe("fallback_visible");
+    expect(ledger?.posts[0]?.fallbackCardMessageId).toBe("om_started_1");
+    expect(ledger?.posts[0]?.attempts[0]?.code).toBe("orphan_reconcile");
+    expect(await readCardFile(wt)).toBeNull();
+  });
+
+  it("leaves a post-only orphan non-terminal when fallback card creation fails", async () => {
+    const wt = join(root, "om_post_only_start_fail");
+    await mkdir(join(wt, ".larkway"), { recursive: true });
+    await writePostFile(wt, { version: 1, posts: [postEntry()] });
+    const { renderer, handlesByMessageId } = makeFakeRenderer({ rejectStart: true });
 
     await reconcileOrphanedCards({
       botId: "gitlab",
@@ -363,8 +412,8 @@ describe("reconcileOrphanedCards — integration", () => {
 
     expect(handlesByMessageId.size).toBe(0);
     const ledger = await readPostFile(wt);
-    expect(ledger?.posts[0]?.status).toBe("fallback_visible");
-    expect(ledger?.posts[0]?.attempts[0]?.code).toBe("orphan_reconcile");
+    expect(ledger?.posts[0]?.status).toBe("pending");
+    expect(ledger?.posts[0]?.fallbackCardMessageId).toBeUndefined();
   });
 
   it("does NOT throw on finalize rejection and bumps retryCount in card.json", async () => {

--- a/src/bridge/reconcile.test.ts
+++ b/src/bridge/reconcile.test.ts
@@ -22,6 +22,7 @@ import type { CardFile } from "./cardFile.js";
 import { writeCardFile, readCardFile } from "./cardFile.js";
 import type { StateFile } from "./stateFile.js";
 import type { CardHandle } from "../lark/card.js";
+import { readPostFile, writePostFile, type PostLedgerEntry } from "./postFile.js";
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -30,7 +31,7 @@ import type { CardHandle } from "../lark/card.js";
 function card(overrides: Partial<CardFile> = {}): CardFile {
   return {
     messageId: "om_card",
-    chatId: "oc_chat",
+    chatId: "chat-a",
     threadId: "om_thread",
     botId: "gitlab",
     retryCount: 0,
@@ -43,6 +44,25 @@ function state(status: StateFile["status"], overrides: Partial<StateFile> = {}):
   return {
     status,
     updated_at: "2026-05-29T12:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function postEntry(overrides: Partial<PostLedgerEntry> = {}): PostLedgerEntry {
+  return {
+    idempotencyKey: "lw-p-orphan",
+    status: "pending",
+    botId: "gitlab",
+    chatId: "chat-a",
+    threadId: "om_thread",
+    replyToMessageId: "om_trigger",
+    role: "primary",
+    logicalIndex: 0,
+    contentDigest: "digest",
+    mentionCount: 0,
+    attempts: [],
+    createdAt: "2026-05-29T12:00:00.000Z",
+    updatedAt: "2026-05-29T12:00:00.000Z",
     ...overrides,
   };
 }
@@ -222,6 +242,56 @@ describe("reconcileOrphanedCards — integration", () => {
     expect(await readCardFile(wt)).toBeNull();
   });
 
+  it("preserves rich state fields when finalizing a fresh orphan card", async () => {
+    await seedWorktree(
+      "om_rich",
+      card({ messageId: "om_msg_rich", threadId: "om_rich" }),
+      state("ready", {
+        last_message: "fallback body",
+        choices: [{ label: "继续", value: "继续处理" }],
+        choice_prompt: "下一步?",
+        image_blocks: [
+          { img_key: "img_v3_x", alt: "截图", mode: "fit_horizontal", preview: true },
+        ],
+        content_blocks: [
+          { type: "markdown", content: "正文" },
+          {
+            type: "image",
+            img_key: "img_v3_y",
+            alt: "图二",
+            mode: "fit_horizontal",
+            preview: true,
+          },
+        ],
+      }),
+    );
+    const { renderer, handlesByMessageId } = makeFakeRenderer();
+
+    await reconcileOrphanedCards({
+      botId: "gitlab",
+      worktreesDir: root,
+      cardRenderer: renderer,
+      log: () => {},
+    });
+
+    const args = handlesByMessageId.get("om_msg_rich")?.finalizeArgs[0];
+    expect(args?.choices).toEqual([{ label: "继续", value: "继续处理" }]);
+    expect(args?.choicePrompt).toBe("下一步?");
+    expect(args?.imageBlocks).toEqual([
+      { img_key: "img_v3_x", alt: "截图", mode: "fit_horizontal", preview: true },
+    ]);
+    expect(args?.contentBlocks).toEqual([
+      { type: "markdown", content: "正文" },
+      {
+        type: "image",
+        img_key: "img_v3_y",
+        alt: "图二",
+        mode: "fit_horizontal",
+        preview: true,
+      },
+    ]);
+  });
+
   it("finalizes a failed orphan as failure with the bot's error as failureReason", async () => {
     const wt = await seedWorktree(
       "om_t2",
@@ -272,7 +342,29 @@ describe("reconcileOrphanedCards — integration", () => {
     expect(args?.success).toBe(false);
     expect(args?.finalText).not.toContain("上一轮的成功回复");
     expect(args?.titleOverride).toBe("⚠️ 本轮被中断");
+    expect(args?.choices).toBeUndefined();
+    expect(args?.contentBlocks).toBeUndefined();
     expect(await readCardFile(wt)).toBeNull();
+  });
+
+  it("reconciles an old post ledger orphan even when no card.json exists", async () => {
+    const wt = join(root, "om_post_only");
+    await mkdir(join(wt, ".larkway"), { recursive: true });
+    await writePostFile(wt, { version: 1, posts: [postEntry()] });
+    const { renderer, handlesByMessageId } = makeFakeRenderer();
+
+    await reconcileOrphanedCards({
+      botId: "gitlab",
+      worktreesDir: root,
+      cardRenderer: renderer,
+      minAgeMs: 60_000,
+      log: () => {},
+    });
+
+    expect(handlesByMessageId.size).toBe(0);
+    const ledger = await readPostFile(wt);
+    expect(ledger?.posts[0]?.status).toBe("fallback_visible");
+    expect(ledger?.posts[0]?.attempts[0]?.code).toBe("orphan_reconcile");
   });
 
   it("does NOT throw on finalize rejection and bumps retryCount in card.json", async () => {

--- a/src/bridge/reconcile.ts
+++ b/src/bridge/reconcile.ts
@@ -43,7 +43,11 @@ import {
   deleteCardFile,
   type CardFile,
 } from "./cardFile.js";
-import { reconcilePostFileOrphans } from "./postFile.js";
+import {
+  markPostLedgerFallbackVisible,
+  reconcilePostFileOrphans,
+  type PostLedgerEntry,
+} from "./postFile.js";
 import { readStateFile, stateFilePathOf, type StateFile } from "./stateFile.js";
 import type { CardHandle, CardRenderer } from "../lark/card.js";
 
@@ -229,6 +233,62 @@ function mapFinalizeArgs(
   };
 }
 
+function postFallbackText(entry: PostLedgerEntry): string {
+  return (
+    "Bridge restarted while reconciling a post-only response. " +
+    "No post message id was recorded, so Larkway created this visible fallback card instead of resending the post.\n" +
+    `post_status: ${entry.status}\n` +
+    `idempotency_key: ${entry.idempotencyKey}`
+  );
+}
+
+async function finalizePostOnlyFallbackCard(input: {
+  deps: ReconcileDeps;
+  worktreePath: string;
+  entry: PostLedgerEntry;
+  existingCard: CardFile | null;
+  nowIso: string;
+  log: (msg: string) => void;
+}): Promise<void> {
+  const fallbackError =
+    input.entry.error ??
+    "orphaned post ledger entry reconciled after visible fallback card finalize";
+  const handle = input.existingCard
+    ? input.deps.cardRenderer.handleFor(input.existingCard.messageId)
+    : await input.deps.cardRenderer.start(input.entry.replyToMessageId, {
+        replyInThread: true,
+        threadId: input.entry.threadId,
+      });
+
+  if (!input.existingCard) {
+    await writeCardFile(input.worktreePath, {
+      messageId: handle.messageId,
+      chatId: input.entry.chatId,
+      threadId: input.entry.threadId,
+      botId: input.entry.botId,
+      retryCount: 0,
+      createdAt: input.nowIso,
+    });
+  }
+
+  await handle.finalize({
+    finalText: postFallbackText(input.entry),
+    success: false,
+    failureReason: fallbackError,
+    titleOverride: "Post fallback recovered",
+    colorOverride: "failure",
+  });
+  await markPostLedgerFallbackVisible(input.worktreePath, input.entry.idempotencyKey, {
+    fallbackCardMessageId: handle.messageId,
+    error: fallbackError,
+    now: () => input.nowIso,
+  });
+  await deleteCardFile(input.worktreePath);
+  input.log(
+    `[reconcile] post-only fallback card finalized for ${input.entry.idempotencyKey} as ${handle.messageId}`,
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Impure reconcile shell
 // ---------------------------------------------------------------------------
@@ -242,7 +302,7 @@ export interface ReconcileDeps {
    * The bot's CardRenderer — reconcile uses handleFor(messageId) to rebuild a
    * handle on the SAME outbound transport / identity that created the card.
    */
-  cardRenderer: Pick<CardRenderer, "handleFor">;
+  cardRenderer: Pick<CardRenderer, "handleFor" | "start">;
   /** Minimum state.json age before a card is eligible. @default 60000 */
   minAgeMs?: number;
   /** Logger. @default console.log */
@@ -313,6 +373,30 @@ export async function reconcileOrphanedCards(deps: ReconcileDeps): Promise<void>
             log(
               `[reconcile] post ledger ${name}: sent=${postResult.sent}, fallback_visible=${postResult.fallbackVisible}`,
             );
+          }
+          if (postResult.visibleFallbackCandidates.length > 0) {
+            if (card && state) {
+              log(
+                `[reconcile] post ledger ${name}: ${postResult.visibleFallbackCandidates.length} candidate(s) need visible fallback; existing card+state will reconcile separately`,
+              );
+            } else {
+              for (const entry of postResult.visibleFallbackCandidates) {
+                try {
+                  await finalizePostOnlyFallbackCard({
+                    deps,
+                    worktreePath: wtPath,
+                    entry,
+                    existingCard: state ? null : card,
+                    nowIso,
+                    log,
+                  });
+                } catch (err) {
+                  log(
+                    `[reconcile] post-only fallback failed for ${name}/${entry.idempotencyKey} (ledger left non-terminal): ${String(err)}`,
+                  );
+                }
+              }
+            }
           }
         } catch (err) {
           log(`[reconcile] post ledger failed for ${name} (skipping): ${String(err)}`);

--- a/src/bridge/reconcile.ts
+++ b/src/bridge/reconcile.ts
@@ -43,8 +43,9 @@ import {
   deleteCardFile,
   type CardFile,
 } from "./cardFile.js";
+import { reconcilePostFileOrphans } from "./postFile.js";
 import { readStateFile, stateFilePathOf, type StateFile } from "./stateFile.js";
-import type { CardRenderer } from "../lark/card.js";
+import type { CardHandle, CardRenderer } from "../lark/card.js";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -196,13 +197,7 @@ function mapFinalizeArgs(
   state: StateFile,
   success: boolean,
   stateFresh = true,
-): {
-  finalText: string;
-  success: boolean;
-  failureReason?: string;
-  titleOverride?: string;
-  colorOverride?: "success" | "failure" | "neutral";
-} {
+): Parameters<CardHandle["finalize"]>[0] {
   if (!stateFresh) {
     return {
       finalText: "⚠️ 本轮在处理中被 bridge 重启中断，未拿到 agent 的新回复。请再 @ 我一次继续。",
@@ -227,6 +222,10 @@ function mapFinalizeArgs(
     ...(failureReason !== undefined ? { failureReason } : {}),
     ...(state.card_title !== undefined ? { titleOverride: state.card_title } : {}),
     ...(state.card_color !== undefined ? { colorOverride: state.card_color } : {}),
+    ...(state.choices !== undefined ? { choices: state.choices } : {}),
+    ...(state.choice_prompt !== undefined ? { choicePrompt: state.choice_prompt } : {}),
+    ...(state.image_blocks !== undefined ? { imageBlocks: state.image_blocks } : {}),
+    ...(state.content_blocks !== undefined ? { contentBlocks: state.content_blocks } : {}),
   };
 }
 
@@ -274,13 +273,12 @@ export async function reconcileOrphanedCards(deps: ReconcileDeps): Promise<void>
 
   // ── Gather per-worktree observations ──────────────────────────────────────
   const now = Date.now();
+  const nowIso = new Date(now).toISOString();
   const candidates: OrphanCandidate[] = [];
   for (const name of dirNames) {
     const wtPath = pathJoin(deps.worktreesDir, name);
     try {
       const card = await readCardFile(wtPath);
-      if (!card) continue; // fast path — no card.json, nothing to reconcile
-
       const state = await readStateFile(wtPath);
 
       // Liveness: any pid associated with the worktree still alive?
@@ -304,6 +302,24 @@ export async function reconcileOrphanedCards(deps: ReconcileDeps): Promise<void>
         ageMs = 0;
       }
 
+      if (!pidAlive) {
+        try {
+          const postResult = await reconcilePostFileOrphans(wtPath, {
+            botId: deps.botId,
+            minAgeMs,
+            now: () => nowIso,
+          });
+          if (postResult.changed) {
+            log(
+              `[reconcile] post ledger ${name}: sent=${postResult.sent}, fallback_visible=${postResult.fallbackVisible}`,
+            );
+          }
+        } catch (err) {
+          log(`[reconcile] post ledger failed for ${name} (skipping): ${String(err)}`);
+        }
+      }
+
+      if (!card) continue; // no card.json → no card to finalize
       candidates.push({ name, card, state, pidAlive, ageMs });
     } catch (err) {
       // Per-worktree gather failure → log + skip this one, continue the sweep.

--- a/src/bridge/reconcile.ts
+++ b/src/bridge/reconcile.ts
@@ -289,6 +289,38 @@ async function finalizePostOnlyFallbackCard(input: {
   );
 }
 
+async function markVisiblePostFallbacksForCard(input: {
+  worktreePath: string;
+  botId: string;
+  minAgeMs: number;
+  nowIso: string;
+  fallbackCardMessageId: string;
+  log: (msg: string) => void;
+}): Promise<number> {
+  const postResult = await reconcilePostFileOrphans(input.worktreePath, {
+    botId: input.botId,
+    minAgeMs: input.minAgeMs,
+    now: () => input.nowIso,
+  });
+
+  if (postResult.visibleFallbackCandidates.length === 0) return 0;
+
+  for (const entry of postResult.visibleFallbackCandidates) {
+    const fallbackError =
+      entry.error ?? "orphaned post ledger entry reconciled after existing visible card finalize";
+    await markPostLedgerFallbackVisible(input.worktreePath, entry.idempotencyKey, {
+      fallbackCardMessageId: input.fallbackCardMessageId,
+      error: fallbackError,
+      now: () => input.nowIso,
+    });
+  }
+
+  input.log(
+    `[reconcile] marked ${postResult.visibleFallbackCandidates.length} post fallback candidate(s) visible via existing card ${input.fallbackCardMessageId}`,
+  );
+  return postResult.visibleFallbackCandidates.length;
+}
+
 // ---------------------------------------------------------------------------
 // Impure reconcile shell
 // ---------------------------------------------------------------------------
@@ -428,6 +460,14 @@ export async function reconcileOrphanedCards(deps: ReconcileDeps): Promise<void>
     try {
       const handle = deps.cardRenderer.handleFor(orphan.card.messageId);
       await handle.finalize(mapFinalizeArgs(state, orphan.success, orphan.stateFresh));
+      await markVisiblePostFallbacksForCard({
+        worktreePath: wtPath,
+        botId: deps.botId,
+        minAgeMs,
+        nowIso,
+        fallbackCardMessageId: handle.messageId,
+        log,
+      });
       // Success → drop card.json so the next boot doesn't re-finalize.
       await deleteCardFile(wtPath);
       log(

--- a/src/bridge/reconcile.ts
+++ b/src/bridge/reconcile.ts
@@ -457,22 +457,10 @@ export async function reconcileOrphanedCards(deps: ReconcileDeps): Promise<void>
     const state = cand?.state;
     if (!state) continue; // defensive — selector already ensured this
 
+    let handle: CardHandle;
     try {
-      const handle = deps.cardRenderer.handleFor(orphan.card.messageId);
+      handle = deps.cardRenderer.handleFor(orphan.card.messageId);
       await handle.finalize(mapFinalizeArgs(state, orphan.success, orphan.stateFresh));
-      await markVisiblePostFallbacksForCard({
-        worktreePath: wtPath,
-        botId: deps.botId,
-        minAgeMs,
-        nowIso,
-        fallbackCardMessageId: handle.messageId,
-        log,
-      });
-      // Success → drop card.json so the next boot doesn't re-finalize.
-      await deleteCardFile(wtPath);
-      log(
-        `[reconcile] finalized ${orphan.name} as ${orphan.success ? "success" : "failure"} (${orphan.reason})`,
-      );
     } catch (err) {
       // Finalize PATCH rejected (e.g. message deleted, transient network).
       // Bump retryCount; if over the cap, delete card.json to stop looping.
@@ -490,6 +478,33 @@ export async function reconcileOrphanedCards(deps: ReconcileDeps): Promise<void>
           log(`[reconcile] could not bump retryCount for ${orphan.name} (ignoring): ${String(writeErr)}`);
         }
       }
+      continue;
+    }
+
+    try {
+      await markVisiblePostFallbacksForCard({
+        worktreePath: wtPath,
+        botId: deps.botId,
+        minAgeMs,
+        nowIso,
+        fallbackCardMessageId: handle.messageId,
+        log,
+      });
+    } catch (err) {
+      log(
+        `[reconcile] post ledger mark failed for ${orphan.name} after visible card finalize; keeping card.json for retry: ${String(err)}`,
+      );
+      continue;
+    }
+
+    try {
+      // Success → drop card.json so the next boot doesn't re-finalize.
+      await deleteCardFile(wtPath);
+      log(
+        `[reconcile] finalized ${orphan.name} as ${orphan.success ? "success" : "failure"} (${orphan.reason})`,
+      );
+    } catch (err) {
+      log(`[reconcile] could not delete card.json for ${orphan.name} after finalize (ignoring): ${String(err)}`);
     }
   }
 }

--- a/src/bridge/surfaceDispatcher.test.ts
+++ b/src/bridge/surfaceDispatcher.test.ts
@@ -7,7 +7,7 @@ import {
   type CardFinalizePayload,
   type SurfaceDispatchInput,
 } from "./surfaceDispatcher.js";
-import { readPostFile } from "./postFile.js";
+import { readPostFile, writePostFile } from "./postFile.js";
 import type { StateFile } from "./stateFile.js";
 import type { OutboundPostClient } from "../lark/outboundPostClient.js";
 
@@ -144,6 +144,78 @@ describe("dispatchResponseSurface", () => {
       expect(ledger?.posts).toHaveLength(1);
       expect(ledger?.posts[0]?.status).toBe("sent");
       expect(ledger?.posts[0]?.postMessageId).toBe("om_post");
+    }));
+
+  it("does not resend when the same logical post is already marked sent", async () =>
+    withTemp(async (dir) => {
+      const first = fakePostClient();
+      const firstResult = await dispatchResponseSurface(
+        baseInput({
+          worktreePath: dir,
+          cardStarted: false,
+          postClient: first.client,
+        }),
+      );
+      expect(firstResult.reason).toBe("post-sent");
+      expect(first.calls).toHaveLength(1);
+
+      const second = fakePostClient();
+      const secondResult = await dispatchResponseSurface(
+        baseInput({
+          worktreePath: dir,
+          cardStarted: false,
+          postClient: second.client,
+        }),
+      );
+
+      expect(secondResult.reason).toBe("post-ledger-already-sent");
+      expect(secondResult.visible).toBe(true);
+      expect(secondResult.post?.messageId).toBe("om_post");
+      expect(second.calls).toHaveLength(0);
+    }));
+
+  it("reconciles an existing pending ledger entry to visible fallback without resending", async () =>
+    withTemp(async (dir) => {
+      const first = fakePostClient();
+      await dispatchResponseSurface(
+        baseInput({
+          worktreePath: dir,
+          cardStarted: false,
+          postClient: first.client,
+        }),
+      );
+      const ledger = await readPostFile(dir);
+      expect(ledger?.posts[0]?.status).toBe("sent");
+      await writePostFile(dir, {
+        version: 1,
+        posts: [
+          {
+            ...ledger!.posts[0]!,
+            status: "pending",
+            postMessageId: undefined,
+            attempts: [],
+          },
+        ],
+      });
+
+      const second = fakePostClient();
+      const result = await dispatchResponseSurface(
+        baseInput({
+          worktreePath: dir,
+          cardStarted: false,
+          postClient: second.client,
+        }),
+      );
+
+      expect(result.reason).toBe("post-orphan-reconciled-fallback-card");
+      expect(result.visible).toBe(true);
+      expect(result.card?.success).toBe(false);
+      expect(result.card?.failureReason).toContain("visible card fallback used");
+      expect(second.calls).toHaveLength(0);
+
+      const after = await readPostFile(dir);
+      expect(after?.posts[0]?.status).toBe("fallback_visible");
+      expect(after?.posts[0]?.attempts[0]?.code).toBe("orphan_reconcile");
     }));
 
   it("uses a compact secondary card for hybrid without repeating the main post body", async () =>

--- a/src/bridge/surfaceDispatcher.ts
+++ b/src/bridge/surfaceDispatcher.ts
@@ -9,6 +9,7 @@ import {
   type PostSurfaceRole,
 } from "../lark/idempotency.js";
 import {
+  readPostFile,
   upsertPostLedgerEntry,
   type PostLedgerEntry,
 } from "./postFile.js";
@@ -36,6 +37,8 @@ export type SurfaceDispatchReason =
   | "visible-fallback-unavailable"
   | "card-capability-required"
   | "mention-policy-blocked"
+  | "post-ledger-already-sent"
+  | "post-orphan-reconciled-fallback-card"
   | "post-sent"
   | "hybrid-post-sent-compact-card"
   | "post-failed-fallback-card";
@@ -184,6 +187,45 @@ async function writeLedger(
   await upsertPostLedgerEntry(input.worktreePath, entry);
 }
 
+async function existingLedgerEntry(
+  input: SurfaceDispatchInput,
+  idempotencyKey: string,
+): Promise<PostLedgerEntry | null> {
+  if (!input.worktreePath) return null;
+  const ledger = await readPostFile(input.worktreePath);
+  return ledger?.posts.find((post) => post.idempotencyKey === idempotencyKey) ?? null;
+}
+
+function sentResult(
+  input: SurfaceDispatchInput,
+  surface: NonNullable<StateFile["response_surface"]>,
+  post: { idempotencyKey: string; messageId: string; role: PostSurfaceRole },
+  reason: Extract<
+    SurfaceDispatchReason,
+    "post-ledger-already-sent" | "post-sent"
+  >,
+): SurfaceDispatchResult {
+  if (surface.mode === "hybrid" || input.cardStarted) {
+    return {
+      card: compactAuditCard(input, post),
+      reason:
+        reason === "post-ledger-already-sent"
+          ? "post-ledger-already-sent"
+          : surface.mode === "hybrid"
+            ? "hybrid-post-sent-compact-card"
+            : "post-sent",
+      visible: true,
+      post,
+    };
+  }
+  return {
+    card: null,
+    reason,
+    visible: true,
+    post,
+  };
+}
+
 export async function dispatchResponseSurface(
   input: SurfaceDispatchInput,
 ): Promise<SurfaceDispatchResult> {
@@ -274,6 +316,66 @@ export async function dispatchResponseSurface(
     logicalIndex,
     contentDigest,
   });
+  const existing = await existingLedgerEntry(input, idempotencyKey);
+  if (existing?.status === "sent" && existing.postMessageId) {
+    return sentResult(
+      input,
+      surface,
+      { idempotencyKey, messageId: existing.postMessageId, role },
+      "post-ledger-already-sent",
+    );
+  }
+  if (existing?.status === "sent") {
+    return fullCard(input, "post-orphan-reconciled-fallback-card");
+  }
+  if (existing?.status === "fallback_visible") {
+    return {
+      card: fallbackFailureCard(
+        input,
+        existing.error ?? "post ledger already reconciled to visible fallback",
+      ),
+      reason: "post-orphan-reconciled-fallback-card",
+      visible: true,
+      post: { idempotencyKey, role },
+    };
+  }
+  if (existing?.status === "policy_blocked") {
+    return {
+      card: policyBlockedCard(input),
+      reason: "mention-policy-blocked",
+      visible: true,
+      post: { idempotencyKey, role },
+    };
+  }
+  if (existing) {
+    const reconciledAt = input.now?.() ?? new Date().toISOString();
+    const error =
+      existing.status === "failed" && existing.error
+        ? existing.error
+        : "orphaned post ledger entry reconciled without resend; visible card fallback used";
+    await writeLedger(input, {
+      ...existing,
+      status: "fallback_visible",
+      error,
+      updatedAt: reconciledAt,
+      attempts: [
+        ...existing.attempts,
+        {
+          attemptedAt: reconciledAt,
+          status: "failed",
+          retryable: false,
+          code: "orphan_reconcile",
+          error,
+        },
+      ],
+    });
+    return {
+      card: fallbackFailureCard(input, error),
+      reason: "post-orphan-reconciled-fallback-card",
+      visible: true,
+      post: { idempotencyKey, role },
+    };
+  }
 
   await writeLedger(
     input,
@@ -330,23 +432,7 @@ export async function dispatchResponseSurface(
     );
 
     const post = { idempotencyKey, messageId: sent.messageId, role };
-    if (surface.mode === "hybrid" || input.cardStarted) {
-      return {
-        card: compactAuditCard(input, post),
-        reason:
-          surface.mode === "hybrid"
-            ? "hybrid-post-sent-compact-card"
-            : "post-sent",
-        visible: true,
-        post,
-      };
-    }
-    return {
-      card: null,
-      reason: "post-sent",
-      visible: true,
-      post,
-    };
+    return sentResult(input, surface, post, "post-sent");
   } catch (err) {
     const failedAt = input.now?.() ?? new Date().toISOString();
     const error = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
## Summary

Implements PR5 for the response surface prototype while keeping all production gates default-off.

- preserve rich card fields during boot-time orphan card reconcile: `choices`, `choice_prompt`, `image_blocks`, and `content_blocks`
- reconcile orphaned `post.json` entries for the current bot without sending or querying real Feishu posts
- create/finalize a visible fallback card before marking post-only non-terminal ledger orphans as `fallback_visible`
- after an existing `card.json` + `state.json` is finalized visibly, mark same-worktree post fallback candidates `fallback_visible` against that existing card to avoid duplicate recovery cards
- split finalize failure from post-ledger mark failure so mark failures keep `card.json` for existing-card retry instead of falling through to post-only recovery
- make dispatcher/reconcile re-entry idempotent: already-sent/fallback-visible ledger entries are terminal, and non-terminal ledger orphans fall back visibly instead of resending
- document PR5 behavior and non-goals in `docs/response-surface-prototype.md`

## Latest fix after third Turing review

Fix commit: `97c8b4ebb7edc590e5a3fcb0fb91a4fb151c6b53` (`fix: keep card ledger retry after mark failure`).

Turing found that the second fix still wrapped `handle.finalize(...)` and `markVisiblePostFallbacksForCard(...)` in the same catch. If finalize succeeded but ledger mark failed while `retryCount + 1 > RETRY_CAP`, the shared finalize-failure handler would attempt to delete `card.json`, allowing a later boot to degrade into post-only recovery and potentially create a second fallback card.

The fix separates the error handling:

- finalize failure: unchanged retry-cap behavior; bump `retryCount`, and delete `card.json` only when the actual card finalize keeps failing past the cap
- post-ledger mark failure after a successful finalize: log/alert and keep `card.json` regardless of retry count, so the next boot retries the existing-card association path
- cleanup delete failure after successful finalize+mark: log and ignore; this can only cause harmless re-finalize attempts, not post-only fallback creation

## Prior Turing fixes retained

Fix commit: `610a7e55bc86b0a1339be86138c7ebf77d66b6b8` (`fix: make post orphan card recovery idempotent`).

When a worktree contains `card.json` + `state.json` plus a `post.json` entry in `pending` without `postMessageId`, reconcile finalizes the existing card once, then marks the ledger `fallback_visible` with that existing card id. A second boot does not call `start()` or create another fallback card.

Fix commit: `d68f5c37d4df981cee912286fb0be36ed1a257cc` (`fix: require visible post orphan fallback`).

Post-only non-terminal ledger entries without `postMessageId` are only candidates until a visible fallback card is actually created/finalized. If card creation/finalize fails, the ledger remains non-terminal and reconcile logs the failure instead of silently marking `fallback_visible`.

## Reconcile behavior

Covered crash/restart windows:

- fresh orphan card + terminal state: finalizes card and preserves rich fields
- stale state older than `card.json`: suppresses stale rich fields and finalizes an interruption failure
- `card.json` + `state.json` + old non-terminal post ledger without `postMessageId`: finalizes the existing card once, then marks the ledger `fallback_visible` with that existing card id; a second reconcile does not call `start()` or create another fallback card
- finalize succeeds but post-ledger mark fails, even with `retryCount` already at cap: keep `card.json`, leave ledger non-terminal, and retry existing-card association on the next boot
- post-only old `planned` / `pending` ledger without `postMessageId`: create/finalize visible fallback card, then mark `fallback_visible` with `fallbackCardMessageId`
- post-only old `failed` ledger without `postMessageId`: same visible fallback card requirement before `fallback_visible`
- fallback card creation/finalize failure: ledger stays non-terminal; no silent recovery claim
- old `pending` / `planned` post ledger with `postMessageId`: marks `sent`
- repeated dispatch for the same logical sent post: reuses the ledger message id and does not call the post client
- repeated dispatch for a non-terminal ledger orphan: returns a visible card fallback and does not call the post client

## Gates / non-goals

Still default-off and non-production-wired:

- `response_surface_prototype.enabled=false` by default
- `post_outbound_enabled=false` by default
- `allowed_mention_open_ids=[]` by default
- production `BridgeHandler` still passes `postOutboundAvailable=false` and no production post client
- no real Feishu post/at, no test cards, no Feishu E2E, no deploy/restart/current bridge touch, no member scope/roster changes

## Visibility / idempotency proof

- Post-only orphan test asserts `cardRenderer.start()` is called, the fake card handle is finalized, the ledger receives `fallbackCardMessageId`, and `fallback_visible` is written only after that visible artifact exists.
- Negative test asserts start failure leaves the ledger `pending` with no `fallbackCardMessageId`.
- Card+state regression test seeds `card.json` + `state.json` + pending `post.json` without `postMessageId`, runs reconcile twice, and asserts only the existing card finalizes once, `startCalls` stays empty, and the ledger is terminal after the first run with `fallbackCardMessageId` set to the existing card id.
- New mark-failure regression test seeds `retryCount=3`, makes finalize succeed and the ledger mark fail, then asserts `card.json` remains, ledger stays `pending`, no finalize-failure retry/delete path runs, and a second reconcile after mark recovery does not `start()` a new fallback card.

## Tests

- `pnpm vitest run src/bridge/reconcile.test.ts` => 23 passed
- `pnpm vitest run src/bridge/postFile.test.ts src/bridge/reconcile.test.ts src/bridge/surfaceDispatcher.test.ts` => 40 passed
- `pnpm vitest run src/bridge/postFile.test.ts src/bridge/surfaceDispatcher.test.ts src/bridge/reconcile.test.ts src/bridge/handler.test.ts src/bridge/surfaceController.test.ts` => 70 passed
- `pnpm typecheck` => passed
- `env -u LARKWAY_HOME pnpm test` => 47 files / 770 tests passed
- GitHub PR CI => 2x SUCCESS on head `97c8b4ebb7edc590e5a3fcb0fb91a4fb151c6b53`

## Safety scan

- `git diff --check` => clean
- diff-only scan for real Feishu/profile/internal identifiers and token env names => no added-line matches