### PR TITLE
feat: gate response surface post client wiring

### DIFF
--- a/src/bridge/handler.test.ts
+++ b/src/bridge/handler.test.ts
@@ -10,7 +10,9 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { mkdtemp, rm, mkdir, writeFile, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { readPostFile } from "./postFile.js";
+import { readPostFile, writePostFile } from "./postFile.js";
+import { buildPostContent } from "../lark/postContent.js";
+import { derivePostIdempotencyKey, digestPostContent } from "../lark/idempotency.js";
 import type { OutboundPostClient } from "../lark/outboundPostClient.js";
 
 // ---------------------------------------------------------------------------
@@ -263,6 +265,39 @@ function makePostClient(opts: { fail?: boolean } = {}) {
     },
   };
   return { client, calls };
+}
+
+async function seedPendingPostLedger(worktreePath: string, text: string): Promise<void> {
+  const content = buildPostContent({ text, mentions: [] });
+  const contentDigest = digestPostContent(content);
+  const idempotencyKey = derivePostIdempotencyKey({
+    botId: "frontend",
+    threadId: "om_msg",
+    triggerMessageId: "om_msg",
+    role: "primary",
+    logicalIndex: 0,
+    contentDigest,
+  });
+  await writePostFile(worktreePath, {
+    version: 1,
+    posts: [
+      {
+        idempotencyKey,
+        status: "pending",
+        botId: "frontend",
+        chatId: "chat_allowed",
+        threadId: "om_msg",
+        replyToMessageId: "om_msg",
+        role: "primary",
+        logicalIndex: 0,
+        contentDigest,
+        mentionCount: 0,
+        attempts: [],
+        createdAt: "2026-06-26T10:00:00.000Z",
+        updatedAt: "2026-06-26T10:00:00.000Z",
+      },
+    ],
+  });
 }
 
 function makeEvent(): Record<string, unknown> {
@@ -778,6 +813,85 @@ describe("handleOne — thin-channel finalize", () => {
     expect(ledger?.posts[0]?.status).toBe("fallback_visible");
     expect(ledger?.posts[0]?.fallbackCardMessageId).toBe("om_card");
     expect(ledger?.posts[0]?.attempts[0]?.status).toBe("failed");
+  });
+
+  it("late-starts a visible fallback card before marking an existing pending post ledger fallback_visible", async () => {
+    const threadId = "om_msg";
+    const finalState = {
+      status: "ready",
+      last_message: "existing ledger 必须等可见卡后再终态",
+      response_surface: {
+        mode: "post",
+        primary: "post",
+      },
+      updated_at: "2026-06-26T10:00:00.000Z",
+    };
+    const wt = await seedWorktree(threadId);
+    await seedPendingPostLedger(wt, finalState.last_message);
+    await seedRepoCachePath();
+    const { client: postClient, calls } = makePostClient();
+
+    runClaudeImpl = () => ({
+      events: (async function* () {
+        yield { type: "system_init", sessionId: "sess_surface_existing_pending", raw: {} };
+        await writeFile(
+          stateFileMod.stateFilePathOf(wt),
+          JSON.stringify(finalState, null, 2),
+          "utf8",
+        );
+      })(),
+      done: Promise.resolve({ exitCode: 0, sessionId: "sess_surface_existing_pending" }),
+      kill: () => {},
+    });
+
+    const { renderer, startArgs, finalizeArgs, whenFinalized } = makeCardRenderer();
+    const { store } = makeSessionStore();
+    const { client } = makeClient(makeEvent());
+
+    const handler = new BridgeHandler({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      client: client as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      cardRenderer: renderer as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      sessionStore: store as any,
+      conventions: makeConventions(),
+      botConfig: {
+        id: "frontend",
+        name: "Frontend",
+        turn_taking_limit: 10,
+        backend: "claude",
+        response_surface_prototype: {
+          enabled: true,
+          allowed_chats: [],
+          allowed_threads: ["om_msg"],
+          lazy_card_creation: true,
+          post_outbound_enabled: true,
+          allowed_mention_open_ids: [],
+          max_posts_per_turn: 1,
+          max_post_attempts: 3,
+          text_threshold_chars: 900,
+        },
+      },
+      postClient,
+    });
+
+    await handler.run();
+    await whenFinalized;
+
+    expect(startArgs).toHaveLength(1);
+    expect(finalizeArgs).toHaveLength(1);
+    expect(finalizeArgs[0]?.success).toBe(false);
+    expect(finalizeArgs[0]?.failureReason).toContain("visible card fallback used");
+    expect(calls).toHaveLength(0);
+    let ledger = await readPostFile(wt);
+    for (let i = 0; i < 100 && ledger?.posts[0]?.status !== "fallback_visible"; i++) {
+      await new Promise((r) => setTimeout(r, 10));
+      ledger = await readPostFile(wt);
+    }
+    expect(ledger?.posts[0]?.status).toBe("fallback_visible");
+    expect(ledger?.posts[0]?.fallbackCardMessageId).toBe("om_card");
+    expect(ledger?.posts[0]?.attempts[0]?.code).toBe("orphan_reconcile");
   });
 
   it("late-stage state.json WITHOUT dev_url is NOT probed and NOT demoted (status=ready → success)", async () => {

--- a/src/bridge/handler.test.ts
+++ b/src/bridge/handler.test.ts
@@ -10,6 +10,8 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { mkdtemp, rm, mkdir, writeFile, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { readPostFile } from "./postFile.js";
+import type { OutboundPostClient } from "../lark/outboundPostClient.js";
 
 // ---------------------------------------------------------------------------
 // handler.ts calls createRunner("claude").run(...) from agent/runner.
@@ -241,6 +243,28 @@ function makeClient(event: Record<string, unknown>) {
   return { client, acked, unhandled, reactionCalls };
 }
 
+function makePostClient(opts: { fail?: boolean } = {}) {
+  const calls: Array<{
+    replyToMessageId: string;
+    content: string;
+    idempotencyKey: string;
+    replyInThread: boolean;
+  }> = [];
+  const client: OutboundPostClient = {
+    async createPostReply(replyToMessageId, content, callOpts) {
+      calls.push({
+        replyToMessageId,
+        content,
+        idempotencyKey: callOpts.idempotencyKey,
+        replyInThread: callOpts.replyInThread,
+      });
+      if (opts.fail) throw new Error("fake post failed");
+      return { messageId: "om_post" };
+    },
+  };
+  return { client, calls };
+}
+
 function makeEvent(): Record<string, unknown> {
   return {
     message_id: "om_msg",
@@ -456,8 +480,8 @@ describe("handleOne — thin-channel finalize", () => {
         backend: "claude",
         response_surface_prototype: {
           enabled: true,
-          allowed_chats: ["oc_chat"],
-          allowed_threads: [],
+          allowed_chats: [],
+          allowed_threads: ["om_msg"],
           lazy_card_creation: true,
           post_outbound_enabled: true,
           allowed_mention_open_ids: [],
@@ -527,8 +551,8 @@ describe("handleOne — thin-channel finalize", () => {
         backend: "claude",
         response_surface_prototype: {
           enabled: true,
-          allowed_chats: ["oc_chat"],
-          allowed_threads: [],
+          allowed_chats: [],
+          allowed_threads: ["om_msg"],
           lazy_card_creation: true,
           post_outbound_enabled: true,
           allowed_mention_open_ids: [],
@@ -546,6 +570,214 @@ describe("handleOne — thin-channel finalize", () => {
     expect(finalizeArgs).toHaveLength(1);
     expect(finalizeArgs[0]?.success).toBe(true);
     expect(finalizeArgs[0]?.finalText).toBe("post 声明下的正文仍必须可见");
+  });
+
+  it("keeps production-default config on visible card fallback even when a post client dependency exists", async () => {
+    const threadId = "om_msg";
+    const finalState = {
+      status: "ready",
+      last_message: "默认配置仍走卡片",
+      response_surface: {
+        mode: "post",
+        primary: "post",
+      },
+      updated_at: "2026-06-26T10:00:00.000Z",
+    };
+    const wt = await seedWorktree(threadId);
+    await seedRepoCachePath();
+    const { client: postClient, calls } = makePostClient();
+
+    runClaudeImpl = () => ({
+      events: (async function* () {
+        yield { type: "system_init", sessionId: "sess_surface_default_off", raw: {} };
+        await writeFile(
+          stateFileMod.stateFilePathOf(wt),
+          JSON.stringify(finalState, null, 2),
+          "utf8",
+        );
+      })(),
+      done: Promise.resolve({ exitCode: 0, sessionId: "sess_surface_default_off" }),
+      kill: () => {},
+    });
+
+    const { renderer, startArgs, finalizeArgs, whenFinalized } = makeCardRenderer();
+    const { store } = makeSessionStore();
+    const { client } = makeClient(makeEvent());
+
+    const handler = new BridgeHandler({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      client: client as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      cardRenderer: renderer as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      sessionStore: store as any,
+      conventions: makeConventions(),
+      botConfig: { id: "frontend", name: "Frontend", turn_taking_limit: 10, backend: "claude" },
+      postClient,
+    });
+
+    await handler.run();
+    await whenFinalized;
+
+    expect(startArgs).toHaveLength(1);
+    expect(finalizeArgs).toHaveLength(1);
+    expect(finalizeArgs[0]?.success).toBe(true);
+    expect(finalizeArgs[0]?.finalText).toBe("默认配置仍走卡片");
+    expect(calls).toHaveLength(0);
+  });
+
+  it("uses an injected post client for allowlisted post-only turns without starting a card", async () => {
+    const threadId = "om_msg";
+    const finalState = {
+      status: "ready",
+      last_message: "隔离配置走 post-only",
+      response_surface: {
+        mode: "post",
+        primary: "post",
+      },
+      updated_at: "2026-06-26T10:00:00.000Z",
+    };
+    const wt = await seedWorktree(threadId);
+    await seedRepoCachePath();
+    const { client: postClient, calls } = makePostClient();
+
+    runClaudeImpl = () => ({
+      events: (async function* () {
+        yield { type: "system_init", sessionId: "sess_surface_post_enabled", raw: {} };
+        await writeFile(
+          stateFileMod.stateFilePathOf(wt),
+          JSON.stringify(finalState, null, 2),
+          "utf8",
+        );
+      })(),
+      done: Promise.resolve({ exitCode: 0, sessionId: "sess_surface_post_enabled" }),
+      kill: () => {},
+    });
+
+    const { renderer, startArgs, finalizeArgs } = makeCardRenderer();
+    const { store } = makeSessionStore();
+    const { client, acked } = makeClient(makeEvent());
+
+    const handler = new BridgeHandler({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      client: client as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      cardRenderer: renderer as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      sessionStore: store as any,
+      conventions: makeConventions(),
+      botConfig: {
+        id: "frontend",
+        name: "Frontend",
+        turn_taking_limit: 10,
+        backend: "claude",
+        response_surface_prototype: {
+          enabled: true,
+          allowed_chats: [],
+          allowed_threads: ["om_msg"],
+          lazy_card_creation: true,
+          post_outbound_enabled: true,
+          allowed_mention_open_ids: [],
+          max_posts_per_turn: 1,
+          max_post_attempts: 3,
+          text_threshold_chars: 900,
+        },
+      },
+      postClient,
+    });
+
+    await handler.run();
+    for (let i = 0; i < 100 && acked.length === 0; i++) {
+      await new Promise((r) => setTimeout(r, 10));
+    }
+
+    expect(acked).toEqual(["om_msg"]);
+    expect(startArgs).toHaveLength(0);
+    expect(finalizeArgs).toHaveLength(0);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.replyToMessageId).toBe("om_msg");
+    expect(calls[0]?.content).toContain("隔离配置走 post-only");
+    const ledger = await readPostFile(wt);
+    expect(ledger?.posts[0]?.status).toBe("sent");
+    expect(ledger?.posts[0]?.postMessageId).toBe("om_post");
+  });
+
+  it("late-starts a visible fallback card before marking a failed post ledger fallback_visible", async () => {
+    const threadId = "om_msg";
+    const finalState = {
+      status: "ready",
+      last_message: "post 失败必须有可见 fallback",
+      response_surface: {
+        mode: "post",
+        primary: "post",
+      },
+      updated_at: "2026-06-26T10:00:00.000Z",
+    };
+    const wt = await seedWorktree(threadId);
+    await seedRepoCachePath();
+    const { client: postClient, calls } = makePostClient({ fail: true });
+
+    runClaudeImpl = () => ({
+      events: (async function* () {
+        yield { type: "system_init", sessionId: "sess_surface_post_failed", raw: {} };
+        await writeFile(
+          stateFileMod.stateFilePathOf(wt),
+          JSON.stringify(finalState, null, 2),
+          "utf8",
+        );
+      })(),
+      done: Promise.resolve({ exitCode: 0, sessionId: "sess_surface_post_failed" }),
+      kill: () => {},
+    });
+
+    const { renderer, startArgs, finalizeArgs, whenFinalized } = makeCardRenderer();
+    const { store } = makeSessionStore();
+    const { client } = makeClient(makeEvent());
+
+    const handler = new BridgeHandler({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      client: client as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      cardRenderer: renderer as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      sessionStore: store as any,
+      conventions: makeConventions(),
+      botConfig: {
+        id: "frontend",
+        name: "Frontend",
+        turn_taking_limit: 10,
+        backend: "claude",
+        response_surface_prototype: {
+          enabled: true,
+          allowed_chats: [],
+          allowed_threads: ["om_msg"],
+          lazy_card_creation: true,
+          post_outbound_enabled: true,
+          allowed_mention_open_ids: [],
+          max_posts_per_turn: 1,
+          max_post_attempts: 3,
+          text_threshold_chars: 900,
+        },
+      },
+      postClient,
+    });
+
+    await handler.run();
+    await whenFinalized;
+
+    expect(startArgs).toHaveLength(1);
+    expect(finalizeArgs).toHaveLength(1);
+    expect(finalizeArgs[0]?.success).toBe(false);
+    expect(finalizeArgs[0]?.failureReason).toContain("visible card fallback used");
+    expect(calls).toHaveLength(1);
+    let ledger = await readPostFile(wt);
+    for (let i = 0; i < 100 && ledger?.posts[0]?.status !== "fallback_visible"; i++) {
+      await new Promise((r) => setTimeout(r, 10));
+      ledger = await readPostFile(wt);
+    }
+    expect(ledger?.posts[0]?.status).toBe("fallback_visible");
+    expect(ledger?.posts[0]?.fallbackCardMessageId).toBe("om_card");
+    expect(ledger?.posts[0]?.attempts[0]?.status).toBe("failed");
   });
 
   it("late-stage state.json WITHOUT dev_url is NOT probed and NOT demoted (status=ready → success)", async () => {

--- a/src/bridge/handler.ts
+++ b/src/bridge/handler.ts
@@ -37,7 +37,12 @@ import { SurfaceController } from "./surfaceController.js";
 import { dispatchResponseSurface } from "./surfaceDispatcher.js";
 import type { RuntimeEventPatch } from "./eventLog.js";
 import type { RuntimeRequirement } from "../runtimeRequirements.js";
-import type { ResponseSurfacePrototypeConfig } from "../responseSurface.js";
+import {
+  isResponseSurfacePostOutboundAvailable,
+  type ResponseSurfacePrototypeConfig,
+} from "../responseSurface.js";
+import type { OutboundPostClient } from "../lark/outboundPostClient.js";
+import { markPostLedgerFallbackVisible } from "./postFile.js";
 
 // ---------------------------------------------------------------------------
 // Private helpers — worktree bootstrap
@@ -463,6 +468,13 @@ export interface BridgeHandlerDeps {
     response_surface_prototype?: ResponseSurfacePrototypeConfig;
   };
   /**
+   * Optional outbound post transport. main.ts only injects this when the bot's
+   * config explicitly enables the response-surface post gate behind an allowlist.
+   * Each turn still re-checks chat/thread allowlists before considering it
+   * available.
+   */
+  postClient?: OutboundPostClient;
+  /**
    * V2: L2 Agent Memory content (职能定义) — loaded from the bot's memory_file by
    * botLoader. Injected into the prompt as a `<agent-memory>` role preamble.
    * When absent (V1 or no memory_file), no memory block is rendered.
@@ -650,13 +662,17 @@ export class BridgeHandler {
     // anchored on the user's message. Thread-replies pass false.
     const isTopLevel = !(typeof parsed.raw.root_id === "string" && parsed.raw.root_id);
     const replyInThread = isTopLevel;
+    const prototypeConfig = this.deps.botConfig?.response_surface_prototype;
+    const postOutboundAvailable = isResponseSurfacePostOutboundAvailable(
+      prototypeConfig,
+      { chatId: parsed.chatId, threadId },
+      { postClientAvailable: !!this.deps.postClient },
+    );
     const surfaceController = SurfaceController.create({
-      prototypeConfig: this.deps.botConfig?.response_surface_prototype,
+      prototypeConfig,
       chatId: parsed.chatId,
       threadId,
-      // PR3 owns real post outbound + ledger + visible post failure fallback.
-      // Until then every runtime path keeps the legacy visible card fallback.
-      postOutboundAvailable: false,
+      postOutboundAvailable,
       postLedgerAvailable: true,
       visibleFallbackAvailable: true,
     });
@@ -1096,90 +1112,131 @@ export class BridgeHandler {
           //
           // Card body text = bot's `last_message` (preferred, productized),
           // falling back to streamed text only when bot didn't write one.
-          if (card) {
-            const reportedStatus = reportedState?.status;
-            const reportedError = reportedState?.error;
-            let success: boolean;
-            let failureReason: string | undefined;
+          const reportedStatus = reportedState?.status;
+          const reportedError = reportedState?.error;
+          let success: boolean;
+          let failureReason: string | undefined;
 
-            if (reportedStatus === "failed") {
-              success = false;
-              failureReason = reportedError ?? "bot 报告 failed (无 error 字段)";
-            } else if (reportedStatus === "ready") {
-              success = true;
-            } else if (result.exitCode === 0) {
-              success = true;
-            } else {
-              success = false;
-              failureReason = `claude exited ${result.exitCode} 且 bot 未更新 state.json status — 可能崩溃`;
+          if (reportedStatus === "failed") {
+            success = false;
+            failureReason = reportedError ?? "bot 报告 failed (无 error 字段)";
+          } else if (reportedStatus === "ready") {
+            success = true;
+          } else if (result.exitCode === 0) {
+            success = true;
+          } else {
+            success = false;
+            failureReason = `claude exited ${result.exitCode} 且 bot 未更新 state.json status — 可能崩溃`;
+          }
+
+          // reportedState is null when the bot didn't rewrite state.json this
+          // turn (stale-guard above), so this falls back to the agent's fresh
+          // streamed text instead of repeating the previous reply. If there's
+          // also no fresh text (e.g. run was interrupted before any output),
+          // show an honest prompt to retry rather than a blank/stale card.
+          const cardBody =
+            reportedState?.last_message ??
+            (lastText.trim()
+              ? lastText
+              : "⚠️ 本轮没有拿到 agent 的新回复(可能被中断或未更新状态),再 @ 我一次重试。");
+
+          // When the agent didn't report status this turn (reportedState null,
+          // per stale-guard) but exited cleanly, don't let the card default to
+          // "✅ 完成" — the agent just produced text without a status, claiming
+          // success is misleading. Show a neutral title/color; the fresh body
+          // text tells the real story. (On a real failure we keep failure style.)
+          const noReportThisTurn = reportedState === null;
+          const neutralTitle =
+            noReportThisTurn && success && !failureReason
+              ? "💬 已回复"
+              : undefined;
+
+          const baseCardPayload = {
+            finalText: cardBody,
+            success,
+            failureReason,
+            titleOverride: reportedState?.card_title ?? neutralTitle,
+            colorOverride:
+              reportedState?.card_color ?? (neutralTitle ? "neutral" : undefined),
+            // V2 dynamic-choice buttons — agent-declared, rendered verbatim.
+            // reportedState is null when state.json wasn't freshly written
+            // (stale-guard), so stale leftover choices never reappear.
+            choices: reportedState?.choices,
+            choicePrompt: reportedState?.choice_prompt,
+            imageBlocks: reportedState?.image_blocks,
+            contentBlocks: reportedState?.content_blocks,
+          };
+          const surfaceDispatch = await dispatchResponseSurface({
+            state: reportedState,
+            prototypeConfig,
+            facts: {
+              botId: this.deps.botConfig?.id ?? "v1-default",
+              chatId: parsed.chatId,
+              threadId,
+              triggerMessageId: messageId,
+              replyToMessageId: messageId,
+              replyInThread,
+            },
+            worktreePath,
+            baseCard: baseCardPayload,
+            cardStarted: !!card,
+            postOutboundAvailable,
+            postLedgerAvailable: true,
+            visibleFallbackAvailable: true,
+            postClient: this.deps.postClient,
+          });
+
+          if (surfaceDispatch.card) {
+            if (!card) {
+              card = await this.deps.cardRenderer.start(messageId, { replyInThread, threadId });
+              try {
+                await writeCardFile(worktreePath, {
+                  messageId: card.messageId,
+                  chatId: parsed.chatId,
+                  threadId,
+                  botId: this.deps.botConfig?.id ?? "",
+                  replyInThread,
+                  createdAt: new Date().toISOString(),
+                });
+              } catch (err) {
+                console.warn("[bridge.handler] writeCardFile(late) failed (continuing):", err);
+              }
             }
 
-            // reportedState is null when the bot didn't rewrite state.json this
-            // turn (stale-guard above), so this falls back to the agent's fresh
-            // streamed text instead of repeating the previous reply. If there's
-            // also no fresh text (e.g. run was interrupted before any output),
-            // show an honest prompt to retry rather than a blank/stale card.
-            const cardBody =
-              reportedState?.last_message ??
-              (lastText.trim()
-                ? lastText
-                : "⚠️ 本轮没有拿到 agent 的新回复(可能被中断或未更新状态),再 @ 我一次重试。");
+            await card.finalize(surfaceDispatch.card);
 
-            // When the agent didn't report status this turn (reportedState null,
-            // per stale-guard) but exited cleanly, don't let the card default to
-            // "✅ 完成" — the agent just produced text without a status, claiming
-            // success is misleading. Show a neutral title/color; the fresh body
-            // text tells the real story. (On a real failure we keep failure style.)
-            const noReportThisTurn = reportedState === null;
-            const neutralTitle =
-              noReportThisTurn && success && !failureReason
-                ? "💬 已回复"
-                : undefined;
-
-            const baseCardPayload = {
-              finalText: cardBody,
-              success,
-              failureReason,
-              titleOverride: reportedState?.card_title ?? neutralTitle,
-              colorOverride:
-                reportedState?.card_color ?? (neutralTitle ? "neutral" : undefined),
-              // V2 dynamic-choice buttons — agent-declared, rendered verbatim.
-              // reportedState is null when state.json wasn't freshly written
-              // (stale-guard), so stale leftover choices never reappear.
-              choices: reportedState?.choices,
-              choicePrompt: reportedState?.choice_prompt,
-              imageBlocks: reportedState?.image_blocks,
-              contentBlocks: reportedState?.content_blocks,
-            };
-            const surfaceDispatch = await dispatchResponseSurface({
-              state: reportedState,
-              prototypeConfig: this.deps.botConfig?.response_surface_prototype,
-              facts: {
-                botId: this.deps.botConfig?.id ?? "v1-default",
-                chatId: parsed.chatId,
-                threadId,
-                triggerMessageId: messageId,
-                replyToMessageId: messageId,
-                replyInThread,
-              },
-              worktreePath,
-              baseCard: baseCardPayload,
-              cardStarted: true,
-              // PR4 wires the dispatcher but keeps production post outbound
-              // unavailable. Real post transport remains behind a later,
-              // separately-authorized PR and explicit bot config gates.
-              postOutboundAvailable: false,
-              postLedgerAvailable: true,
-              visibleFallbackAvailable: true,
-            });
-            if (surfaceDispatch.card) {
-              await card.finalize(surfaceDispatch.card);
+            let keepCardFileForRetry = false;
+            if (
+              surfaceDispatch.reason === "post-failed-fallback-card" &&
+              surfaceDispatch.post?.idempotencyKey
+            ) {
+              try {
+                await markPostLedgerFallbackVisible(
+                  worktreePath,
+                  surfaceDispatch.post.idempotencyKey,
+                  {
+                    fallbackCardMessageId: card.messageId,
+                    error:
+                      surfaceDispatch.card.failureReason ??
+                      "post outbound failed; visible card fallback used",
+                  },
+                );
+              } catch (err) {
+                keepCardFileForRetry = true;
+                console.warn(
+                  "[bridge.handler] post fallback ledger mark failed after visible card finalize; keeping card.json for retry:",
+                  err,
+                );
+              }
             }
 
             // Card was finalized successfully — drop its card.json so boot
-            // reconcile doesn't re-finalize an already-finalized card.
-            // Best-effort (deleteCardFile never throws).
-            await deleteCardFile(worktreePath);
+            // reconcile doesn't re-finalize an already-finalized card. If the
+            // post fallback ledger mark failed, keep card.json so boot reconcile
+            // can retry association with the existing visible card.
+            if (!keepCardFileForRetry) {
+              await deleteCardFile(worktreePath);
+            }
           }
 
           // Terminal SUCCESS: promote the message out of in-flight into the

--- a/src/bridge/handler.ts
+++ b/src/bridge/handler.ts
@@ -1206,10 +1206,7 @@ export class BridgeHandler {
             await card.finalize(surfaceDispatch.card);
 
             let keepCardFileForRetry = false;
-            if (
-              surfaceDispatch.reason === "post-failed-fallback-card" &&
-              surfaceDispatch.post?.idempotencyKey
-            ) {
+            if (surfaceDispatch.post?.requiresFallbackLedgerMark) {
               try {
                 await markPostLedgerFallbackVisible(
                   worktreePath,
@@ -1217,6 +1214,7 @@ export class BridgeHandler {
                   {
                     fallbackCardMessageId: card.messageId,
                     error:
+                      surfaceDispatch.post.fallbackError ??
                       surfaceDispatch.card.failureReason ??
                       "post outbound failed; visible card fallback used",
                   },
@@ -1224,7 +1222,7 @@ export class BridgeHandler {
               } catch (err) {
                 keepCardFileForRetry = true;
                 console.warn(
-                  "[bridge.handler] post fallback ledger mark failed after visible card finalize; keeping card.json for retry:",
+                  "[bridge.handler] fallback ledger mark failed after visible card finalize; keeping card.json for retry:",
                   err,
                 );
               }

--- a/src/bridge/surfaceDispatcher.test.ts
+++ b/src/bridge/surfaceDispatcher.test.ts
@@ -264,7 +264,7 @@ describe("dispatchResponseSurface", () => {
     expect(calls).toHaveLength(0);
   });
 
-  it("falls back to a visible failure card and ledger status when post send fails", async () =>
+  it("returns a visible failure card and leaves ledger failed until the card is finalized", async () =>
     withTemp(async (dir) => {
       const { client } = fakePostClient({ fail: true });
       const result = await dispatchResponseSurface(
@@ -282,7 +282,7 @@ describe("dispatchResponseSurface", () => {
 
       const ledger = await readPostFile(dir);
       expect(ledger?.posts).toHaveLength(1);
-      expect(ledger?.posts[0]?.status).toBe("fallback_visible");
+      expect(ledger?.posts[0]?.status).toBe("failed");
       expect(ledger?.posts[0]?.attempts[0]?.status).toBe("failed");
     }));
 

--- a/src/bridge/surfaceDispatcher.test.ts
+++ b/src/bridge/surfaceDispatcher.test.ts
@@ -174,7 +174,7 @@ describe("dispatchResponseSurface", () => {
       expect(second.calls).toHaveLength(0);
     }));
 
-  it("reconciles an existing pending ledger entry to visible fallback without resending", async () =>
+  it("returns visible fallback for an existing pending ledger without marking it before card finalize", async () =>
     withTemp(async (dir) => {
       const first = fakePostClient();
       await dispatchResponseSurface(
@@ -214,8 +214,9 @@ describe("dispatchResponseSurface", () => {
       expect(second.calls).toHaveLength(0);
 
       const after = await readPostFile(dir);
-      expect(after?.posts[0]?.status).toBe("fallback_visible");
-      expect(after?.posts[0]?.attempts[0]?.code).toBe("orphan_reconcile");
+      expect(after?.posts[0]?.status).toBe("pending");
+      expect(after?.posts[0]?.fallbackCardMessageId).toBeUndefined();
+      expect(after?.posts[0]?.attempts).toEqual([]);
     }));
 
   it("uses a compact secondary card for hybrid without repeating the main post body", async () =>

--- a/src/bridge/surfaceDispatcher.ts
+++ b/src/bridge/surfaceDispatcher.ts
@@ -72,6 +72,8 @@ export interface SurfaceDispatchResult {
     idempotencyKey: string;
     messageId?: string;
     role: PostSurfaceRole;
+    requiresFallbackLedgerMark?: boolean;
+    fallbackError?: string;
   };
 }
 
@@ -348,32 +350,20 @@ export async function dispatchResponseSurface(
     };
   }
   if (existing) {
-    const reconciledAt = input.now?.() ?? new Date().toISOString();
     const error =
       existing.status === "failed" && existing.error
         ? existing.error
         : "orphaned post ledger entry reconciled without resend; visible card fallback used";
-    await writeLedger(input, {
-      ...existing,
-      status: "fallback_visible",
-      error,
-      updatedAt: reconciledAt,
-      attempts: [
-        ...existing.attempts,
-        {
-          attemptedAt: reconciledAt,
-          status: "failed",
-          retryable: false,
-          code: "orphan_reconcile",
-          error,
-        },
-      ],
-    });
     return {
       card: fallbackFailureCard(input, error),
       reason: "post-orphan-reconciled-fallback-card",
       visible: true,
-      post: { idempotencyKey, role },
+      post: {
+        idempotencyKey,
+        role,
+        requiresFallbackLedgerMark: true,
+        fallbackError: error,
+      },
     };
   }
 
@@ -462,7 +452,12 @@ export async function dispatchResponseSurface(
       card: fallbackFailureCard(input, err),
       reason: "post-failed-fallback-card",
       visible: true,
-      post: { idempotencyKey, role },
+      post: {
+        idempotencyKey,
+        role,
+        requiresFallbackLedgerMark: true,
+        fallbackError: error,
+      },
     };
   }
 }

--- a/src/bridge/surfaceDispatcher.ts
+++ b/src/bridge/surfaceDispatcher.ts
@@ -458,28 +458,6 @@ export async function dispatchResponseSurface(
         ],
       }),
     );
-    await writeLedger(
-      input,
-      newLedgerEntry({
-        status: "fallback_visible",
-        idempotencyKey,
-        now: input.now?.() ?? new Date().toISOString(),
-        facts: input.facts,
-        role,
-        logicalIndex,
-        contentDigest,
-        mentionCount: mentions.length,
-        error,
-        attempts: [
-          {
-            attemptedAt: failedAt,
-            status: "failed",
-            retryable: false,
-            error,
-          },
-        ],
-      }),
-    );
     return {
       card: fallbackFailureCard(input, err),
       reason: "post-failed-fallback-card",

--- a/src/lark/channelClient.ts
+++ b/src/lark/channelClient.ts
@@ -30,7 +30,9 @@ import { promisify } from "node:util";
 import type { LarkMessageEvent, LarkClientOptions } from "./transport.js";
 import { AsyncQueue } from "./transport.js";
 import { ChannelCardClient, type OutboundLarkChannel } from "./channelCardClient.js";
+import { ChannelPostClient } from "./channelPostClient.js";
 import type { OutboundCardClient } from "./outboundCardClient.js";
+import type { OutboundPostClient } from "./outboundPostClient.js";
 
 const execFile = promisify(execFileCallback);
 const LEARNED_CHATS_LIMIT = 100;
@@ -478,6 +480,8 @@ export class ChannelClient {
   private readonly cardThreads = new Map<string, string>();
   /** Lazily built (after connect) so it can bind the live channel handle. */
   private cardClient: ChannelCardClient | null = null;
+  /** Lazily built and only requested by main.ts when post outbound gates are configured. */
+  private postClient: ChannelPostClient | null = null;
 
   constructor(opts: LarkClientOptions) {
     if (!opts.appId || !opts.appSecret) {
@@ -707,6 +711,23 @@ export class ChannelClient {
       });
     }
     return this.cardClient;
+  }
+
+  /**
+   * Return an OutboundPostClient bound to this client's channel handle.
+   *
+   * main.ts only calls this when the per-bot response-surface config explicitly
+   * enables post outbound behind an allowlist. The returned client still resolves
+   * the live channel lazily at send time, so default production bots never create
+   * or inject a real post client.
+   */
+  outboundPostClient(): OutboundPostClient {
+    if (!this.postClient) {
+      this.postClient = new ChannelPostClient({
+        resolveChannel: () => this.channel,
+      });
+    }
+    return this.postClient;
   }
 
   /**

--- a/src/main.ts
+++ b/src/main.ts
@@ -32,6 +32,7 @@ import { ensureLarkCliProfile, deriveLarkCliProfile } from "./lark/profileBootst
 import { checkWorkspacePermissionGrant } from "./agent/permissionGate.js";
 import { runtimeRequirementsForBots } from "./runtimeRequirements.js";
 import { registerCrashGuard } from "./crashGuard.js";
+import { shouldProvideResponseSurfacePostClient } from "./responseSurface.js";
 
 /** How often the bridge rewrites each bot's status.json liveness heartbeat. */
 const STATUS_WRITE_INTERVAL_MS = 30_000;
@@ -330,6 +331,10 @@ async function runV2Mode({
       return [{ id: peer.bot_open_id, name: peer.name, description: peer.description ?? "" }];
     });
 
+    const postClient = shouldProvideResponseSurfacePostClient(bot.response_surface_prototype)
+      ? client.outboundPostClient()
+      : undefined;
+
     const handler = new BridgeHandler({
       client,
       cardRenderer,
@@ -352,6 +357,7 @@ async function runV2Mode({
         gitlab_token_env: bot.gitlab_token_env,
         response_surface_prototype: bot.response_surface_prototype,
       },
+      postClient,
       gitlabToken: effectiveGitlabToken,
       agentMemory: bot.agent_memory,
       larkCliProfile,

--- a/src/responseSurface.ts
+++ b/src/responseSurface.ts
@@ -151,3 +151,26 @@ export function isResponseSurfacePrototypeAllowlisted(
     config.allowed_threads.length > 0 && config.allowed_threads.includes(facts.threadId);
   return chatAllowed || threadAllowed;
 }
+
+export function shouldProvideResponseSurfacePostClient(
+  config: ResponseSurfacePrototypeConfig | undefined,
+): boolean {
+  return !!(
+    config?.enabled &&
+    config.post_outbound_enabled &&
+    config.max_posts_per_turn >= 1 &&
+    (config.allowed_chats.length > 0 || config.allowed_threads.length > 0)
+  );
+}
+
+export function isResponseSurfacePostOutboundAvailable(
+  config: ResponseSurfacePrototypeConfig | undefined,
+  facts: { chatId: string; threadId: string },
+  opts: { postClientAvailable: boolean },
+): boolean {
+  return !!(
+    opts.postClientAvailable &&
+    shouldProvideResponseSurfacePostClient(config) &&
+    isResponseSurfacePrototypeAllowlisted(config, facts)
+  );
+}


### PR DESCRIPTION
## Summary

PR6a adds gated runtime wiring for response-surface post outbound while keeping production defaults off.

- Adds config helpers so a post client is only provided when the response-surface prototype is enabled, post outbound is enabled, max posts is non-zero, and a chat/thread allowlist exists.
- Adds a lazy `ChannelClient.outboundPostClient()` wrapper around the existing `ChannelPostClient`.
- Injects the post client into `BridgeHandler` only when those config gates warrant it.
- Computes `postOutboundAvailable` per turn using the current chat/thread allowlist plus the presence of an injected post client.
- Moves final surface dispatch out of the early-card-only branch so lazy post-only turns can send through the post path, and fallback/hybrid turns can late-start a visible card when needed.
- Defers all fallback ledger `fallback_visible` marking until after the fallback card has been finalized, preserving the visible-reply invariant for both new post failures and existing non-terminal post ledger re-entry.

## Default-off proof

- Default bot config still has `response_surface_prototype.enabled=false`, `post_outbound_enabled=false`, empty allowlists, and empty mention allowlist.
- `main.ts` does not create/inject a real post client unless the config gates are explicitly enabled and allowlisted.
- `BridgeHandler` still falls back to visible card when config is default/off or the current chat/thread is not allowlisted.

## Regression coverage

- Default production config with an injected fake dependency still finalizes a visible card and never calls the post client.
- Allowlisted isolated config uses a fake post client for post-only and writes a `sent` ledger.
- New post send failure finalizes a visible fallback card before marking `fallback_visible` with the fallback card message id.
- Existing pending post ledger re-entry returns a fallback card without marking `fallback_visible` in `surfaceDispatcher`; this simulates the crash window before handler late-start/finalize.
- Handler late-starts/finalizes a fallback card for existing pending ledger re-entry, then marks `fallback_visible` with `fallbackCardMessageId`.

## Tests

- `pnpm vitest run src/bridge/handler.test.ts src/bridge/surfaceDispatcher.test.ts` => 2 files / 36 tests passed.
- `pnpm vitest run src/bridge/handler.test.ts src/bridge/surfaceDispatcher.test.ts src/lark/channelPostClient.test.ts src/lark/channelClient.test.ts` => 4 files / 85 tests passed.
- `pnpm typecheck` => passed.
- `env -u LARKWAY_HOME pnpm test` => 47 files / 774 tests passed.
- `git diff --check` => passed.
- Added-line scan for real Feishu/profile/internal identifiers and token env names => no matches.

## Boundaries

No real post/at, no test card, no prototype enablement, no deploy/restart/current bridge touch, no production config changes, no member scope/roster, no PR6 dogfood execution in this PR.
