### PR TITLE
feat: harden response surface rollout gates

### DIFF
--- a/docs/response-surface-production-rollout.md
+++ b/docs/response-surface-production-rollout.md
@@ -1,0 +1,140 @@
+# Response Surface Production Grey Rollout
+
+This runbook is for a future production grey release after explicit owner
+approval. It assumes the code is already deployed with response surface defaults
+still off.
+
+## Safety Invariants
+
+- Default config must stay off until the rollout step:
+  - `enabled: false`
+  - `post_outbound_enabled: false`
+  - `allowed_chats: []`
+  - `allowed_threads: []`
+  - `allowed_mention_open_ids: []`
+- Never start with a broad allowlist. Use one chat or one thread first.
+- Never use `@all`.
+- A turn must always produce a visible card or a visible post. If the post path
+  is unavailable, over budget, policy-blocked, or fails, the handler must fall
+  back to a visible card.
+- Real chat ids, open ids, app ids, and secrets belong only in private operator
+  config and private evidence, not in public docs, PRs, or logs copied to PRs.
+
+## Preflight
+
+1. Confirm the target release commit and installed package version.
+2. Confirm no production bot config has response surface enabled:
+   ```yaml
+   response_surface_prototype:
+     enabled: false
+     kill_switch: false
+     post_outbound_enabled: false
+     allowed_chats: []
+     allowed_threads: []
+     allowed_mention_open_ids: []
+   ```
+3. Confirm the production bridge has no response-surface error spike in recent
+   logs.
+4. Prepare a private rollout config with:
+   - one test or grey chat in `allowed_chats`, or one topic in
+     `allowed_threads`;
+   - `allowed_mention_open_ids` containing only confirmed members;
+   - `max_posts_per_turn: 1`;
+   - a conservative `max_posts_per_window` and `post_window_ms`;
+   - `kill_switch: false` only for the grey window.
+5. Prepare rollback config before changing anything:
+   ```yaml
+   response_surface_prototype:
+     enabled: false
+     kill_switch: true
+     post_outbound_enabled: false
+     allowed_chats: []
+     allowed_threads: []
+     allowed_mention_open_ids: []
+   ```
+
+## Enable Order
+
+Use the smallest possible grey scope.
+
+1. Set allowlists first while `enabled: false`.
+2. Set budget fields:
+   - `max_posts_per_turn: 1`
+   - `max_posts_per_window: <small integer>`
+   - `post_window_ms: <window in ms>`
+3. Set `post_outbound_enabled: true`.
+4. Set `enabled: true`.
+5. Confirm the runtime log shows the post client is provided only for the
+   allowlisted bot config.
+
+## Observability
+
+Watch structured bridge logs for:
+
+- `[response_surface.dispatch]` counts by `reason`.
+- `reason=post-sent`
+- `reason=hybrid-post-sent-compact-card`
+- `reason=post-failed-fallback-card`
+- `reason=post-rate-limit-exhausted`
+- `reason=mention-policy-blocked`
+- `reason=post-orphan-reconciled-fallback-card`
+
+For each grey turn, confirm:
+
+- `visible=true`
+- `hasCard=true` or `postMessageIdPresent=true`
+- no `fallback_visible` ledger entry lacks `fallbackCardMessageId`
+- ledger distribution has no stale `planned` or `pending` entries after the
+  recovery window unless a visible fallback retry is pending
+- budget `used <= limit`
+
+## Stop Conditions
+
+Immediately rollback if any of these occur:
+
+- any send targets a non-allowlisted chat or thread
+- any mention target is not in `allowed_mention_open_ids`
+- a turn has no visible card and no visible post
+- a ledger entry becomes `fallback_visible` without `fallbackCardMessageId`
+- duplicate recovery cards are created for the same orphan
+- `post-rate-limit-exhausted` does not fall back to a visible card
+- post failures spike above the operator's threshold
+- production bridge PID/cwd/exe does not match the intended process
+- a token, app secret, chat id, open id, or app id is about to be copied into a
+  public PR, issue, doc, or evidence file
+
+## Rollback
+
+Prefer config rollback over code rollback for response surface incidents.
+
+1. Apply the prepared rollback config:
+   ```yaml
+   response_surface_prototype:
+     enabled: false
+     kill_switch: true
+     post_outbound_enabled: false
+     allowed_chats: []
+     allowed_threads: []
+     allowed_mention_open_ids: []
+   ```
+2. Use the deployment system's normal config reload path. Do not run broad kill
+   commands. If a process stop is explicitly authorized, stop only the known PID.
+3. Confirm the next runtime decision is `prototype-disabled` or
+   `kill-switch-active`, and no new `post-sent` events appear.
+4. Keep watching reconcile logs until stale `planned`/`pending` entries either
+   become `sent` because a `postMessageId` exists, or become
+   `fallback_visible` only after a visible fallback card is finalized.
+
+## Post-Rollout Evidence
+
+Private evidence may include raw message ids. Public evidence must be sanitized.
+
+Record:
+
+- release commit/package version
+- private config snapshot hash before and after rollback
+- dispatch reason counts
+- post ledger status distribution
+- budget usage
+- rollback confirmation
+- any stop-condition trigger and its timestamp

--- a/docs/response-surface-prototype.md
+++ b/docs/response-surface-prototype.md
@@ -71,9 +71,12 @@ response_surface_prototype:
   allowed_threads:
     - <thread_id>
   lazy_card_creation: true
+  kill_switch: false
   post_outbound_enabled: false
   allowed_mention_open_ids: []
   max_posts_per_turn: 1
+  max_posts_per_window: 4
+  post_window_ms: 60000
   max_post_attempts: 3
   text_threshold_chars: 1200
 ```
@@ -84,9 +87,12 @@ Defaults:
 - `allowed_chats: []`
 - `allowed_threads: []`
 - `lazy_card_creation: false`
+- `kill_switch: false`
 - `post_outbound_enabled: false`
 - `allowed_mention_open_ids: []`
 - `max_posts_per_turn: 1`
+- `max_posts_per_window: 4`
+- `post_window_ms: 60000`
 - `max_post_attempts: 3`
 - `text_threshold_chars: 1200`
 
@@ -206,11 +212,35 @@ This is a conservative reconcile policy. It never queries or sends real Feishu
 post messages in PR5, never repeats an outbound post during recovery, and never
 marks `fallback_visible` unless a visible fallback artifact exists.
 
+## PR7 Production Hardening
+
+PR7 keeps the prototype default-off while making a future production grey
+release observable, bounded, and reversible.
+
+- `kill_switch: true` forces the runtime back to the legacy visible-card path
+  even if `enabled`, `post_outbound_enabled`, and allowlists are otherwise set.
+  This is the operator rollback switch when code rollback is too slow.
+- `max_posts_per_turn` remains a hard per-turn cap. The current dispatcher sends
+  at most one logical post per turn; setting this below `1` disables post
+  outbound and falls back to the visible card.
+- `max_posts_per_window` + `post_window_ms` add a runtime sliding-window cap per
+  bot/chat/thread in the bridge process. If the window is exhausted, the turn
+  falls back to a visible card before the post transport is called.
+- Dispatcher logs one structured line per surface decision:
+  `[response_surface.dispatch] { ... }`. The payload includes dispatch reason,
+  visibility, card/post presence, budget state, and `post.json` ledger status
+  distribution.
+- `post.json` ledger summaries count `planned`, `pending`, `sent`, `failed`,
+  `fallback_visible`, `policy_blocked`, `postMessageId`, and
+  `fallbackCardMessageId` entries. These are meant for operator dashboards/log
+  queries, not public evidence files.
+
+All PR7 safeguards are mechanical gates. They do not decide business workflow,
+do not expand the allowlist, and do not enable real post outbound by default.
+
 ## Non-Goals Until Later PRs
 
-- No production-wired real IM post outbound.
-- No production-wired real peer `at`.
-- No production-wired visible post failure fallback.
-- No Feishu E2E or test cards.
-- No deployment, restart, or production bridge touch.
-- No expansion of dogfood surface.
+- No production enablement in repo defaults.
+- No automatic allowlist expansion.
+- No real post/at or Feishu E2E during unit-test PRs.
+- No deployment, restart, or production bridge touch as part of code changes.

--- a/src/bridge/handler.test.ts
+++ b/src/bridge/handler.test.ts
@@ -518,9 +518,12 @@ describe("handleOne — thin-channel finalize", () => {
           allowed_chats: [],
           allowed_threads: ["om_msg"],
           lazy_card_creation: true,
+          kill_switch: false,
           post_outbound_enabled: true,
           allowed_mention_open_ids: [],
           max_posts_per_turn: 1,
+          max_posts_per_window: 4,
+          post_window_ms: 60_000,
           max_post_attempts: 3,
           text_threshold_chars: 900,
         },
@@ -589,9 +592,12 @@ describe("handleOne — thin-channel finalize", () => {
           allowed_chats: [],
           allowed_threads: ["om_msg"],
           lazy_card_creation: true,
+          kill_switch: false,
           post_outbound_enabled: true,
           allowed_mention_open_ids: [],
           max_posts_per_turn: 1,
+          max_posts_per_window: 4,
+          post_window_ms: 60_000,
           max_post_attempts: 3,
           text_threshold_chars: 900,
         },
@@ -711,9 +717,12 @@ describe("handleOne — thin-channel finalize", () => {
           allowed_chats: [],
           allowed_threads: ["om_msg"],
           lazy_card_creation: true,
+          kill_switch: false,
           post_outbound_enabled: true,
           allowed_mention_open_ids: [],
           max_posts_per_turn: 1,
+          max_posts_per_window: 4,
+          post_window_ms: 60_000,
           max_post_attempts: 3,
           text_threshold_chars: 900,
         },
@@ -735,6 +744,80 @@ describe("handleOne — thin-channel finalize", () => {
     const ledger = await readPostFile(wt);
     expect(ledger?.posts[0]?.status).toBe("sent");
     expect(ledger?.posts[0]?.postMessageId).toBe("om_post");
+  });
+
+  it("honors the response-surface kill switch even when post outbound is otherwise configured", async () => {
+    const threadId = "om_msg";
+    const finalState = {
+      status: "ready",
+      last_message: "kill switch 下仍必须可见",
+      response_surface: {
+        mode: "post",
+        primary: "post",
+      },
+      updated_at: "2026-06-26T10:00:00.000Z",
+    };
+    const wt = await seedWorktree(threadId);
+    await seedRepoCachePath();
+    const { client: postClient, calls } = makePostClient();
+
+    runClaudeImpl = () => ({
+      events: (async function* () {
+        yield { type: "system_init", sessionId: "sess_surface_kill_switch", raw: {} };
+        await writeFile(
+          stateFileMod.stateFilePathOf(wt),
+          JSON.stringify(finalState, null, 2),
+          "utf8",
+        );
+      })(),
+      done: Promise.resolve({ exitCode: 0, sessionId: "sess_surface_kill_switch" }),
+      kill: () => {},
+    });
+
+    const { renderer, startArgs, finalizeArgs, whenFinalized } = makeCardRenderer();
+    const { store } = makeSessionStore();
+    const { client } = makeClient(makeEvent());
+
+    const handler = new BridgeHandler({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      client: client as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      cardRenderer: renderer as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      sessionStore: store as any,
+      conventions: makeConventions(),
+      botConfig: {
+        id: "frontend",
+        name: "Frontend",
+        turn_taking_limit: 10,
+        backend: "claude",
+        response_surface_prototype: {
+          enabled: true,
+          allowed_chats: [],
+          allowed_threads: ["om_msg"],
+          lazy_card_creation: true,
+          kill_switch: true,
+          post_outbound_enabled: true,
+          allowed_mention_open_ids: [],
+          max_posts_per_turn: 1,
+          max_posts_per_window: 4,
+          post_window_ms: 60_000,
+          max_post_attempts: 3,
+          text_threshold_chars: 900,
+        },
+      },
+      postClient,
+    });
+
+    await handler.run();
+    await whenFinalized;
+
+    expect(startArgs).toHaveLength(1);
+    expect(finalizeArgs).toHaveLength(1);
+    expect(finalizeArgs[0]?.success).toBe(true);
+    expect(finalizeArgs[0]?.finalText).toBe("kill switch 下仍必须可见");
+    expect(calls).toHaveLength(0);
+    expect(await readPostFile(wt)).toBeNull();
   });
 
   it("late-starts a visible fallback card before marking a failed post ledger fallback_visible", async () => {
@@ -787,9 +870,12 @@ describe("handleOne — thin-channel finalize", () => {
           allowed_chats: [],
           allowed_threads: ["om_msg"],
           lazy_card_creation: true,
+          kill_switch: false,
           post_outbound_enabled: true,
           allowed_mention_open_ids: [],
           max_posts_per_turn: 1,
+          max_posts_per_window: 4,
+          post_window_ms: 60_000,
           max_post_attempts: 3,
           text_threshold_chars: 900,
         },
@@ -866,9 +952,12 @@ describe("handleOne — thin-channel finalize", () => {
           allowed_chats: [],
           allowed_threads: ["om_msg"],
           lazy_card_creation: true,
+          kill_switch: false,
           post_outbound_enabled: true,
           allowed_mention_open_ids: [],
           max_posts_per_turn: 1,
+          max_posts_per_window: 4,
+          post_window_ms: 60_000,
           max_post_attempts: 3,
           text_threshold_chars: 900,
         },

--- a/src/bridge/handler.test.ts
+++ b/src/bridge/handler.test.ts
@@ -11,6 +11,7 @@ import { mkdtemp, rm, mkdir, writeFile, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { readPostFile, writePostFile } from "./postFile.js";
+import { reconcileOrphanedCards } from "./reconcile.js";
 import { buildPostContent } from "../lark/postContent.js";
 import { derivePostIdempotencyKey, digestPostContent } from "../lark/idempotency.js";
 import type { OutboundPostClient } from "../lark/outboundPostClient.js";
@@ -981,6 +982,99 @@ describe("handleOne — thin-channel finalize", () => {
     expect(ledger?.posts[0]?.status).toBe("fallback_visible");
     expect(ledger?.posts[0]?.fallbackCardMessageId).toBe("om_card");
     expect(ledger?.posts[0]?.attempts[0]?.code).toBe("orphan_reconcile");
+  });
+
+  it("late-starts a visible fallback card before marking a disallowed mention policy_blocked", async () => {
+    const threadId = "om_msg";
+    const finalState = {
+      status: "ready",
+      last_message: "policy blocked 也必须先有可见卡",
+      response_surface: {
+        mode: "post",
+        primary: "post",
+        post: { mentions: [{ user_id: "user_blocked", label: "Blocked" }] },
+      },
+      updated_at: "2026-06-26T10:00:00.000Z",
+    };
+    const wt = await seedWorktree(threadId);
+    await seedRepoCachePath();
+    const { client: postClient, calls } = makePostClient();
+
+    runClaudeImpl = () => ({
+      events: (async function* () {
+        yield { type: "system_init", sessionId: "sess_surface_policy_blocked", raw: {} };
+        await writeFile(
+          stateFileMod.stateFilePathOf(wt),
+          JSON.stringify(finalState, null, 2),
+          "utf8",
+        );
+      })(),
+      done: Promise.resolve({ exitCode: 0, sessionId: "sess_surface_policy_blocked" }),
+      kill: () => {},
+    });
+
+    const { renderer, startArgs, finalizeArgs, whenFinalized } = makeCardRenderer();
+    const { store } = makeSessionStore();
+    const { client } = makeClient(makeEvent());
+
+    const handler = new BridgeHandler({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      client: client as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      cardRenderer: renderer as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      sessionStore: store as any,
+      conventions: makeConventions(),
+      botConfig: {
+        id: "frontend",
+        name: "Frontend",
+        turn_taking_limit: 10,
+        backend: "claude",
+        response_surface_prototype: {
+          enabled: true,
+          allowed_chats: [],
+          allowed_threads: ["om_msg"],
+          lazy_card_creation: true,
+          kill_switch: false,
+          post_outbound_enabled: true,
+          allowed_mention_open_ids: ["user_allowed"],
+          max_posts_per_turn: 1,
+          max_posts_per_window: 4,
+          post_window_ms: 60_000,
+          max_post_attempts: 3,
+          text_threshold_chars: 900,
+        },
+      },
+      postClient,
+    });
+
+    await handler.run();
+    await whenFinalized;
+
+    expect(startArgs).toHaveLength(1);
+    expect(finalizeArgs).toHaveLength(1);
+    expect(finalizeArgs[0]?.success).toBe(false);
+    expect(finalizeArgs[0]?.failureReason).toContain("allowed_mention_open_ids");
+    expect(calls).toHaveLength(0);
+    let ledger = await readPostFile(wt);
+    for (let i = 0; i < 100 && ledger?.posts[0]?.status !== "policy_blocked"; i++) {
+      await new Promise((r) => setTimeout(r, 10));
+      ledger = await readPostFile(wt);
+    }
+    expect(ledger?.posts[0]?.status).toBe("policy_blocked");
+    expect(ledger?.posts[0]?.fallbackCardMessageId).toBe("om_card");
+    expect(ledger?.posts[0]?.postMessageId).toBeUndefined();
+    expect(ledger?.posts[0]?.attempts[0]?.code).toBe("mention_policy_blocked");
+
+    await reconcileOrphanedCards({
+      worktreesDir: root,
+      botId: "frontend",
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      cardRenderer: renderer as any,
+      log: () => {},
+    });
+    expect(startArgs).toHaveLength(1);
+    expect((await readPostFile(wt))?.posts[0]?.status).toBe("policy_blocked");
   });
 
   it("late-stage state.json WITHOUT dev_url is NOT probed and NOT demoted (status=ready → success)", async () => {

--- a/src/bridge/handler.ts
+++ b/src/bridge/handler.ts
@@ -43,6 +43,7 @@ import {
 } from "../responseSurface.js";
 import type { OutboundPostClient } from "../lark/outboundPostClient.js";
 import { markPostLedgerFallbackVisible } from "./postFile.js";
+import { ResponseSurfacePostBudget } from "./postBudget.js";
 
 // ---------------------------------------------------------------------------
 // Private helpers — worktree bootstrap
@@ -515,6 +516,7 @@ export interface BridgeHandlerDeps {
 
 export class BridgeHandler {
   private readonly deps: BridgeHandlerDeps;
+  private readonly responseSurfacePostBudget = new ResponseSurfacePostBudget();
   private closed = false;
 
   constructor(deps: BridgeHandlerDeps) {
@@ -1184,6 +1186,20 @@ export class BridgeHandler {
             postLedgerAvailable: true,
             visibleFallbackAvailable: true,
             postClient: this.deps.postClient,
+            postBudget: prototypeConfig
+              ? {
+                  reserve: () =>
+                    this.responseSurfacePostBudget.reserve({
+                      scope: {
+                        botId: this.deps.botConfig?.id ?? "v1-default",
+                        chatId: parsed.chatId,
+                        threadId,
+                      },
+                      maxPosts: prototypeConfig.max_posts_per_window,
+                      windowMs: prototypeConfig.post_window_ms,
+                    }),
+                }
+              : undefined,
           });
 
           if (surfaceDispatch.card) {

--- a/src/bridge/handler.ts
+++ b/src/bridge/handler.ts
@@ -42,7 +42,7 @@ import {
   type ResponseSurfacePrototypeConfig,
 } from "../responseSurface.js";
 import type { OutboundPostClient } from "../lark/outboundPostClient.js";
-import { markPostLedgerFallbackVisible } from "./postFile.js";
+import { markPostLedgerFallbackVisible, markPostLedgerPolicyBlockedVisible } from "./postFile.js";
 import { ResponseSurfacePostBudget } from "./postBudget.js";
 
 // ---------------------------------------------------------------------------
@@ -1243,11 +1243,32 @@ export class BridgeHandler {
                 );
               }
             }
+            if (surfaceDispatch.post?.requiresPolicyLedgerMark) {
+              try {
+                await markPostLedgerPolicyBlockedVisible(
+                  worktreePath,
+                  surfaceDispatch.post.idempotencyKey,
+                  {
+                    fallbackCardMessageId: card.messageId,
+                    error:
+                      surfaceDispatch.post.policyError ??
+                      surfaceDispatch.card.failureReason ??
+                      "mention policy blocked; visible card fallback used",
+                  },
+                );
+              } catch (err) {
+                keepCardFileForRetry = true;
+                console.warn(
+                  "[bridge.handler] policy-blocked ledger mark failed after visible card finalize; keeping card.json for retry:",
+                  err,
+                );
+              }
+            }
 
             // Card was finalized successfully — drop its card.json so boot
             // reconcile doesn't re-finalize an already-finalized card. If the
-            // post fallback ledger mark failed, keep card.json so boot reconcile
-            // can retry association with the existing visible card.
+            // post fallback/policy ledger mark failed, keep card.json so boot
+            // reconcile can retry association with the existing visible card.
             if (!keepCardFileForRetry) {
               await deleteCardFile(worktreePath);
             }

--- a/src/bridge/postBudget.test.ts
+++ b/src/bridge/postBudget.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { ResponseSurfacePostBudget } from "./postBudget.js";
+
+const scope = { botId: "bot", chatId: "chat", threadId: "thread" };
+
+describe("ResponseSurfacePostBudget", () => {
+  it("enforces a sliding-window post cap per bot/chat/thread scope", () => {
+    const budget = new ResponseSurfacePostBudget();
+
+    expect(
+      budget.reserve({ scope, maxPosts: 1, windowMs: 60_000, nowMs: 1_000 }).allowed,
+    ).toBe(true);
+
+    const denied = budget.reserve({
+      scope,
+      maxPosts: 1,
+      windowMs: 60_000,
+      nowMs: 30_000,
+    });
+    expect(denied).toMatchObject({
+      allowed: false,
+      used: 1,
+      limit: 1,
+      windowMs: 60_000,
+      reason: "post-window-exhausted",
+    });
+
+    expect(
+      budget.reserve({ scope, maxPosts: 1, windowMs: 60_000, nowMs: 61_001 }).allowed,
+    ).toBe(true);
+  });
+
+  it("isolates budgets by scope", () => {
+    const budget = new ResponseSurfacePostBudget();
+
+    expect(
+      budget.reserve({ scope, maxPosts: 1, windowMs: 60_000, nowMs: 1_000 }).allowed,
+    ).toBe(true);
+    expect(
+      budget.reserve({
+        scope: { ...scope, threadId: "other-thread" },
+        maxPosts: 1,
+        windowMs: 60_000,
+        nowMs: 1_001,
+      }).allowed,
+    ).toBe(true);
+  });
+});

--- a/src/bridge/postBudget.ts
+++ b/src/bridge/postBudget.ts
@@ -1,0 +1,62 @@
+export interface ResponseSurfacePostBudgetScope {
+  botId: string;
+  chatId: string;
+  threadId: string;
+}
+
+export interface ResponseSurfacePostBudgetInput {
+  scope: ResponseSurfacePostBudgetScope;
+  maxPosts: number;
+  windowMs: number;
+  nowMs?: number;
+}
+
+export interface ResponseSurfacePostBudgetDecision {
+  allowed: boolean;
+  used: number;
+  limit: number;
+  windowMs: number;
+  resetAt?: string;
+  reason?: "post-window-exhausted";
+}
+
+function scopeKey(scope: ResponseSurfacePostBudgetScope): string {
+  return `${scope.botId}\u0000${scope.chatId}\u0000${scope.threadId}`;
+}
+
+export class ResponseSurfacePostBudget {
+  private readonly buckets = new Map<string, number[]>();
+
+  reserve(input: ResponseSurfacePostBudgetInput): ResponseSurfacePostBudgetDecision {
+    const nowMs = input.nowMs ?? Date.now();
+    const limit = Math.max(0, Math.floor(input.maxPosts));
+    const windowMs = Math.max(1, Math.floor(input.windowMs));
+    const key = scopeKey(input.scope);
+    const cutoff = nowMs - windowMs;
+    const existing = (this.buckets.get(key) ?? []).filter((ts) => ts > cutoff);
+
+    if (limit < 1 || existing.length >= limit) {
+      this.buckets.set(key, existing);
+      return {
+        allowed: false,
+        used: existing.length,
+        limit,
+        windowMs,
+        resetAt:
+          existing.length > 0
+            ? new Date(Math.min(...existing) + windowMs).toISOString()
+            : undefined,
+        reason: "post-window-exhausted",
+      };
+    }
+
+    const next = [...existing, nowMs];
+    this.buckets.set(key, next);
+    return {
+      allowed: true,
+      used: next.length,
+      limit,
+      windowMs,
+    };
+  }
+}

--- a/src/bridge/postFile.test.ts
+++ b/src/bridge/postFile.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import {
   assertPostStatusTransition,
   markPostLedgerFallbackVisible,
+  markPostLedgerPolicyBlockedVisible,
   postFilePathOf,
   readPostFile,
   reconcilePostFileOrphans,
@@ -203,5 +204,21 @@ describe("postFile ledger", () => {
     expect(next.posts[0]?.fallbackCardMessageId).toBe("om_card_fallback");
     expect(next.posts[0]?.attempts[0]?.code).toBe("orphan_reconcile");
     expect(next.posts[0]?.error).toBe("visible card finalized");
+  });
+
+  it("marks policy_blocked only after a visible fallback card exists", async () => {
+    const wt = await tempWorktree();
+    await writePostFile(wt, { version: 1, posts: [entry("planned")] });
+
+    const next = await markPostLedgerPolicyBlockedVisible(wt, "lw-p-entry", {
+      fallbackCardMessageId: "om_card_policy",
+      error: "mention blocked after visible card finalized",
+      now: () => "2026-06-26T00:02:00.000Z",
+    });
+
+    expect(next.posts[0]?.status).toBe("policy_blocked");
+    expect(next.posts[0]?.fallbackCardMessageId).toBe("om_card_policy");
+    expect(next.posts[0]?.attempts[0]?.code).toBe("mention_policy_blocked");
+    expect(next.posts[0]?.error).toBe("mention blocked after visible card finalized");
   });
 });

--- a/src/bridge/postFile.ts
+++ b/src/bridge/postFile.ts
@@ -74,8 +74,41 @@ export type PostAttempt = z.infer<typeof PostAttemptSchema>;
 export type PostLedgerEntry = z.infer<typeof PostLedgerEntrySchema>;
 export type PostFile = z.infer<typeof PostFileSchema>;
 
+export interface PostLedgerSummary {
+  total: number;
+  planned: number;
+  pending: number;
+  sent: number;
+  failed: number;
+  fallback_visible: number;
+  policy_blocked: number;
+  withPostMessageId: number;
+  withFallbackCardMessageId: number;
+}
+
 export function emptyPostFile(): PostFile {
   return { version: 1, posts: [] };
+}
+
+export function summarizePostLedger(data: PostFile | null | undefined): PostLedgerSummary {
+  const summary: PostLedgerSummary = {
+    total: 0,
+    planned: 0,
+    pending: 0,
+    sent: 0,
+    failed: 0,
+    fallback_visible: 0,
+    policy_blocked: 0,
+    withPostMessageId: 0,
+    withFallbackCardMessageId: 0,
+  };
+  for (const post of data?.posts ?? []) {
+    summary.total += 1;
+    summary[post.status] += 1;
+    if (post.postMessageId) summary.withPostMessageId += 1;
+    if (post.fallbackCardMessageId) summary.withFallbackCardMessageId += 1;
+  }
+  return summary;
 }
 
 export function postDirOf(worktreePath: string): string {

--- a/src/bridge/postFile.ts
+++ b/src/bridge/postFile.ts
@@ -369,3 +369,45 @@ export async function markPostLedgerFallbackVisible(
   await writePostFile(worktreePath, next);
   return next;
 }
+
+export async function markPostLedgerPolicyBlockedVisible(
+  worktreePath: string,
+  idempotencyKey: string,
+  opts: {
+    fallbackCardMessageId: string;
+    error: string;
+    now?: () => string;
+  },
+): Promise<PostFile> {
+  const existing = (await readPostFile(worktreePath)) ?? emptyPostFile();
+  const idx = existing.posts.findIndex((post) => post.idempotencyKey === idempotencyKey);
+  if (idx < 0) {
+    throw new Error(`post ledger entry not found: ${idempotencyKey}`);
+  }
+
+  const current = existing.posts[idx];
+  assertPostStatusTransition(current.status, "policy_blocked");
+  const now = opts.now?.() ?? new Date().toISOString();
+  const nextPosts = [...existing.posts];
+  nextPosts[idx] = {
+    ...current,
+    status: "policy_blocked",
+    fallbackCardMessageId: opts.fallbackCardMessageId,
+    error: opts.error,
+    updatedAt: now,
+    attempts: [
+      ...current.attempts,
+      {
+        attemptedAt: now,
+        status: "failed",
+        retryable: false,
+        code: "mention_policy_blocked",
+        error: opts.error,
+      },
+    ],
+  };
+
+  const next = { version: 1 as const, posts: nextPosts };
+  await writePostFile(worktreePath, next);
+  return next;
+}

--- a/src/bridge/surfaceController.test.ts
+++ b/src/bridge/surfaceController.test.ts
@@ -6,9 +6,12 @@ const allowlistedConfig = {
   allowed_chats: ["chat_allowed"],
   allowed_threads: [],
   lazy_card_creation: true,
+  kill_switch: false,
   post_outbound_enabled: false,
   allowed_mention_open_ids: [],
   max_posts_per_turn: 1,
+  max_posts_per_window: 4,
+  post_window_ms: 60_000,
   max_post_attempts: 3,
   text_threshold_chars: 1200,
 };
@@ -26,9 +29,12 @@ describe("SurfaceController", () => {
         allowed_chats: [],
         allowed_threads: [],
         lazy_card_creation: false,
+        kill_switch: false,
         post_outbound_enabled: false,
         allowed_mention_open_ids: [],
         max_posts_per_turn: 1,
+        max_posts_per_window: 4,
+        post_window_ms: 60_000,
         max_post_attempts: 3,
         text_threshold_chars: 1200,
       },
@@ -63,6 +69,23 @@ describe("SurfaceController", () => {
 
     expect(controller.shouldStartCardImmediately()).toBe(true);
     expect(controller.decision.reason).toBe("post-outbound-disabled");
+  });
+
+  it("keeps card fallback while the runtime kill switch is active", () => {
+    const controller = SurfaceController.create({
+      prototypeConfig: {
+        ...postEnabledConfig,
+        kill_switch: true,
+      },
+      chatId: "chat_allowed",
+      threadId: "om_thread",
+      postOutboundAvailable: true,
+      postLedgerAvailable: true,
+      visibleFallbackAvailable: true,
+    });
+
+    expect(controller.shouldStartCardImmediately()).toBe(true);
+    expect(controller.decision.reason).toBe("kill-switch-active");
   });
 
   it("keeps card fallback before post outbound transport is available", () => {

--- a/src/bridge/surfaceController.ts
+++ b/src/bridge/surfaceController.ts
@@ -27,6 +27,7 @@ export interface SurfaceControllerDecision {
   lazyCardCreationEnabled: boolean;
   reason:
     | "prototype-disabled"
+    | "kill-switch-active"
     | "not-allowlisted"
     | "lazy-card-disabled"
     | "post-outbound-disabled"
@@ -51,6 +52,15 @@ export class SurfaceController {
         prototypeEnabled: false,
         lazyCardCreationEnabled: false,
         reason: "prototype-disabled",
+      });
+    }
+
+    if (cfg.kill_switch) {
+      return new SurfaceController({
+        startCardImmediately: true,
+        prototypeEnabled: false,
+        lazyCardCreationEnabled: false,
+        reason: "kill-switch-active",
       });
     }
 

--- a/src/bridge/surfaceDispatcher.test.ts
+++ b/src/bridge/surfaceDispatcher.test.ts
@@ -16,9 +16,12 @@ const enabledConfig = {
   allowed_chats: ["chat_allowed"],
   allowed_threads: [],
   lazy_card_creation: true,
+  kill_switch: false,
   post_outbound_enabled: true,
   allowed_mention_open_ids: ["user_allowed"],
   max_posts_per_turn: 1,
+  max_posts_per_window: 4,
+  post_window_ms: 60_000,
   max_post_attempts: 3,
   text_threshold_chars: 1200,
 };
@@ -264,6 +267,34 @@ describe("dispatchResponseSurface", () => {
     expect(result.visible).toBe(true);
     expect(calls).toHaveLength(0);
   });
+
+  it("degrades to a visible card when the runtime post budget is exhausted", async () =>
+    withTemp(async (dir) => {
+      const { client, calls } = fakePostClient();
+      const result = await dispatchResponseSurface(
+        baseInput({
+          worktreePath: dir,
+          postClient: client,
+          postBudget: {
+            reserve: () => ({
+              allowed: false,
+              used: 4,
+              limit: 4,
+              windowMs: 60_000,
+              resetAt: "2026-06-26T00:01:00.000Z",
+              reason: "post-window-exhausted",
+            }),
+          },
+        }),
+      );
+
+      expect(result.reason).toBe("post-rate-limit-exhausted");
+      expect(result.visible).toBe(true);
+      expect(result.card?.finalText).toBe("主回复正文");
+      expect(result.budget?.allowed).toBe(false);
+      expect(calls).toHaveLength(0);
+      expect(await readPostFile(dir)).toBeNull();
+    }));
 
   it("returns a visible failure card and leaves ledger failed until the card is finalized", async () =>
     withTemp(async (dir) => {

--- a/src/bridge/surfaceDispatcher.test.ts
+++ b/src/bridge/surfaceDispatcher.test.ts
@@ -222,6 +222,35 @@ describe("dispatchResponseSurface", () => {
       expect(after?.posts[0]?.attempts).toEqual([]);
     }));
 
+  it("does not terminalize policy_blocked before a visible fallback card is finalized", async () =>
+    withTemp(async (dir) => {
+      const { client, calls } = fakePostClient();
+      const result = await dispatchResponseSurface(
+        baseInput({
+          worktreePath: dir,
+          cardStarted: false,
+          postClient: client,
+          state: state({
+            mode: "post",
+            primary: "post",
+            post: { mentions: [{ user_id: "user_blocked", label: "Blocked" }] },
+          }),
+        }),
+      );
+
+      expect(result.reason).toBe("mention-policy-blocked");
+      expect(result.visible).toBe(true);
+      expect(result.card?.success).toBe(false);
+      expect(result.post?.requiresPolicyLedgerMark).toBe(true);
+      expect(calls).toHaveLength(0);
+
+      const after = await readPostFile(dir);
+      expect(after?.posts[0]?.status).toBe("planned");
+      expect(after?.posts[0]?.fallbackCardMessageId).toBeUndefined();
+      expect(after?.posts[0]?.postMessageId).toBeUndefined();
+      expect(after?.posts[0]?.attempts).toEqual([]);
+    }));
+
   it("uses a compact secondary card for hybrid without repeating the main post body", async () =>
     withTemp(async (dir) => {
       const { client } = fakePostClient();

--- a/src/bridge/surfaceDispatcher.ts
+++ b/src/bridge/surfaceDispatcher.ts
@@ -10,9 +10,12 @@ import {
 } from "../lark/idempotency.js";
 import {
   readPostFile,
+  summarizePostLedger,
   upsertPostLedgerEntry,
+  type PostLedgerSummary,
   type PostLedgerEntry,
 } from "./postFile.js";
+import type { ResponseSurfacePostBudgetDecision } from "./postBudget.js";
 import type { Choice, ContentBlock, ImageBlock } from "../lark/card.js";
 
 export interface CardFinalizePayload {
@@ -30,8 +33,10 @@ export interface CardFinalizePayload {
 export type SurfaceDispatchReason =
   | "legacy-card-mode"
   | "prototype-disabled"
+  | "kill-switch-active"
   | "not-allowlisted"
   | "post-outbound-disabled"
+  | "post-rate-limit-exhausted"
   | "post-outbound-unavailable"
   | "post-ledger-unavailable"
   | "visible-fallback-unavailable"
@@ -61,6 +66,9 @@ export interface SurfaceDispatchInput {
   postLedgerAvailable: boolean;
   visibleFallbackAvailable: boolean;
   postClient?: OutboundPostClient;
+  postBudget?: {
+    reserve: () => ResponseSurfacePostBudgetDecision;
+  };
   now?: () => string;
 }
 
@@ -75,6 +83,7 @@ export interface SurfaceDispatchResult {
     requiresFallbackLedgerMark?: boolean;
     fallbackError?: string;
   };
+  budget?: ResponseSurfacePostBudgetDecision;
 }
 
 function fullCard(
@@ -228,7 +237,46 @@ function sentResult(
   };
 }
 
-export async function dispatchResponseSurface(
+async function ledgerSummaryFor(input: SurfaceDispatchInput): Promise<PostLedgerSummary> {
+  if (!input.worktreePath) return summarizePostLedger(null);
+  return summarizePostLedger(await readPostFile(input.worktreePath));
+}
+
+function emitSurfaceObservation(input: {
+  facts: SurfaceDispatchInput["facts"];
+  result: SurfaceDispatchResult;
+  ledger: PostLedgerSummary;
+  durationMs: number;
+}): void {
+  console.log(
+    "[response_surface.dispatch]",
+    JSON.stringify({
+      event: "response_surface.dispatch",
+      botId: input.facts.botId,
+      chatId: input.facts.chatId,
+      threadId: input.facts.threadId,
+      reason: input.result.reason,
+      visible: input.result.visible,
+      hasCard: !!input.result.card,
+      hasPost: !!input.result.post,
+      postMessageIdPresent: !!input.result.post?.messageId,
+      budget: input.result.budget
+        ? {
+            allowed: input.result.budget.allowed,
+            used: input.result.budget.used,
+            limit: input.result.budget.limit,
+            windowMs: input.result.budget.windowMs,
+            resetAt: input.result.budget.resetAt,
+            reason: input.result.budget.reason,
+          }
+        : undefined,
+      ledger: input.ledger,
+      durationMs: input.durationMs,
+    }),
+  );
+}
+
+async function dispatchResponseSurfaceInner(
   input: SurfaceDispatchInput,
 ): Promise<SurfaceDispatchResult> {
   const surface = input.state?.response_surface;
@@ -238,6 +286,7 @@ export async function dispatchResponseSurface(
 
   const cfg = input.prototypeConfig;
   if (!cfg?.enabled) return fullCard(input, "prototype-disabled");
+  if (cfg.kill_switch) return fullCard(input, "kill-switch-active");
   if (
     !isResponseSurfacePrototypeAllowlisted(cfg, {
       chatId: input.facts.chatId,
@@ -248,6 +297,7 @@ export async function dispatchResponseSurface(
   }
   if (!cfg.post_outbound_enabled) return fullCard(input, "post-outbound-disabled");
   if (cfg.max_posts_per_turn < 1) return fullCard(input, "post-outbound-disabled");
+  if (cfg.max_posts_per_window < 1) return fullCard(input, "post-rate-limit-exhausted");
   if (!input.postOutboundAvailable || !input.postClient) {
     return fullCard(input, "post-outbound-unavailable");
   }
@@ -367,6 +417,14 @@ export async function dispatchResponseSurface(
     };
   }
 
+  const budget = input.postBudget?.reserve();
+  if (budget && !budget.allowed) {
+    return {
+      ...fullCard(input, "post-rate-limit-exhausted"),
+      budget,
+    };
+  }
+
   await writeLedger(
     input,
     newLedgerEntry({
@@ -422,7 +480,7 @@ export async function dispatchResponseSurface(
     );
 
     const post = { idempotencyKey, messageId: sent.messageId, role };
-    return sentResult(input, surface, post, "post-sent");
+    return { ...sentResult(input, surface, post, "post-sent"), budget };
   } catch (err) {
     const failedAt = input.now?.() ?? new Date().toISOString();
     const error = err instanceof Error ? err.message : String(err);
@@ -458,6 +516,22 @@ export async function dispatchResponseSurface(
         requiresFallbackLedgerMark: true,
         fallbackError: error,
       },
+      budget,
     };
   }
+}
+
+export async function dispatchResponseSurface(
+  input: SurfaceDispatchInput,
+): Promise<SurfaceDispatchResult> {
+  const startedAt = Date.now();
+  const result = await dispatchResponseSurfaceInner(input);
+  const ledger = await ledgerSummaryFor(input);
+  emitSurfaceObservation({
+    facts: input.facts,
+    result,
+    ledger,
+    durationMs: Date.now() - startedAt,
+  });
+  return result;
 }

--- a/src/bridge/surfaceDispatcher.ts
+++ b/src/bridge/surfaceDispatcher.ts
@@ -82,6 +82,8 @@ export interface SurfaceDispatchResult {
     role: PostSurfaceRole;
     requiresFallbackLedgerMark?: boolean;
     fallbackError?: string;
+    requiresPolicyLedgerMark?: boolean;
+    policyError?: string;
   };
   budget?: ResponseSurfacePostBudgetDecision;
 }
@@ -330,10 +332,11 @@ async function dispatchResponseSurfaceInner(
   const now = input.now?.() ?? new Date().toISOString();
 
   if (blockedMention) {
+    const policyError = `mention target is not allowed: ${blockedMention.user_id}`;
     await writeLedger(
       input,
       newLedgerEntry({
-        status: "policy_blocked",
+        status: "planned",
         idempotencyKey: policyIdempotencyKey,
         now,
         facts: input.facts,
@@ -341,14 +344,19 @@ async function dispatchResponseSurfaceInner(
         logicalIndex,
         contentDigest: policyDigest,
         mentionCount: mentions.length,
-        error: `mention target is not allowed: ${blockedMention.user_id}`,
+        error: policyError,
       }),
     );
     return {
       card: policyBlockedCard(input),
       reason: "mention-policy-blocked",
       visible: true,
-      post: { idempotencyKey: policyIdempotencyKey, role },
+      post: {
+        idempotencyKey: policyIdempotencyKey,
+        role,
+        requiresPolicyLedgerMark: true,
+        policyError,
+      },
     };
   }
 

--- a/src/config/botLoader.test.ts
+++ b/src/config/botLoader.test.ts
@@ -566,9 +566,12 @@ bot_open_id: ou_surface_default
       allowed_chats: [],
       allowed_threads: [],
       lazy_card_creation: false,
+      kill_switch: false,
       post_outbound_enabled: false,
       allowed_mention_open_ids: [],
       max_posts_per_turn: 1,
+      max_posts_per_window: 4,
+      post_window_ms: 60_000,
       max_post_attempts: 3,
       text_threshold_chars: 1200,
     });
@@ -592,10 +595,13 @@ response_surface_prototype:
   allowed_threads:
     - om_thread
   lazy_card_creation: true
+  kill_switch: true
   post_outbound_enabled: true
   allowed_mention_open_ids:
     - surface_peer
   max_posts_per_turn: 2
+  max_posts_per_window: 7
+  post_window_ms: 30000
   max_post_attempts: 2
   text_threshold_chars: 900
 `,
@@ -608,9 +614,12 @@ response_surface_prototype:
       allowed_chats: ["oc_test"],
       allowed_threads: ["om_thread"],
       lazy_card_creation: true,
+      kill_switch: true,
       post_outbound_enabled: true,
       allowed_mention_open_ids: ["surface_peer"],
       max_posts_per_turn: 2,
+      max_posts_per_window: 7,
+      post_window_ms: 30_000,
       max_post_attempts: 2,
       text_threshold_chars: 900,
     });

--- a/src/responseSurface.test.ts
+++ b/src/responseSurface.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import {
+  defaultResponseSurfacePrototypeConfig,
+  isResponseSurfacePostOutboundAvailable,
+  isResponseSurfacePrototypeAllowlisted,
+  shouldProvideResponseSurfacePostClient,
+} from "./responseSurface.js";
+
+const enabledConfig = {
+  ...defaultResponseSurfacePrototypeConfig(),
+  enabled: true,
+  allowed_chats: ["chat"],
+  lazy_card_creation: true,
+  post_outbound_enabled: true,
+};
+
+describe("response surface production gates", () => {
+  it("keeps the default config fully off", () => {
+    const cfg = defaultResponseSurfacePrototypeConfig();
+
+    expect(cfg).toMatchObject({
+      enabled: false,
+      post_outbound_enabled: false,
+      kill_switch: false,
+      allowed_chats: [],
+      allowed_threads: [],
+      allowed_mention_open_ids: [],
+      max_posts_per_turn: 1,
+      max_posts_per_window: 4,
+      post_window_ms: 60_000,
+    });
+    expect(shouldProvideResponseSurfacePostClient(cfg)).toBe(false);
+  });
+
+  it("uses kill_switch as an emergency post-client gate", () => {
+    const cfg = { ...enabledConfig, kill_switch: true };
+
+    expect(isResponseSurfacePrototypeAllowlisted(cfg, { chatId: "chat", threadId: "thread" }))
+      .toBe(false);
+    expect(shouldProvideResponseSurfacePostClient(cfg)).toBe(false);
+    expect(
+      isResponseSurfacePostOutboundAvailable(cfg, { chatId: "chat", threadId: "thread" }, {
+        postClientAvailable: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not provide a post client when the runtime window cap is zero", () => {
+    const cfg = { ...enabledConfig, max_posts_per_window: 0 };
+
+    expect(shouldProvideResponseSurfacePostClient(cfg)).toBe(false);
+  });
+});

--- a/src/responseSurface.ts
+++ b/src/responseSurface.ts
@@ -8,9 +8,12 @@ export function defaultResponseSurfacePrototypeConfig() {
     allowed_chats: [] as string[],
     allowed_threads: [] as string[],
     lazy_card_creation: false,
+    kill_switch: false,
     post_outbound_enabled: false,
     allowed_mention_open_ids: [] as string[],
     max_posts_per_turn: 1,
+    max_posts_per_window: 4,
+    post_window_ms: 60_000,
     max_post_attempts: 3,
     text_threshold_chars: 1200,
   };
@@ -23,9 +26,12 @@ const responseSurfacePrototypeConfigDefaults = () => ({
   allowed_chats: [] as string[],
   allowed_threads: [] as string[],
   lazy_card_creation: false,
+  kill_switch: false,
   post_outbound_enabled: false,
   allowed_mention_open_ids: [] as string[],
   max_posts_per_turn: 1,
+  max_posts_per_window: 4,
+  post_window_ms: 60_000,
   max_post_attempts: 3,
   text_threshold_chars: 1200,
 });
@@ -108,6 +114,12 @@ export const ResponseSurfacePrototypeConfigSchema = z
      */
     lazy_card_creation: z.boolean().default(false),
     /**
+     * Runtime kill switch for emergency rollback. When true, every response
+     * surface post path is treated as disabled even if enabled/allowlists are
+     * otherwise configured. Default false preserves current default-off behavior.
+     */
+    kill_switch: z.boolean().default(false),
+    /**
      * PR3 dark-launch gate for real post outbound. This must stay false by
      * default. PR4's dispatcher also requires this gate before any post path.
      */
@@ -123,6 +135,16 @@ export const ResponseSurfacePrototypeConfigSchema = z
      * unavailable, but fake-channel dispatch tests enforce this bounded shape.
      */
     max_posts_per_turn: z.number().int().min(0).max(10).default(1),
+    /**
+     * Sliding-window hard cap for real post sends within one bot/chat/thread
+     * runtime scope. This is enforced in the production handler before a post
+     * transport call is attempted; exhausted windows degrade to visible cards.
+     */
+    max_posts_per_window: z.number().int().min(0).max(100).default(4),
+    /**
+     * Sliding-window duration for max_posts_per_window.
+     */
+    post_window_ms: z.number().int().min(1_000).max(86_400_000).default(60_000),
     /**
      * Max attempts for one logical post. Retry classification is intentionally
      * narrow in PR3: only 5xx errors are retryable.
@@ -145,6 +167,7 @@ export function isResponseSurfacePrototypeAllowlisted(
   facts: { chatId: string; threadId: string },
 ): boolean {
   if (!config?.enabled) return false;
+  if (config.kill_switch) return false;
   const chatAllowed =
     config.allowed_chats.length > 0 && config.allowed_chats.includes(facts.chatId);
   const threadAllowed =
@@ -157,8 +180,10 @@ export function shouldProvideResponseSurfacePostClient(
 ): boolean {
   return !!(
     config?.enabled &&
+    !config.kill_switch &&
     config.post_outbound_enabled &&
     config.max_posts_per_turn >= 1 &&
+    config.max_posts_per_window >= 1 &&
     (config.allowed_chats.length > 0 || config.allowed_threads.length > 0)
   );
 }


### PR DESCRIPTION
## Summary

PR7 production hardening for the response surface prototype. This keeps production default-off while adding the safety controls needed before a future grey rollout:

- add a config kill-switch (`kill_switch`) that forces legacy visible-card fallback even when the prototype is otherwise enabled
- add a runtime sliding-window post budget (`max_posts_per_window` + `post_window_ms`) enforced before post transport calls
- add structured `[response_surface.dispatch]` logs with dispatch reason, visibility, card/post presence, budget state, and post ledger status distribution
- add post ledger summary helpers for observability
- document grey rollout + rollback steps in `docs/response-surface-production-rollout.md`
- update response surface prototype docs with PR7 gates

## Default-off proof

Defaults remain production-safe:

- `enabled: false`
- `post_outbound_enabled: false`
- `allowed_chats: []`
- `allowed_threads: []`
- `allowed_mention_open_ids: []`
- `kill_switch: false`
- `shouldProvideResponseSurfacePostClient(defaultConfig) === false`

`main.ts` still injects a real post client only through `shouldProvideResponseSurfacePostClient(bot.response_surface_prototype)`. The new helper also requires `!kill_switch` and `max_posts_per_window >= 1`, so production defaults still do not provide any post client.

## Safety coverage

- Kill-switch integration test: handler finalizes a visible card and does not call the injected post client when `kill_switch=true`.
- Runtime rate-limit test: dispatcher returns visible card fallback with `post-rate-limit-exhausted`, does not call post client, and does not write a post ledger entry.
- Budget tracker tests: sliding-window cap is enforced per bot/chat/thread scope.
- Existing PR5/PR6a protections are covered in targeted tests: failed post fallback and orphan fallback still finalize a visible card before `fallback_visible` ledger marking.

## Verification

- `pnpm typecheck` ✅
- `pnpm vitest run src/responseSurface.test.ts src/bridge/postBudget.test.ts src/bridge/surfaceController.test.ts src/bridge/surfaceDispatcher.test.ts src/bridge/handler.test.ts src/config/botLoader.test.ts src/bridge/postFile.test.ts src/bridge/reconcile.test.ts` ✅ 8 files / 110 tests
- `env -u LARKWAY_HOME pnpm test` ✅ 49 files / 782 tests
- `git diff --cached --check` ✅ before commit
- Added-line sensitive scan for real Feishu/profile/internal IDs and token/app secret values ✅ no matches

## Boundaries

No production enablement, no real post/at, no test card, no Feishu E2E, no deploy/restart/current bridge touch, no member scope/roster, no PR merge.
