### PR TITLE
fix: keep response surface progress card dynamic

### DIFF
--- a/docs/response-surface-prototype.md
+++ b/docs/response-surface-prototype.md
@@ -111,28 +111,16 @@ empty `allowed_mention_open_ids` allows the Agent to choose targets; non-empty
 
 ## PR2 / PR4 SurfaceController Foundation
 
-`SurfaceController` centralizes the card-start decision. Production wiring still
-passes `postOutboundAvailable: false`, so every production path creates the
-legacy visible card before the Agent runs.
+`SurfaceController` centralizes the card-start decision. The bridge creates a
+visible processing card before the Agent runs so streamed tool/progress events
+can update the in-progress card during the turn. Post/hybrid dispatch still runs
+at finalize time; when a post is sent, the already-visible card becomes the
+compact secondary/audit surface instead of suppressing mid-turn progress.
 
-The lazy branch is eligible only when all of these are true:
-
-- prototype enabled
-- chat/thread allowed by the allowlist gate; empty chat/thread allowlists allow all
-- `lazy_card_creation: true`
-- `post_outbound_enabled: true`
-- post outbound transport available
-- post ledger available
-- visible failure fallback available
-
-Otherwise the controller starts the legacy card immediately:
-
-- prototype disabled -> card immediately
-- not allowlisted -> card immediately
-- lazy card disabled -> card immediately
-- post outbound disabled/unavailable -> card immediately
-- post ledger unavailable -> card immediately
-- visible fallback unavailable -> card immediately
+`lazy_card_creation` is retained for config compatibility, but it no longer
+suppresses the initial processing card when post outbound is available. This
+keeps response surfaces compatible with the live progress-card UX and preserves
+the visible-card fallback invariant.
 
 ## PR3 Idempotency Reservation
 

--- a/docs/response-surface-prototype.md
+++ b/docs/response-surface-prototype.md
@@ -13,7 +13,8 @@ post outbound behind runtime gates and production safeguards.
 ## Principles
 
 - The Agent chooses the response surface by writing `response_surface` in
-  `state.json`.
+  `state.json`. When it omits `response_surface`, the default-on runtime treats
+  plain text as `post` and still keeps card-only payloads on the card path.
 - The bridge provides channel infrastructure only: validation, mechanical
   degradation, idempotency/fallback/reconcile plumbing, and safe rendering.
 - The bridge must not encode business rules such as "short task = post" or
@@ -65,6 +66,14 @@ Supported narrow fields:
 The schema soft-fails this prototype field. A malformed `response_surface`
 becomes `undefined` and must not discard `status`, `last_message`, choices, or
 other legacy card fields needed to finalize the existing card.
+
+When `response_surface` is absent and the prototype is enabled, a plain text
+reply defaults to the primary post path. This is the default-on user experience:
+the bridge creates and dynamically updates the processing card during the turn,
+sends the final reply as a post, then recalls the transient processing card after
+the post is visible. Agent-declared `choices`, `image_blocks`, or
+`content_blocks` remain card-only by default because posts cannot render those
+interactive/rich card controls.
 
 ## Bot Config Gate
 

--- a/docs/response-surface-prototype.md
+++ b/docs/response-surface-prototype.md
@@ -80,6 +80,8 @@ response_surface_prototype:
   post_outbound_enabled: true
   allow_agent_mentions: true
   allowed_mention_open_ids: []
+  recall_processing_card_on_post_success: true
+  retain_hybrid_audit_card: true
   max_posts_per_turn: 1
   max_posts_per_window: 4
   post_window_ms: 60000
@@ -97,6 +99,8 @@ Defaults:
 - `post_outbound_enabled: true`
 - `allow_agent_mentions: true`
 - `allowed_mention_open_ids: []`
+- `recall_processing_card_on_post_success: true`
+- `retain_hybrid_audit_card: true`
 - `max_posts_per_turn: 1`
 - `max_posts_per_window: 4`
 - `post_window_ms: 60000`
@@ -109,13 +113,23 @@ separate: `allow_agent_mentions: false` disables all Agent-authored mentions;
 empty `allowed_mention_open_ids` allows the Agent to choose targets; non-empty
 `allowed_mention_open_ids` narrows mentions to that set. `@all` remains blocked.
 
+When a primary post succeeds, `recall_processing_card_on_post_success: true`
+recalls the already-visible processing card after the post is confirmed visible,
+so the final view is not duplicated as "card + post". Recall is best-effort:
+if recall fails, the bridge keeps/finalizes the card instead of risking an
+invisible reply. Hybrid mode keeps the compact audit card by default through
+`retain_hybrid_audit_card: true`; operators can set it false to recall that
+card after a successful primary post too.
+
 ## PR2 / PR4 SurfaceController Foundation
 
 `SurfaceController` centralizes the card-start decision. The bridge creates a
 visible processing card before the Agent runs so streamed tool/progress events
 can update the in-progress card during the turn. Post/hybrid dispatch still runs
-at finalize time; when a post is sent, the already-visible card becomes the
-compact secondary/audit surface instead of suppressing mid-turn progress.
+at finalize time. When a primary post is sent successfully, the bridge recalls
+the transient processing card unless the card is intentionally retained as a
+hybrid compact audit surface. Card-only turns and post failure/policy fallbacks
+keep the card because it is the visible reply.
 
 `lazy_card_creation` is retained for config compatibility, but it no longer
 suppresses the initial processing card when post outbound is available. This

--- a/src/bridge/handler.test.ts
+++ b/src/bridge/handler.test.ts
@@ -116,6 +116,8 @@ interface FinalizeArgs {
   mentionOpenId?: string;
   titleOverride?: string;
   colorOverride?: string;
+  choices?: Array<{ label: string; value: string }>;
+  choicePrompt?: string;
   imageBlocks?: Array<{
     img_key: string;
     alt: string;
@@ -681,15 +683,11 @@ describe("handleOne — thin-channel finalize", () => {
     expect(calls).toHaveLength(0);
   });
 
-  it("keeps the in-progress card dynamic while using an injected post client for post-primary turns", async () => {
+  it("defaults undeclared plain replies to post while keeping the in-progress card dynamic", async () => {
     const threadId = "om_msg";
     const finalState = {
       status: "ready",
-      last_message: "隔离配置走 post-only",
-      response_surface: {
-        mode: "post",
-        primary: "post",
-      },
+      last_message: "默认开启后纯文本走 post",
       updated_at: "2026-06-26T10:00:00.000Z",
     };
     const wt = await seedWorktree(threadId);
@@ -764,10 +762,85 @@ describe("handleOne — thin-channel finalize", () => {
     expect(finalizeArgs).toHaveLength(0);
     expect(calls).toHaveLength(1);
     expect(calls[0]?.replyToMessageId).toBe("om_msg");
-    expect(calls[0]?.content).toContain("隔离配置走 post-only");
+    expect(calls[0]?.content).toContain("默认开启后纯文本走 post");
     const ledger = await readPostFile(wt);
     expect(ledger?.posts[0]?.status).toBe("sent");
     expect(ledger?.posts[0]?.postMessageId).toBe("om_post");
+  });
+
+  it("keeps undeclared choice replies on the card path even when default post is enabled", async () => {
+    const threadId = "om_msg";
+    const finalState = {
+      status: "ready",
+      last_message: "需要按钮所以保留卡片",
+      choices: [{ label: "继续", value: "继续处理" }],
+      choice_prompt: "下一步?",
+      updated_at: "2026-06-26T10:00:00.000Z",
+    };
+    const wt = await seedWorktree(threadId);
+    await seedRepoCachePath();
+    const { client: postClient, calls } = makePostClient();
+
+    runClaudeImpl = () => ({
+      events: (async function* () {
+        yield { type: "system_init", sessionId: "sess_surface_default_card_capability", raw: {} };
+        await writeFile(
+          stateFileMod.stateFilePathOf(wt),
+          JSON.stringify(finalState, null, 2),
+          "utf8",
+        );
+      })(),
+      done: Promise.resolve({ exitCode: 0, sessionId: "sess_surface_default_card_capability" }),
+      kill: () => {},
+    });
+
+    const { renderer, finalizeArgs, recallArgs, whenFinalized } = makeCardRenderer();
+    const { store } = makeSessionStore();
+    const { client } = makeClient(makeEvent());
+
+    const handler = new BridgeHandler({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      client: client as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      cardRenderer: renderer as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      sessionStore: store as any,
+      conventions: makeConventions(),
+      botConfig: {
+        id: "frontend",
+        name: "Frontend",
+        turn_taking_limit: 10,
+        backend: "claude",
+        response_surface_prototype: {
+          ...defaultResponseSurfacePrototypeConfig(),
+          enabled: true,
+          allowed_chats: [],
+          allowed_threads: ["om_msg"],
+          lazy_card_creation: true,
+          kill_switch: false,
+          post_outbound_enabled: true,
+          allow_agent_mentions: true,
+          allowed_mention_open_ids: [],
+          max_posts_per_turn: 1,
+          max_posts_per_window: 4,
+          post_window_ms: 60_000,
+          max_post_attempts: 3,
+          text_threshold_chars: 900,
+        },
+      },
+      postClient,
+    });
+
+    await handler.run();
+    await whenFinalized;
+
+    expect(calls).toHaveLength(0);
+    expect(recallArgs).toHaveLength(0);
+    expect(finalizeArgs).toHaveLength(1);
+    expect(finalizeArgs[0]?.finalText).toBe("需要按钮所以保留卡片");
+    expect(finalizeArgs[0]?.choices).toEqual([{ label: "继续", value: "继续处理" }]);
+    expect(finalizeArgs[0]?.choicePrompt).toBe("下一步?");
+    expect(await readPostFile(wt)).toBeNull();
   });
 
   it("falls back to a compact card when post succeeds but processing-card recall fails", async () => {

--- a/src/bridge/handler.test.ts
+++ b/src/bridge/handler.test.ts
@@ -15,6 +15,7 @@ import { reconcileOrphanedCards } from "./reconcile.js";
 import { buildPostContent } from "../lark/postContent.js";
 import { derivePostIdempotencyKey, digestPostContent } from "../lark/idempotency.js";
 import type { OutboundPostClient } from "../lark/outboundPostClient.js";
+import { defaultResponseSurfacePrototypeConfig } from "../responseSurface.js";
 
 // ---------------------------------------------------------------------------
 // handler.ts calls createRunner("claude").run(...) from agent/runner.
@@ -143,10 +144,11 @@ interface FinalizeArgs {
  * fire-and-forget (it sets up a per-thread promise chain and returns without
  * awaiting handleOne), so tests await whenFinalized to know the turn finished.
  */
-function makeCardRenderer() {
+function makeCardRenderer(rendererOpts: { recallFails?: boolean } = {}) {
   const finalizeArgs: FinalizeArgs[] = [];
   const startArgs: Array<{ messageId: string; replyInThread?: boolean; threadId?: string }> = [];
   const handleEvents: unknown[] = [];
+  const recallArgs: string[] = [];
   let resolveFinalized!: () => void;
   const whenFinalized = new Promise<void>((r) => {
     resolveFinalized = r;
@@ -163,10 +165,14 @@ function makeCardRenderer() {
           finalizeArgs.push(a);
           resolveFinalized();
         },
+        recall: async () => {
+          recallArgs.push("om_card");
+          if (rendererOpts.recallFails) throw new Error("fake recall failed");
+        },
       };
     },
   };
-  return { renderer, finalizeArgs, startArgs, handleEvents, whenFinalized };
+  return { renderer, finalizeArgs, startArgs, handleEvents, recallArgs, whenFinalized };
 }
 
 /** Minimal SessionStore fake — in-memory, records put() calls. */
@@ -499,7 +505,7 @@ describe("handleOne — thin-channel finalize", () => {
   });
 
   it("keeps visible card fallback when response surface is enabled before post outbound exists", async () => {
-    const { renderer, startArgs, finalizeArgs, whenFinalized } = makeCardRenderer();
+    const { renderer, startArgs, finalizeArgs, recallArgs, whenFinalized } = makeCardRenderer();
     const { store } = makeSessionStore();
     const { client } = makeClient(makeEvent());
     stubRunClaude("sess_surface", 0);
@@ -518,6 +524,7 @@ describe("handleOne — thin-channel finalize", () => {
         turn_taking_limit: 10,
         backend: "claude",
         response_surface_prototype: {
+          ...defaultResponseSurfacePrototypeConfig(),
           enabled: true,
           allowed_chats: [],
           allowed_threads: ["om_msg"],
@@ -575,7 +582,7 @@ describe("handleOne — thin-channel finalize", () => {
       kill: () => {},
     });
 
-    const { renderer, startArgs, finalizeArgs, whenFinalized } = makeCardRenderer();
+    const { renderer, startArgs, finalizeArgs, recallArgs, whenFinalized } = makeCardRenderer();
     const { store } = makeSessionStore();
     const { client } = makeClient(makeEvent());
 
@@ -593,6 +600,7 @@ describe("handleOne — thin-channel finalize", () => {
         turn_taking_limit: 10,
         backend: "claude",
         response_surface_prototype: {
+          ...defaultResponseSurfacePrototypeConfig(),
           enabled: true,
           allowed_chats: [],
           allowed_threads: ["om_msg"],
@@ -647,7 +655,7 @@ describe("handleOne — thin-channel finalize", () => {
       kill: () => {},
     });
 
-    const { renderer, startArgs, finalizeArgs, whenFinalized } = makeCardRenderer();
+    const { renderer, startArgs, finalizeArgs, recallArgs, whenFinalized } = makeCardRenderer();
     const { store } = makeSessionStore();
     const { client } = makeClient(makeEvent());
 
@@ -703,7 +711,7 @@ describe("handleOne — thin-channel finalize", () => {
       kill: () => {},
     });
 
-    const { renderer, startArgs, finalizeArgs, handleEvents, whenFinalized } = makeCardRenderer();
+    const { renderer, startArgs, finalizeArgs, handleEvents, recallArgs } = makeCardRenderer();
     const { store } = makeSessionStore();
     const { client, acked } = makeClient(makeEvent());
 
@@ -721,6 +729,96 @@ describe("handleOne — thin-channel finalize", () => {
         turn_taking_limit: 10,
         backend: "claude",
         response_surface_prototype: {
+          ...defaultResponseSurfacePrototypeConfig(),
+          enabled: true,
+          allowed_chats: [],
+          allowed_threads: ["om_msg"],
+          lazy_card_creation: true,
+          kill_switch: false,
+          post_outbound_enabled: true,
+          allow_agent_mentions: true,
+          allowed_mention_open_ids: [],
+          max_posts_per_turn: 1,
+          max_posts_per_window: 4,
+          post_window_ms: 60_000,
+          max_post_attempts: 3,
+          text_threshold_chars: 900,
+        },
+      },
+      postClient,
+    });
+
+    await handler.run();
+    for (let i = 0; i < 100 && acked.length === 0; i++) {
+      await new Promise((r) => setTimeout(r, 10));
+    }
+
+    expect(acked).toEqual(["om_msg"]);
+    expect(startArgs).toHaveLength(1);
+    expect(handleEvents.map((event) => (event as { type?: string }).type)).toEqual([
+      "system_init",
+      "tool_use",
+      "text_delta",
+    ]);
+    expect(recallArgs).toEqual(["om_card"]);
+    expect(finalizeArgs).toHaveLength(0);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.replyToMessageId).toBe("om_msg");
+    expect(calls[0]?.content).toContain("隔离配置走 post-only");
+    const ledger = await readPostFile(wt);
+    expect(ledger?.posts[0]?.status).toBe("sent");
+    expect(ledger?.posts[0]?.postMessageId).toBe("om_post");
+  });
+
+  it("falls back to a compact card when post succeeds but processing-card recall fails", async () => {
+    const threadId = "om_msg";
+    const finalState = {
+      status: "ready",
+      last_message: "post 已发但撤卡失败",
+      response_surface: {
+        mode: "post",
+        primary: "post",
+      },
+      updated_at: "2026-06-26T10:00:00.000Z",
+    };
+    const wt = await seedWorktree(threadId);
+    await seedRepoCachePath();
+    const { client: postClient, calls } = makePostClient();
+
+    runClaudeImpl = () => ({
+      events: (async function* () {
+        yield { type: "system_init", sessionId: "sess_surface_recall_failed", raw: {} };
+        await writeFile(
+          stateFileMod.stateFilePathOf(wt),
+          JSON.stringify(finalState, null, 2),
+          "utf8",
+        );
+      })(),
+      done: Promise.resolve({ exitCode: 0, sessionId: "sess_surface_recall_failed" }),
+      kill: () => {},
+    });
+
+    const { renderer, finalizeArgs, recallArgs, whenFinalized } = makeCardRenderer({
+      recallFails: true,
+    });
+    const { store } = makeSessionStore();
+    const { client, acked } = makeClient(makeEvent());
+
+    const handler = new BridgeHandler({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      client: client as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      cardRenderer: renderer as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      sessionStore: store as any,
+      conventions: makeConventions(),
+      botConfig: {
+        id: "frontend",
+        name: "Frontend",
+        turn_taking_limit: 10,
+        backend: "claude",
+        response_surface_prototype: {
+          ...defaultResponseSurfacePrototypeConfig(),
           enabled: true,
           allowed_chats: [],
           allowed_threads: ["om_msg"],
@@ -745,21 +843,89 @@ describe("handleOne — thin-channel finalize", () => {
       await new Promise((r) => setTimeout(r, 10));
     }
 
-    expect(acked).toEqual(["om_msg"]);
-    expect(startArgs).toHaveLength(1);
-    expect(handleEvents.map((event) => (event as { type?: string }).type)).toEqual([
-      "system_init",
-      "tool_use",
-      "text_delta",
-    ]);
+    expect(calls).toHaveLength(1);
+    expect(recallArgs).toEqual(["om_card"]);
     expect(finalizeArgs).toHaveLength(1);
     expect(finalizeArgs[0]?.finalText).toContain("post_message_id: om_post");
-    expect(calls).toHaveLength(1);
-    expect(calls[0]?.replyToMessageId).toBe("om_msg");
-    expect(calls[0]?.content).toContain("隔离配置走 post-only");
+    expect(acked).toEqual(["om_msg"]);
     const ledger = await readPostFile(wt);
     expect(ledger?.posts[0]?.status).toBe("sent");
     expect(ledger?.posts[0]?.postMessageId).toBe("om_post");
+  });
+
+  it("keeps the hybrid compact audit card by default after a primary post succeeds", async () => {
+    const threadId = "om_msg";
+    const finalState = {
+      status: "ready",
+      last_message: "hybrid 主 post + 审计卡",
+      response_surface: {
+        mode: "hybrid",
+        primary: "post",
+      },
+      updated_at: "2026-06-26T10:00:00.000Z",
+    };
+    const wt = await seedWorktree(threadId);
+    await seedRepoCachePath();
+    const { client: postClient, calls } = makePostClient();
+
+    runClaudeImpl = () => ({
+      events: (async function* () {
+        yield { type: "system_init", sessionId: "sess_surface_hybrid", raw: {} };
+        await writeFile(
+          stateFileMod.stateFilePathOf(wt),
+          JSON.stringify(finalState, null, 2),
+          "utf8",
+        );
+      })(),
+      done: Promise.resolve({ exitCode: 0, sessionId: "sess_surface_hybrid" }),
+      kill: () => {},
+    });
+
+    const { renderer, finalizeArgs, recallArgs, whenFinalized } = makeCardRenderer();
+    const { store } = makeSessionStore();
+    const { client } = makeClient(makeEvent());
+
+    const handler = new BridgeHandler({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      client: client as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      cardRenderer: renderer as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      sessionStore: store as any,
+      conventions: makeConventions(),
+      botConfig: {
+        id: "frontend",
+        name: "Frontend",
+        turn_taking_limit: 10,
+        backend: "claude",
+        response_surface_prototype: {
+          ...defaultResponseSurfacePrototypeConfig(),
+          enabled: true,
+          allowed_chats: [],
+          allowed_threads: ["om_msg"],
+          lazy_card_creation: true,
+          kill_switch: false,
+          post_outbound_enabled: true,
+          allow_agent_mentions: true,
+          allowed_mention_open_ids: [],
+          max_posts_per_turn: 1,
+          max_posts_per_window: 4,
+          post_window_ms: 60_000,
+          max_post_attempts: 3,
+          text_threshold_chars: 900,
+        },
+      },
+      postClient,
+    });
+
+    await handler.run();
+    await whenFinalized;
+
+    expect(calls).toHaveLength(1);
+    expect(recallArgs).toHaveLength(0);
+    expect(finalizeArgs).toHaveLength(1);
+    expect(finalizeArgs[0]?.finalText).toContain("post_message_id: om_post");
+    expect((await readPostFile(wt))?.posts[0]?.status).toBe("sent");
   });
 
   it("honors the response-surface kill switch even when post outbound is otherwise configured", async () => {
@@ -790,7 +956,7 @@ describe("handleOne — thin-channel finalize", () => {
       kill: () => {},
     });
 
-    const { renderer, startArgs, finalizeArgs, whenFinalized } = makeCardRenderer();
+    const { renderer, startArgs, finalizeArgs, recallArgs, whenFinalized } = makeCardRenderer();
     const { store } = makeSessionStore();
     const { client } = makeClient(makeEvent());
 
@@ -808,6 +974,7 @@ describe("handleOne — thin-channel finalize", () => {
         turn_taking_limit: 10,
         backend: "claude",
         response_surface_prototype: {
+          ...defaultResponseSurfacePrototypeConfig(),
           enabled: true,
           allowed_chats: [],
           allowed_threads: ["om_msg"],
@@ -865,7 +1032,7 @@ describe("handleOne — thin-channel finalize", () => {
       kill: () => {},
     });
 
-    const { renderer, startArgs, finalizeArgs, whenFinalized } = makeCardRenderer();
+    const { renderer, startArgs, finalizeArgs, recallArgs, whenFinalized } = makeCardRenderer();
     const { store } = makeSessionStore();
     const { client } = makeClient(makeEvent());
 
@@ -883,6 +1050,7 @@ describe("handleOne — thin-channel finalize", () => {
         turn_taking_limit: 10,
         backend: "claude",
         response_surface_prototype: {
+          ...defaultResponseSurfacePrototypeConfig(),
           enabled: true,
           allowed_chats: [],
           allowed_threads: ["om_msg"],
@@ -908,6 +1076,7 @@ describe("handleOne — thin-channel finalize", () => {
     expect(finalizeArgs).toHaveLength(1);
     expect(finalizeArgs[0]?.success).toBe(false);
     expect(finalizeArgs[0]?.failureReason).toContain("visible card fallback used");
+    expect(recallArgs).toHaveLength(0);
     expect(calls).toHaveLength(1);
     let ledger = await readPostFile(wt);
     for (let i = 0; i < 100 && ledger?.posts[0]?.status !== "fallback_visible"; i++) {
@@ -948,7 +1117,7 @@ describe("handleOne — thin-channel finalize", () => {
       kill: () => {},
     });
 
-    const { renderer, startArgs, finalizeArgs, whenFinalized } = makeCardRenderer();
+    const { renderer, startArgs, finalizeArgs, recallArgs, whenFinalized } = makeCardRenderer();
     const { store } = makeSessionStore();
     const { client } = makeClient(makeEvent());
 
@@ -966,6 +1135,7 @@ describe("handleOne — thin-channel finalize", () => {
         turn_taking_limit: 10,
         backend: "claude",
         response_surface_prototype: {
+          ...defaultResponseSurfacePrototypeConfig(),
           enabled: true,
           allowed_chats: [],
           allowed_threads: ["om_msg"],
@@ -991,6 +1161,7 @@ describe("handleOne — thin-channel finalize", () => {
     expect(finalizeArgs).toHaveLength(1);
     expect(finalizeArgs[0]?.success).toBe(false);
     expect(finalizeArgs[0]?.failureReason).toContain("visible card fallback used");
+    expect(recallArgs).toHaveLength(0);
     expect(calls).toHaveLength(0);
     let ledger = await readPostFile(wt);
     for (let i = 0; i < 100 && ledger?.posts[0]?.status !== "fallback_visible"; i++) {
@@ -1031,7 +1202,7 @@ describe("handleOne — thin-channel finalize", () => {
       kill: () => {},
     });
 
-    const { renderer, startArgs, finalizeArgs, whenFinalized } = makeCardRenderer();
+    const { renderer, startArgs, finalizeArgs, recallArgs, whenFinalized } = makeCardRenderer();
     const { store } = makeSessionStore();
     const { client } = makeClient(makeEvent());
 
@@ -1049,6 +1220,7 @@ describe("handleOne — thin-channel finalize", () => {
         turn_taking_limit: 10,
         backend: "claude",
         response_surface_prototype: {
+          ...defaultResponseSurfacePrototypeConfig(),
           enabled: true,
           allowed_chats: [],
           allowed_threads: ["om_msg"],
@@ -1074,6 +1246,7 @@ describe("handleOne — thin-channel finalize", () => {
     expect(finalizeArgs).toHaveLength(1);
     expect(finalizeArgs[0]?.success).toBe(false);
     expect(finalizeArgs[0]?.failureReason).toContain("blocked by policy");
+    expect(recallArgs).toHaveLength(0);
     expect(calls).toHaveLength(0);
     let ledger = await readPostFile(wt);
     for (let i = 0; i < 100 && ledger?.posts[0]?.status !== "policy_blocked"; i++) {

--- a/src/bridge/handler.test.ts
+++ b/src/bridge/handler.test.ts
@@ -146,6 +146,7 @@ interface FinalizeArgs {
 function makeCardRenderer() {
   const finalizeArgs: FinalizeArgs[] = [];
   const startArgs: Array<{ messageId: string; replyInThread?: boolean; threadId?: string }> = [];
+  const handleEvents: unknown[] = [];
   let resolveFinalized!: () => void;
   const whenFinalized = new Promise<void>((r) => {
     resolveFinalized = r;
@@ -155,7 +156,9 @@ function makeCardRenderer() {
       startArgs.push({ messageId, ...opts });
       return {
         messageId: "om_card",
-        handle: () => {},
+        handle: (event: unknown) => {
+          handleEvents.push(event);
+        },
         finalize: async (a: FinalizeArgs) => {
           finalizeArgs.push(a);
           resolveFinalized();
@@ -163,7 +166,7 @@ function makeCardRenderer() {
       };
     },
   };
-  return { renderer, finalizeArgs, startArgs, whenFinalized };
+  return { renderer, finalizeArgs, startArgs, handleEvents, whenFinalized };
 }
 
 /** Minimal SessionStore fake — in-memory, records put() calls. */
@@ -670,7 +673,7 @@ describe("handleOne — thin-channel finalize", () => {
     expect(calls).toHaveLength(0);
   });
 
-  it("uses an injected post client for allowlisted post-only turns without starting a card", async () => {
+  it("keeps the in-progress card dynamic while using an injected post client for post-primary turns", async () => {
     const threadId = "om_msg";
     const finalState = {
       status: "ready",
@@ -688,6 +691,8 @@ describe("handleOne — thin-channel finalize", () => {
     runClaudeImpl = () => ({
       events: (async function* () {
         yield { type: "system_init", sessionId: "sess_surface_post_enabled", raw: {} };
+        yield { type: "tool_use", name: "exec_command", input: { cmd: "pnpm test" }, raw: {} };
+        yield { type: "text_delta", text: "正在跑测试", raw: {} };
         await writeFile(
           stateFileMod.stateFilePathOf(wt),
           JSON.stringify(finalState, null, 2),
@@ -698,7 +703,7 @@ describe("handleOne — thin-channel finalize", () => {
       kill: () => {},
     });
 
-    const { renderer, startArgs, finalizeArgs } = makeCardRenderer();
+    const { renderer, startArgs, finalizeArgs, handleEvents, whenFinalized } = makeCardRenderer();
     const { store } = makeSessionStore();
     const { client, acked } = makeClient(makeEvent());
 
@@ -735,13 +740,20 @@ describe("handleOne — thin-channel finalize", () => {
     });
 
     await handler.run();
+    await whenFinalized;
     for (let i = 0; i < 100 && acked.length === 0; i++) {
       await new Promise((r) => setTimeout(r, 10));
     }
 
     expect(acked).toEqual(["om_msg"]);
-    expect(startArgs).toHaveLength(0);
-    expect(finalizeArgs).toHaveLength(0);
+    expect(startArgs).toHaveLength(1);
+    expect(handleEvents.map((event) => (event as { type?: string }).type)).toEqual([
+      "system_init",
+      "tool_use",
+      "text_delta",
+    ]);
+    expect(finalizeArgs).toHaveLength(1);
+    expect(finalizeArgs[0]?.finalText).toContain("post_message_id: om_post");
     expect(calls).toHaveLength(1);
     expect(calls[0]?.replyToMessageId).toBe("om_msg");
     expect(calls[0]?.content).toContain("隔离配置走 post-only");
@@ -825,7 +837,7 @@ describe("handleOne — thin-channel finalize", () => {
     expect(await readPostFile(wt)).toBeNull();
   });
 
-  it("late-starts a visible fallback card before marking a failed post ledger fallback_visible", async () => {
+  it("finalizes a visible fallback card before marking a failed post ledger fallback_visible", async () => {
     const threadId = "om_msg";
     const finalState = {
       status: "ready",
@@ -907,7 +919,7 @@ describe("handleOne — thin-channel finalize", () => {
     expect(ledger?.posts[0]?.attempts[0]?.status).toBe("failed");
   });
 
-  it("late-starts a visible fallback card before marking an existing pending post ledger fallback_visible", async () => {
+  it("finalizes a visible fallback card before marking an existing pending post ledger fallback_visible", async () => {
     const threadId = "om_msg";
     const finalState = {
       status: "ready",
@@ -990,7 +1002,7 @@ describe("handleOne — thin-channel finalize", () => {
     expect(ledger?.posts[0]?.attempts[0]?.code).toBe("orphan_reconcile");
   });
 
-  it("late-starts a visible fallback card before marking a disallowed mention policy_blocked", async () => {
+  it("finalizes a visible fallback card before marking a disallowed mention policy_blocked", async () => {
     const threadId = "om_msg";
     const finalState = {
       status: "ready",

--- a/src/bridge/handler.ts
+++ b/src/bridge/handler.ts
@@ -1202,6 +1202,15 @@ export class BridgeHandler {
               : undefined,
           });
 
+          const postMessageId = surfaceDispatch.post?.messageId;
+          const shouldRecallProcessingCard =
+            !!postMessageId &&
+            prototypeConfig?.recall_processing_card_on_post_success !== false &&
+            !(
+              reportedState?.response_surface?.mode === "hybrid" &&
+              prototypeConfig?.retain_hybrid_audit_card !== false
+            );
+
           if (surfaceDispatch.card) {
             if (!card) {
               card = await this.deps.cardRenderer.start(messageId, { replyInThread, threadId });
@@ -1219,58 +1228,84 @@ export class BridgeHandler {
               }
             }
 
-            await card.finalize(surfaceDispatch.card);
-
-            let keepCardFileForRetry = false;
-            if (surfaceDispatch.post?.requiresFallbackLedgerMark) {
+            if (shouldRecallProcessingCard) {
+              let cardResolved = false;
               try {
-                await markPostLedgerFallbackVisible(
-                  worktreePath,
-                  surfaceDispatch.post.idempotencyKey,
-                  {
-                    fallbackCardMessageId: card.messageId,
-                    error:
-                      surfaceDispatch.post.fallbackError ??
-                      surfaceDispatch.card.failureReason ??
-                      "post outbound failed; visible card fallback used",
-                  },
-                );
+                await card.recall();
+                cardResolved = true;
               } catch (err) {
-                keepCardFileForRetry = true;
                 console.warn(
-                  "[bridge.handler] fallback ledger mark failed after visible card finalize; keeping card.json for retry:",
+                  "[bridge.handler] recall processing card after post success failed; keeping/finalizing card as fallback:",
                   err,
                 );
+                try {
+                  await card.finalize(surfaceDispatch.card);
+                  cardResolved = true;
+                } catch (finalizeErr) {
+                  console.warn(
+                    "[bridge.handler] finalize fallback after recall failure also failed; keeping card.json for retry:",
+                    finalizeErr,
+                  );
+                }
               }
-            }
-            if (surfaceDispatch.post?.requiresPolicyLedgerMark) {
-              try {
-                await markPostLedgerPolicyBlockedVisible(
-                  worktreePath,
-                  surfaceDispatch.post.idempotencyKey,
-                  {
-                    fallbackCardMessageId: card.messageId,
-                    error:
-                      surfaceDispatch.post.policyError ??
-                      surfaceDispatch.card.failureReason ??
-                      "mention policy blocked; visible card fallback used",
-                  },
-                );
-              } catch (err) {
-                keepCardFileForRetry = true;
-                console.warn(
-                  "[bridge.handler] policy-blocked ledger mark failed after visible card finalize; keeping card.json for retry:",
-                  err,
-                );
-              }
-            }
 
-            // Card was finalized successfully — drop its card.json so boot
-            // reconcile doesn't re-finalize an already-finalized card. If the
-            // post fallback/policy ledger mark failed, keep card.json so boot
-            // reconcile can retry association with the existing visible card.
-            if (!keepCardFileForRetry) {
-              await deleteCardFile(worktreePath);
+              if (cardResolved) {
+                await deleteCardFile(worktreePath);
+              }
+            } else {
+              await card.finalize(surfaceDispatch.card);
+
+              let keepCardFileForRetry = false;
+              if (surfaceDispatch.post?.requiresFallbackLedgerMark) {
+                try {
+                  await markPostLedgerFallbackVisible(
+                    worktreePath,
+                    surfaceDispatch.post.idempotencyKey,
+                    {
+                      fallbackCardMessageId: card.messageId,
+                      error:
+                        surfaceDispatch.post.fallbackError ??
+                        surfaceDispatch.card.failureReason ??
+                        "post outbound failed; visible card fallback used",
+                    },
+                  );
+                } catch (err) {
+                  keepCardFileForRetry = true;
+                  console.warn(
+                    "[bridge.handler] fallback ledger mark failed after visible card finalize; keeping card.json for retry:",
+                    err,
+                  );
+                }
+              }
+              if (surfaceDispatch.post?.requiresPolicyLedgerMark) {
+                try {
+                  await markPostLedgerPolicyBlockedVisible(
+                    worktreePath,
+                    surfaceDispatch.post.idempotencyKey,
+                    {
+                      fallbackCardMessageId: card.messageId,
+                      error:
+                        surfaceDispatch.post.policyError ??
+                        surfaceDispatch.card.failureReason ??
+                        "mention policy blocked; visible card fallback used",
+                    },
+                  );
+                } catch (err) {
+                  keepCardFileForRetry = true;
+                  console.warn(
+                    "[bridge.handler] policy-blocked ledger mark failed after visible card finalize; keeping card.json for retry:",
+                    err,
+                  );
+                }
+              }
+
+              // Card was finalized successfully — drop its card.json so boot
+              // reconcile doesn't re-finalize an already-finalized card. If the
+              // post fallback/policy ledger mark failed, keep card.json so boot
+              // reconcile can retry association with the existing visible card.
+              if (!keepCardFileForRetry) {
+                await deleteCardFile(worktreePath);
+              }
             }
           }
 

--- a/src/bridge/reconcile.test.ts
+++ b/src/bridge/reconcile.test.ts
@@ -177,6 +177,7 @@ function makeFakeRenderer(opts?: {
       messageId,
       finalizeArgs,
       handle: () => {},
+      recall: vi.fn(async () => {}) as unknown as CardHandle["recall"],
       finalize: vi.fn(async (a) => {
         finalizeArgs.push(a);
         if (opts?.rejectFinalize) throw new Error("PATCH 230001 not the sender");

--- a/src/bridge/surfaceController.test.ts
+++ b/src/bridge/surfaceController.test.ts
@@ -75,8 +75,8 @@ describe("SurfaceController", () => {
       visibleFallbackAvailable: true,
     });
 
-    expect(controller.shouldStartCardImmediately()).toBe(false);
-    expect(controller.decision.reason).toBe("lazy-card-ready");
+    expect(controller.shouldStartCardImmediately()).toBe(true);
+    expect(controller.decision.reason).toBe("dynamic-progress-card");
   });
 
   it("keeps card fallback when post outbound is disabled by config", () => {
@@ -146,7 +146,7 @@ describe("SurfaceController", () => {
     expect(controller.decision.reason).toBe("visible-fallback-unavailable-card-fallback");
   });
 
-  it("has a future lazy-ready path only when post outbound is available", () => {
+  it("keeps a dynamic progress card even when post outbound is available", () => {
     const controller = SurfaceController.create({
       prototypeConfig: postEnabledConfig,
       chatId: "chat_allowed",
@@ -156,7 +156,8 @@ describe("SurfaceController", () => {
       visibleFallbackAvailable: true,
     });
 
-    expect(controller.shouldStartCardImmediately()).toBe(false);
-    expect(controller.decision.reason).toBe("lazy-card-ready");
+    expect(controller.shouldStartCardImmediately()).toBe(true);
+    expect(controller.decision.reason).toBe("dynamic-progress-card");
+    expect(controller.decision.lazyCardCreationEnabled).toBe(true);
   });
 });

--- a/src/bridge/surfaceController.test.ts
+++ b/src/bridge/surfaceController.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import { SurfaceController } from "./surfaceController.js";
+import { defaultResponseSurfacePrototypeConfig } from "../responseSurface.js";
 
 const allowlistedConfig = {
+  ...defaultResponseSurfacePrototypeConfig(),
   enabled: true,
   allowed_chats: ["chat_allowed"],
   allowed_threads: [],
@@ -26,6 +28,7 @@ describe("SurfaceController", () => {
   it("keeps legacy eager card creation when the prototype is disabled", () => {
     const controller = SurfaceController.create({
       prototypeConfig: {
+        ...defaultResponseSurfacePrototypeConfig(),
         enabled: false,
         allowed_chats: [],
         allowed_threads: [],

--- a/src/bridge/surfaceController.ts
+++ b/src/bridge/surfaceController.ts
@@ -18,9 +18,10 @@ export interface SurfaceControllerInput {
 
 export interface SurfaceControllerDecision {
   /**
-   * Whether handler must create the legacy processing card before running the
-   * agent. PR4 production wiring keeps this true because post outbound remains
-   * unavailable.
+   * Whether handler must create the processing card before running the Agent.
+   * This stays true for live progress updates even when post/hybrid dispatch is
+   * available; final dispatch can still turn the card into a compact audit
+   * surface after the post succeeds.
    */
   startCardImmediately: boolean;
   prototypeEnabled: boolean;
@@ -34,7 +35,7 @@ export interface SurfaceControllerDecision {
     | "post-outbound-unavailable-card-fallback"
     | "post-ledger-unavailable-card-fallback"
     | "visible-fallback-unavailable-card-fallback"
-    | "lazy-card-ready";
+    | "dynamic-progress-card";
 }
 
 export class SurfaceController {
@@ -124,10 +125,10 @@ export class SurfaceController {
     }
 
     return new SurfaceController({
-      startCardImmediately: false,
+      startCardImmediately: true,
       prototypeEnabled: true,
       lazyCardCreationEnabled: true,
-      reason: "lazy-card-ready",
+      reason: "dynamic-progress-card",
     });
   }
 

--- a/src/bridge/surfaceDispatcher.test.ts
+++ b/src/bridge/surfaceDispatcher.test.ts
@@ -10,8 +10,10 @@ import {
 import { readPostFile, writePostFile } from "./postFile.js";
 import type { StateFile } from "./stateFile.js";
 import type { OutboundPostClient } from "../lark/outboundPostClient.js";
+import { defaultResponseSurfacePrototypeConfig } from "../responseSurface.js";
 
 const enabledConfig = {
+  ...defaultResponseSurfacePrototypeConfig(),
   enabled: true,
   allowed_chats: ["chat_allowed"],
   allowed_threads: [],

--- a/src/bridge/surfaceDispatcher.test.ts
+++ b/src/bridge/surfaceDispatcher.test.ts
@@ -58,6 +58,15 @@ function state(surface: NonNullable<StateFile["response_surface"]>, extra = {}):
   };
 }
 
+function stateWithoutSurface(extra = {}): StateFile {
+  return {
+    status: "ready",
+    last_message: "主回复正文",
+    updated_at: "2026-06-26T00:00:00.000Z",
+    ...extra,
+  };
+}
+
 function baseInput(overrides: Partial<SurfaceDispatchInput> = {}): SurfaceDispatchInput {
   return {
     state: state({ mode: "post", primary: "post" }),
@@ -152,6 +161,76 @@ describe("dispatchResponseSurface", () => {
       expect(ledger?.posts[0]?.status).toBe("sent");
       expect(ledger?.posts[0]?.postMessageId).toBe("om_post");
     }));
+
+  it("defaults an undeclared plain-text response to post when the prototype is enabled", async () =>
+    withTemp(async (dir) => {
+      const { client, calls } = fakePostClient();
+      const result = await dispatchResponseSurface(
+        baseInput({
+          worktreePath: dir,
+          state: stateWithoutSurface(),
+          cardStarted: true,
+          postClient: client,
+        }),
+      );
+
+      expect(result.reason).toBe("post-sent");
+      expect(result.visible).toBe(true);
+      expect(result.card?.finalText).toContain("post_message_id: om_post");
+      expect(result.post?.messageId).toBe("om_post");
+      expect(calls).toHaveLength(1);
+      expect(calls[0]?.content).toContain("主回复正文");
+
+      const ledger = await readPostFile(dir);
+      expect(ledger?.posts[0]?.status).toBe("sent");
+      expect(ledger?.posts[0]?.postMessageId).toBe("om_post");
+    }));
+
+  it("keeps undeclared card-only capabilities on the visible card path", async () =>
+    withTemp(async (dir) => {
+      const { client, calls } = fakePostClient();
+      const result = await dispatchResponseSurface(
+        baseInput({
+          worktreePath: dir,
+          state: stateWithoutSurface({
+            choices: [{ label: "继续", value: "继续处理" }],
+            image_blocks: [{ img_key: "img_fake", alt: "preview" }],
+            content_blocks: [{ type: "markdown", content: "富排版正文" }],
+          }),
+          baseCard: {
+            ...baseCard(),
+            choices: [{ label: "继续", value: "继续处理" }],
+            imageBlocks: [{ img_key: "img_fake", alt: "preview", mode: "fit_horizontal", preview: true }],
+            contentBlocks: [{ type: "markdown", content: "富排版正文" }],
+          },
+          cardStarted: true,
+          postClient: client,
+        }),
+      );
+
+      expect(result.reason).toBe("card-capability-required");
+      expect(result.visible).toBe(true);
+      expect(result.card?.choices).toEqual([{ label: "继续", value: "继续处理" }]);
+      expect(result.card?.contentBlocks).toEqual([{ type: "markdown", content: "富排版正文" }]);
+      expect(calls).toHaveLength(0);
+      expect(await readPostFile(dir)).toBeNull();
+    }));
+
+  it("keeps the visible card when an undeclared default post is unavailable", async () => {
+    const { client, calls } = fakePostClient();
+    const result = await dispatchResponseSurface(
+      baseInput({
+        state: stateWithoutSurface(),
+        postClient: client,
+        postOutboundAvailable: false,
+      }),
+    );
+
+    expect(result.reason).toBe("post-outbound-unavailable");
+    expect(result.card?.finalText).toBe("主回复正文");
+    expect(result.visible).toBe(true);
+    expect(calls).toHaveLength(0);
+  });
 
   it("does not resend when the same logical post is already marked sent", async () =>
     withTemp(async (dir) => {

--- a/src/bridge/surfaceDispatcher.ts
+++ b/src/bridge/surfaceDispatcher.ts
@@ -110,6 +110,15 @@ function hasCardOnlyPayload(state: StateFile | null): boolean {
   );
 }
 
+function hasCardOnlyPayloadIn(input: SurfaceDispatchInput): boolean {
+  return !!(
+    hasCardOnlyPayload(input.state) ||
+    input.baseCard.choices?.length ||
+    input.baseCard.imageBlocks?.length ||
+    input.baseCard.contentBlocks?.length
+  );
+}
+
 function compactAuditCard(
   input: SurfaceDispatchInput,
   post: { idempotencyKey: string; messageId: string },
@@ -284,10 +293,15 @@ function emitSurfaceObservation(input: {
 async function dispatchResponseSurfaceInner(
   input: SurfaceDispatchInput,
 ): Promise<SurfaceDispatchResult> {
-  const surface = input.state?.response_surface;
-  if (!surface || surface.mode === "card" || surface.primary === "card") {
+  const declaredSurface = input.state?.response_surface;
+  if (declaredSurface?.mode === "card" || declaredSurface?.primary === "card") {
     return fullCard(input, "legacy-card-mode");
   }
+  if (!declaredSurface && hasCardOnlyPayloadIn(input)) {
+    return fullCard(input, "card-capability-required");
+  }
+  const surface: NonNullable<StateFile["response_surface"]> =
+    declaredSurface ?? { mode: "post", primary: "post" };
 
   const cfg = input.prototypeConfig;
   if (!cfg?.enabled) return fullCard(input, "prototype-disabled");
@@ -309,7 +323,7 @@ async function dispatchResponseSurfaceInner(
   if (!input.visibleFallbackAvailable) {
     return fullCard(input, "visible-fallback-unavailable");
   }
-  if (hasCardOnlyPayload(input.state)) {
+  if (hasCardOnlyPayloadIn(input)) {
     return fullCard(input, "card-capability-required");
   }
   if (!input.postLedgerAvailable || !input.worktreePath) {

--- a/src/config/botLoader.test.ts
+++ b/src/config/botLoader.test.ts
@@ -545,7 +545,7 @@ read_only: false
     expect(bots[0]?.read_only).toBe(false);
   });
 
-  it("response_surface_prototype defaults post surfaces on but mentions off", async () => {
+  it("response_surface_prototype defaults post surfaces and agent-authored mentions on", async () => {
     await createBotsDir();
     await writeYaml(
       "surface-default.yaml",
@@ -570,6 +570,8 @@ bot_open_id: ou_surface_default
       post_outbound_enabled: true,
       allow_agent_mentions: true,
       allowed_mention_open_ids: [],
+      recall_processing_card_on_post_success: true,
+      retain_hybrid_audit_card: true,
       max_posts_per_turn: 1,
       max_posts_per_window: 4,
       post_window_ms: 60_000,
@@ -605,6 +607,8 @@ response_surface_prototype:
   max_posts_per_window: 7
   post_window_ms: 30000
   max_post_attempts: 2
+  recall_processing_card_on_post_success: false
+  retain_hybrid_audit_card: false
   text_threshold_chars: 900
 `,
     );
@@ -620,6 +624,8 @@ response_surface_prototype:
       post_outbound_enabled: true,
       allow_agent_mentions: false,
       allowed_mention_open_ids: ["surface_peer"],
+      recall_processing_card_on_post_success: false,
+      retain_hybrid_audit_card: false,
       max_posts_per_turn: 2,
       max_posts_per_window: 7,
       post_window_ms: 30_000,

--- a/src/lark/card.test.ts
+++ b/src/lark/card.test.ts
@@ -17,6 +17,7 @@ import { describe, it, expect, vi } from "vitest";
 
 class FakeOutbound {
   readonly patchCalls: Array<{ messageId: string; cardJson: string }> = [];
+  readonly recallCalls: string[] = [];
   createCalls: Array<{ replyTo: string; cardJson: string; replyInThread: boolean }> = [];
   /** When set, patchCard rejects with this error (simulates a failing send). */
   patchError: Error | null = null;
@@ -37,6 +38,10 @@ class FakeOutbound {
   async patchCard(messageId: string, cardJson: string): Promise<void> {
     if (this.patchError) throw this.patchError;
     this.patchCalls.push({ messageId, cardJson });
+  }
+
+  async recallCard(messageId: string): Promise<void> {
+    this.recallCalls.push(messageId);
   }
 }
 
@@ -168,6 +173,53 @@ describe("CardRenderer.start() — replyInThread (Phase 4)", () => {
     await renderer.start("om_user_msg", { replyInThread: false });
 
     expect(fake.createCalls[0]!.replyInThread).toBe(false);
+  });
+});
+
+describe("CardHandle.recall()", () => {
+  it("recalls the created card message and suppresses later live patches", async () => {
+    const { CardRenderer } = await import("./card.js");
+    const fake = new FakeOutbound();
+    const renderer = new CardRenderer({
+      outbound: fake,
+      patchIntervalMs: 10_000,
+      botName: "Frontend",
+    });
+    const handle = await renderer.start("om_user_msg");
+
+    handle.handle({
+      type: "text_delta",
+      text: "partial answer",
+      raw: { message: { id: "msg_1" } },
+    });
+    await handle.recall();
+    handle.handle({
+      type: "text_delta",
+      text: "should not patch after recall",
+      raw: { message: { id: "msg_1" } },
+    });
+
+    expect(fake.recallCalls).toEqual(["om_test123"]);
+    expect(fake.patchCalls.length).toBeGreaterThanOrEqual(1);
+    const lastPatch = lastPatchedCard(fake);
+    expect(lastPatch?.header?.title?.content).toBe("🔧 处理中");
+  });
+
+  it("throws when the outbound transport cannot recall cards", async () => {
+    const { CardRenderer } = await import("./card.js");
+    const outboundWithoutRecall = {
+      async createCard() {
+        return { messageId: "om_test123" };
+      },
+      async patchCard() {},
+    };
+    const renderer = new CardRenderer({
+      outbound: outboundWithoutRecall,
+      patchIntervalMs: 10_000,
+    });
+    const handle = await renderer.start("om_user_msg");
+
+    await expect(handle.recall()).rejects.toThrow(/does not support recallCard/);
   });
 });
 

--- a/src/lark/card.ts
+++ b/src/lark/card.ts
@@ -95,6 +95,13 @@ export interface CardHandle {
      */
     contentBlocks?: ContentBlock[];
   }): Promise<void>;
+
+  /**
+   * Recall the card message. Used after a primary post succeeds so the transient
+   * progress card does not remain as a duplicate response. May throw; callers
+   * must treat this as best-effort because the post is already visible.
+   */
+  recall(): Promise<void>;
 }
 
 // ---------------------------------------------------------------------------
@@ -705,6 +712,21 @@ class CardHandleImpl implements CardHandle {
     // the final exception to the caller after maxAttempts so handler.ts
     // can surface it. Reused logic mirrors live patches.
     await this.livePatchWithRetry(cardJsonStr, /*throwOnFinalFail*/ true);
+  }
+
+  async recall(): Promise<void> {
+    this.finalized = true;
+
+    if (this.state.pendingPatch !== null) {
+      clearTimeout(this.state.pendingPatch);
+      this.state.pendingPatch = null;
+    }
+
+    await this.drainLivePatches();
+    if (!this.outbound.recallCard) {
+      throw new Error("[lark.card] outbound client does not support recallCard");
+    }
+    await this.outbound.recallCard(this.messageId);
   }
 
   // ── Private: accumulate ───────────────────────────────────────────────────

--- a/src/lark/channelCardClient.test.ts
+++ b/src/lark/channelCardClient.test.ts
@@ -10,6 +10,7 @@
  *  - createCard records messageId -> replyTo(threadId) in the shared map.
  *  - BL-16: createCard retries on socket hang up (with same uuid for idempotency).
  *  - BL-16: patchCard retries on socket hang up (PATCH is idempotent).
+ *  - recallCard recalls the created card message and removes its thread route.
  */
 import { describe, it, expect } from "vitest";
 import { ChannelCardClient, type OutboundLarkChannel } from "./channelCardClient.js";
@@ -24,6 +25,9 @@ interface ReplyCall {
   msg_type: string;
   reply_in_thread?: boolean;
 }
+interface DeleteCall {
+  message_id: string;
+}
 
 const messageReactionStub = {
   async create() {
@@ -36,6 +40,7 @@ const messageReactionStub = {
 function fakeChannel(replyMessageId: string | undefined) {
   const updateCardCalls: UpdateCardCall[] = [];
   const replyCalls: (ReplyCall & { uuid?: string })[] = [];
+  const deleteCalls: DeleteCall[] = [];
   const channel: OutboundLarkChannel = {
     async updateCard(messageId, card) {
       updateCardCalls.push({ messageId, card });
@@ -54,13 +59,16 @@ function fakeChannel(replyMessageId: string | undefined) {
               });
               return { data: replyMessageId ? { message_id: replyMessageId } : {} };
             },
+            async delete(payload) {
+              deleteCalls.push({ message_id: payload.path.message_id });
+            },
           },
           messageReaction: messageReactionStub,
         },
       },
     },
   };
-  return { channel, updateCardCalls, replyCalls };
+  return { channel, updateCardCalls, replyCalls, deleteCalls };
 }
 
 /**
@@ -73,6 +81,7 @@ function flakyChannel(
   const { replyMessageId = "om_created", replyFailCount = 1, updateCardFailCount = 1 } = opts;
   const replyCalls: (ReplyCall & { uuid?: string })[] = [];
   const updateCardCalls: UpdateCardCall[] = [];
+  const deleteCalls: DeleteCall[] = [];
   let replyAttempts = 0;
   let updateAttempts = 0;
 
@@ -104,13 +113,16 @@ function flakyChannel(
               });
               return { data: { message_id: replyMessageId } };
             },
+            async delete(payload) {
+              deleteCalls.push({ message_id: payload.path.message_id });
+            },
           },
           messageReaction: messageReactionStub,
         },
       },
     },
   };
-  return { channel, replyCalls, updateCardCalls, get replyAttempts() { return replyAttempts; }, get updateAttempts() { return updateAttempts; } };
+  return { channel, replyCalls, updateCardCalls, deleteCalls, get replyAttempts() { return replyAttempts; }, get updateAttempts() { return updateAttempts; } };
 }
 
 describe("ChannelCardClient.patchCard", () => {
@@ -238,6 +250,30 @@ describe("ChannelCardClient.createCard", () => {
   });
 });
 
+describe("ChannelCardClient.recallCard", () => {
+  it("recalls the card message and removes its card-thread route", async () => {
+    const { channel, deleteCalls } = fakeChannel("om_created");
+    const cardThreads = new Map<string, string>([["om_created", "om_root"]]);
+    const client = new ChannelCardClient({ resolveChannel: () => channel, cardThreads });
+
+    await client.recallCard("om_created");
+
+    expect(deleteCalls).toEqual([{ message_id: "om_created" }]);
+    expect(cardThreads.has("om_created")).toBe(false);
+  });
+
+  it("throws when called before the channel is connected", async () => {
+    const client = new ChannelCardClient({
+      resolveChannel: () => null,
+      cardThreads: new Map(),
+    });
+
+    await expect(client.recallCard("om_card")).rejects.toThrow(
+      /before the Channel SDK connected/,
+    );
+  });
+});
+
 // ---------------------------------------------------------------------------
 // BL-16: retry tests for createCard and patchCard
 // ---------------------------------------------------------------------------
@@ -276,7 +312,7 @@ describe("ChannelCardClient.createCard — retry on socket hang up (BL-16)", () 
             attempts++;
             if (attempts < 3) throw new Error("socket hang up");
             return { data: { message_id: "om_created" } };
-          } },
+          }, async delete() {} },
           messageReaction: messageReactionStub,
         } },
       },

--- a/src/lark/channelCardClient.ts
+++ b/src/lark/channelCardClient.ts
@@ -124,6 +124,9 @@ export interface OutboundLarkChannel {
             path: { message_id: string };
             data: { content: string; msg_type: string; reply_in_thread?: boolean; uuid?: string };
           }): Promise<RawReplyResult>;
+          delete(payload: {
+            path: { message_id: string };
+          }): Promise<void>;
         };
         messageReaction: {
           create(payload: {
@@ -295,5 +298,19 @@ export class ChannelCardClient implements OutboundCardClient {
     // so retrying on transient transport errors (socket hang up / ETIMEDOUT) is
     // always safe. Wrap in withRetry before calling the SDK's updateCard.
     await withRetry("patchCard", () => this.channel().updateCard(messageId, card));
+  }
+
+  /**
+   * Recall an interactive card message. This is used after a primary post reply
+   * has already been sent successfully; callers treat failures as best-effort so
+   * recall never creates an invisible reply.
+   */
+  async recallCard(messageId: string): Promise<void> {
+    await withRetry("recallCard", () =>
+      this.channel().rawClient.im.v1.message.delete({
+        path: { message_id: messageId },
+      }),
+    );
+    this.cardThreads.delete(messageId);
   }
 }

--- a/src/lark/outboundCardClient.ts
+++ b/src/lark/outboundCardClient.ts
@@ -1,9 +1,10 @@
 /**
  * src/lark/outboundCardClient.ts
  *
- * Transport-neutral abstraction for the two OUTBOUND card network calls:
+ * Transport-neutral abstraction for the OUTBOUND card network calls:
  *   - createCard  → create the initial interactive card (reply to user msg)
  *   - patchCard   → update an existing card's content
+ *   - recallCard  → best-effort revoke of a card message after a post succeeds
  *
  * card.ts owns all card-JSON building + throttle/retry orchestration; it only
  * delegates the leaf network call to an OutboundCardClient. The sole
@@ -39,4 +40,10 @@ export interface OutboundCardClient {
    * @param cardJson   Stringified Card JSON 2.0 (already built by card.ts).
    */
   patchCard(messageId: string, cardJson: string): Promise<void>;
+
+  /**
+   * Recall/delete a card message. Used only after a primary post has been sent
+   * successfully, so failure is handled by the caller as a best-effort cleanup.
+   */
+  recallCard?(messageId: string): Promise<void>;
 }

--- a/src/responseSurface.test.ts
+++ b/src/responseSurface.test.ts
@@ -25,6 +25,8 @@ describe("response surface production gates", () => {
       allowed_chats: [],
       allowed_threads: [],
       allowed_mention_open_ids: [],
+      recall_processing_card_on_post_success: true,
+      retain_hybrid_audit_card: true,
       max_posts_per_turn: 1,
       max_posts_per_window: 4,
       post_window_ms: 60_000,

--- a/src/responseSurface.ts
+++ b/src/responseSurface.ts
@@ -12,6 +12,8 @@ export function defaultResponseSurfacePrototypeConfig() {
     post_outbound_enabled: true,
     allow_agent_mentions: true,
     allowed_mention_open_ids: [] as string[],
+    recall_processing_card_on_post_success: true,
+    retain_hybrid_audit_card: true,
     max_posts_per_turn: 1,
     max_posts_per_window: 4,
     post_window_ms: 60_000,
@@ -31,6 +33,8 @@ const responseSurfacePrototypeConfigDefaults = () => ({
   post_outbound_enabled: true,
   allow_agent_mentions: true,
   allowed_mention_open_ids: [] as string[],
+  recall_processing_card_on_post_success: true,
+  retain_hybrid_audit_card: true,
   max_posts_per_turn: 1,
   max_posts_per_window: 4,
   post_window_ms: 60_000,
@@ -138,6 +142,18 @@ export const ResponseSurfacePrototypeConfigSchema = z
      * Keep real IDs in private bot config, never in public docs/tests.
      */
     allowed_mention_open_ids: z.array(z.string().min(1)).default([]),
+    /**
+     * When a primary post has been sent successfully, recall the live processing
+     * card so the final visible surface is the post rather than post + duplicate
+     * card. Recall is best-effort; failure leaves/finalizes the card.
+     */
+    recall_processing_card_on_post_success: z.boolean().default(true),
+    /**
+     * Hybrid mode may keep the already-visible card as a compact audit surface
+     * after the primary post succeeds. Operators can turn this off to recall that
+     * card as well, leaving only the post.
+     */
+    retain_hybrid_audit_card: z.boolean().default(true),
     /**
      * Hard cap for surface dispatch. PR4 still keeps production post outbound
      * unavailable, but fake-channel dispatch tests enforce this bounded shape.


### PR DESCRIPTION
## Summary

Fixes the 0.3.20 regression where the in-progress "processing" card no longer updated while tools were running, makes the default-on response surface actually default plain replies to post, and recalls the transient processing card after a visible post succeeds.

## Root Cause

- `c90b7f8` introduced gated post-client runtime wiring and allowed the post-ready branch to skip eager card creation when `lazy_card_creation=true`.
- `handler.ts` streams tool/progress events only through the live card handle, so no live card means no mid-turn PATCH/progress updates.
- `fe58405` / 0.3.20 flipped response surface defaults on, which made that latent post-ready branch common in production.
- A second gap remained in `surfaceDispatcher.ts`: when agents did not explicitly write `response_surface`, the dispatcher treated the reply as legacy card. Default-on enabled the post gates, but did not default the reply shape to post.

## Changes

- Keep the visible processing card eager and dynamic even when post/hybrid dispatch is enabled.
- Default an undeclared, plain-text reply to post when the response surface prototype is enabled.
- Keep undeclared card-only replies on the card path when they include choices/buttons, image blocks, or rich content blocks.
- Preserve explicit agent overrides: declared `mode: card`, `mode: post`, and hybrid behavior still win.
- Add `CardHandle.recall()` plus Feishu channel recall wiring so a successful visible post can remove the transient processing card.
- Only recall the processing card after the post ledger is `sent` / visible. Post unavailable, post failure, policy block, rate limit, kill-switch, and card-only capability paths keep a visible card fallback.
- Add config switches for recall behavior and hybrid audit-card retention.
- Update response-surface docs to describe dynamic progress cards, default plain-text post behavior, and card-only fallback cases.

## Safety

- No invisible reply path: post failure/unavailable/policy/rate-limit/kill-switch all retain or finalize a visible card.
- Recall failure is non-fatal: if the processing card cannot be recalled, it remains visible.
- Card-only features remain card-only by default.
- Default-on, auto-@, @all blocking, send budgets, kill-switch, and orphan-reconcile invariants are preserved.
- No hardcoded real Feishu IDs, no production config changes, no deploy/restart, no real test sends.

## Verification

- `pnpm vitest run src/bridge/surfaceController.test.ts src/bridge/handler.test.ts src/bridge/surfaceDispatcher.test.ts src/responseSurface.test.ts` => 4 files / 56 tests passed.
- `pnpm vitest run src/bridge/handler.test.ts src/bridge/surfaceDispatcher.test.ts src/lark/channelCardClient.test.ts` => 3 files / 58 tests passed.
- `pnpm vitest run src/bridge/surfaceDispatcher.test.ts src/bridge/handler.test.ts src/bridge/reconcile.test.ts src/bridge/surfaceController.test.ts src/lark/card.test.ts src/lark/channelCardClient.test.ts src/responseSurface.test.ts src/config/botLoader.test.ts` => 8 files / 163 tests passed.
- `pnpm vitest run src/bridge/surfaceDispatcher.test.ts src/bridge/handler.test.ts` => 2 files / 48 tests passed.
- `pnpm typecheck` => passed.
- `env -u LARKWAY_HOME pnpm test` => 49 files / 800 tests passed.
- `git diff --check` => clean.
- Added-line scan for Feishu/profile IDs and token/secret patterns => no matches.
- GitHub PR CI => 2x SUCCESS on head `2f2745b27a68e8f66859edce78a3310e30603506`.
