### PR TITLE
Fix CardKit readback and add session heartbeat

### DIFF
--- a/src/bridge/eventLog.ts
+++ b/src/bridge/eventLog.ts
@@ -20,6 +20,7 @@ export type RuntimeEventTrigger =
   | "mention"
   | "thread_reply"
   | "card_action"
+  | "session_heartbeat"
   | "gap_fill"
   | "unknown";
 

--- a/src/bridge/handler.ts
+++ b/src/bridge/handler.ts
@@ -713,6 +713,17 @@ export class BridgeHandler {
     // Step 1: parse
     const parsed = parseMessage(event);
     const { threadId, messageId, senderOpenId } = parsed;
+    const isInternalHeartbeat =
+      parsed.raw["larkway_internal_trigger"] === "session_heartbeat";
+    const replyTargetMessageId =
+      typeof parsed.raw["reply_to_message_id"] === "string" &&
+      parsed.raw["reply_to_message_id"].length > 0
+        ? parsed.raw["reply_to_message_id"]
+        : messageId;
+    const removeProcessingReaction = async (): Promise<void> => {
+      if (isInternalHeartbeat) return;
+      await this.deps.client.removeProcessingReaction?.(messageId);
+    };
     const botId = this.deps.botConfig?.id;
     const eventLogId = messageId;
     const eventStartedAt = Date.now();
@@ -724,8 +735,9 @@ export class BridgeHandler {
         console.warn("[bridge.handler] recordRuntimeEvent failed (continuing):", err);
       }
     };
-    const triggerType =
-      typeof parsed.raw.root_id === "string" && parsed.raw.root_id
+    const triggerType = isInternalHeartbeat
+      ? "session_heartbeat"
+      : typeof parsed.raw.root_id === "string" && parsed.raw.root_id
         ? "thread_reply"
         : "mention";
     await recordEvent({
@@ -742,7 +754,9 @@ export class BridgeHandler {
       statusPath: ["已收到"],
       reason: "已进入 bridge，准备创建处理卡片。",
     });
-    await this.deps.client.addProcessingReaction?.(messageId);
+    if (!isInternalHeartbeat) {
+      await this.deps.client.addProcessingReaction?.(messageId);
+    }
 
     // Step 2: session lookup — determines is_new_thread.
     const existing = this.deps.sessionStore.get(threadId, botId);
@@ -780,7 +794,7 @@ export class BridgeHandler {
     let progressPostStartFailed = false;
     if (!cardKitAvailable && surfaceController.shouldStartCardImmediately()) {
       try {
-        card = await this.deps.cardRenderer.start(messageId, { replyInThread, threadId });
+        card = await this.deps.cardRenderer.start(replyTargetMessageId, { replyInThread, threadId });
         await recordEvent({
           status: "running",
           startedAt: new Date().toISOString(),
@@ -798,7 +812,7 @@ export class BridgeHandler {
         // Without a card we can still run Claude, but operator won't see output.
         // Proceed — sessionStore still needs updating.
       } finally {
-        await this.deps.client.removeProcessingReaction?.(messageId);
+        await removeProcessingReaction();
       }
     } else {
       await recordEvent({
@@ -1048,7 +1062,7 @@ export class BridgeHandler {
         try {
           cardKitProgress = await createCardKitProgressHandle({
             cardKitClient: this.deps.cardKitClient,
-            replyToMessageId: messageId,
+            replyToMessageId: replyTargetMessageId,
             replyInThread,
             facts: {
               botId: this.deps.botConfig?.id ?? "v1-default",
@@ -1066,7 +1080,7 @@ export class BridgeHandler {
             status: "message_sent",
             cardId: cardKitProgress.cardId,
             messageId: cardKitProgress.messageId,
-            replyToMessageId: messageId,
+            replyToMessageId: replyTargetMessageId,
             chatId: parsed.chatId,
             threadId,
             botId: this.deps.botConfig?.id ?? "",
@@ -1085,7 +1099,7 @@ export class BridgeHandler {
             updatedAt: new Date().toISOString(),
           };
           await writeCardKitFile(worktreePath, cardKitRecord);
-          await this.deps.client.removeProcessingReaction?.(messageId);
+          await removeProcessingReaction();
           await recordEvent({
             status: "running",
             startedAt: new Date().toISOString(),
@@ -1096,7 +1110,7 @@ export class BridgeHandler {
           const existingMessageId = cardKitReplyConversionMessageId(err);
           if (existingMessageId) {
             card = this.deps.cardRenderer.handleFor(existingMessageId);
-            await this.deps.client.removeProcessingReaction?.(messageId);
+            await removeProcessingReaction();
             await recordEvent({
               status: "running",
               startedAt: new Date().toISOString(),
@@ -1135,7 +1149,7 @@ export class BridgeHandler {
           try {
             progressPost = await createPostProgressHandle({
               postClient: this.deps.postClient,
-              replyToMessageId: messageId,
+              replyToMessageId: replyTargetMessageId,
               replyInThread,
               facts: {
                 botId: this.deps.botConfig?.id ?? "v1-default",
@@ -1144,7 +1158,7 @@ export class BridgeHandler {
               },
               initialText: "努力回答中...",
             });
-            await this.deps.client.removeProcessingReaction?.(messageId);
+            await removeProcessingReaction();
             await recordEvent({
               status: "running",
               startedAt: new Date().toISOString(),
@@ -1160,8 +1174,8 @@ export class BridgeHandler {
 
       if (!card && (progressPostStartFailed || cardKitStartFailed)) {
         try {
-          card = await this.deps.cardRenderer.start(messageId, { replyInThread, threadId });
-          await this.deps.client.removeProcessingReaction?.(messageId);
+          card = await this.deps.cardRenderer.start(replyTargetMessageId, { replyInThread, threadId });
+          await removeProcessingReaction();
           await recordEvent({
             status: "running",
             startedAt: new Date().toISOString(),
@@ -1177,7 +1191,7 @@ export class BridgeHandler {
           );
           await createOnlyPostFallback({
             postClient: this.deps.postClient,
-            replyToMessageId: messageId,
+            replyToMessageId: replyTargetMessageId,
             replyInThread,
             botId: this.deps.botConfig?.id ?? "v1-default",
             threadId,
@@ -1189,7 +1203,7 @@ export class BridgeHandler {
             title: "Larkway fallback",
             logPrefix: "[bridge.handler]",
           });
-          await this.deps.client.removeProcessingReaction?.(messageId);
+          await removeProcessingReaction();
           await recordEvent({
             status: "running",
             startedAt: new Date().toISOString(),
@@ -1374,6 +1388,7 @@ export class BridgeHandler {
               botId,
               createdTs: now,
               lastActiveTs: now,
+              chatId: parsed.chatId,
               senderOpenId,
             });
           } else if (sessionId !== undefined && currentExisting !== undefined) {
@@ -1384,6 +1399,7 @@ export class BridgeHandler {
               botId,
               createdTs: currentExisting.createdTs,
               lastActiveTs: now,
+              chatId: parsed.chatId,
               senderOpenId,
             });
           } else if (currentExisting !== undefined && sessionId === undefined) {
@@ -1391,6 +1407,7 @@ export class BridgeHandler {
             await this.deps.sessionStore.put({
               ...currentExisting,
               lastActiveTs: now,
+              chatId: parsed.chatId,
             });
           }
 
@@ -1503,7 +1520,7 @@ export class BridgeHandler {
               console.warn("[bridge.handler] CardKit finalize failed; using card fallback:", err);
               cardKitProgress.close();
               try {
-                card = await this.deps.cardRenderer.start(messageId, { replyInThread, threadId });
+                card = await this.deps.cardRenderer.start(replyTargetMessageId, { replyInThread, threadId });
                 await writeCardFile(worktreePath, {
                   messageId: card.messageId,
                   chatId: parsed.chatId,
@@ -1528,7 +1545,7 @@ export class BridgeHandler {
               } catch (legacyErr) {
                 const postFallback = await createOnlyPostFallback({
                   postClient: this.deps.postClient,
-                  replyToMessageId: messageId,
+                  replyToMessageId: replyTargetMessageId,
                   replyInThread,
                   botId: this.deps.botConfig?.id ?? "v1-default",
                   threadId,
@@ -1559,7 +1576,7 @@ export class BridgeHandler {
               chatId: parsed.chatId,
               threadId,
               triggerMessageId: messageId,
-              replyToMessageId: messageId,
+              replyToMessageId: replyTargetMessageId,
               replyInThread,
             },
             worktreePath,
@@ -1594,7 +1611,7 @@ export class BridgeHandler {
 
           if (surfaceDispatch.card) {
             if (!card) {
-              card = await this.deps.cardRenderer.start(messageId, { replyInThread, threadId });
+              card = await this.deps.cardRenderer.start(replyTargetMessageId, { replyInThread, threadId });
               try {
                 await writeCardFile(worktreePath, {
                   messageId: card.messageId,
@@ -1703,7 +1720,7 @@ export class BridgeHandler {
       }
     } catch (err) {
       console.error("[bridge.handler] handleOne failed for thread", threadId, err);
-      await this.deps.client.removeProcessingReaction?.(messageId);
+      await removeProcessingReaction();
       await recordEvent({
         status: "failed",
         finishedAt: new Date().toISOString(),
@@ -1729,7 +1746,7 @@ export class BridgeHandler {
       const createHardFailurePostFallback = async (failureReason: string) => {
         const fallback = await createOnlyPostFallback({
           postClient: this.deps.postClient,
-          replyToMessageId: messageId,
+          replyToMessageId: replyTargetMessageId,
           replyInThread,
           botId: this.deps.botConfig?.id ?? "v1-default",
           threadId,
@@ -1757,7 +1774,7 @@ export class BridgeHandler {
             cardKitFinalizeErr,
           );
           try {
-            card = await this.deps.cardRenderer.start(messageId, { replyInThread, threadId });
+            card = await this.deps.cardRenderer.start(replyTargetMessageId, { replyInThread, threadId });
           } catch (cardStartErr) {
             console.error("[bridge.handler] failure card start also failed:", cardStartErr);
             await createHardFailurePostFallback(
@@ -1778,7 +1795,7 @@ export class BridgeHandler {
             postFinalizeErr,
           );
           try {
-            card = await this.deps.cardRenderer.start(messageId, { replyInThread, threadId });
+            card = await this.deps.cardRenderer.start(replyTargetMessageId, { replyInThread, threadId });
           } catch (cardStartErr) {
             console.error("[bridge.handler] failure card start also failed:", cardStartErr);
             await createHardFailurePostFallback(

--- a/src/bridge/sessionHeartbeat.test.ts
+++ b/src/bridge/sessionHeartbeat.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_SESSION_HEARTBEAT_CONFIG,
+  buildSessionHeartbeatEvent,
+  selectDueSessionHeartbeats,
+} from "./sessionHeartbeat.js";
+import type { SessionRecord } from "../claude/sessionStore.js";
+
+const NOW = 1_000_000;
+
+function record(overrides: Partial<SessionRecord> = {}): SessionRecord {
+  return {
+    threadId: "om_thread",
+    sessionId: "sess",
+    botId: "elon",
+    chatId: "oc_chat",
+    createdTs: 1,
+    lastActiveTs: NOW - 31 * 60 * 1000,
+    ...overrides,
+  };
+}
+
+describe("selectDueSessionHeartbeats", () => {
+  const config = {
+    ...DEFAULT_SESSION_HEARTBEAT_CONFIG,
+    enabled: true,
+    idle_after_ms: 30 * 60 * 1000,
+    active_within_ms: 24 * 60 * 60 * 1000,
+    max_sessions_per_tick: 2,
+  };
+
+  it("selects idle, recently active sessions for the requested bot", () => {
+    const due = selectDueSessionHeartbeats(
+      [
+        record({ threadId: "om_due_2", lastActiveTs: NOW - 40 * 60 * 1000 }),
+        record({ threadId: "om_fresh", lastActiveTs: NOW - 10 * 60 * 1000 }),
+        record({ threadId: "om_other_bot", botId: "turing" }),
+        record({ threadId: "om_no_chat", chatId: undefined }),
+        record({ threadId: "om_due_1", lastActiveTs: NOW - 50 * 60 * 1000 }),
+      ],
+      config,
+      NOW,
+      "elon",
+    );
+
+    expect(due.map((item) => item.threadId)).toEqual(["om_due_1", "om_due_2"]);
+  });
+
+  it("does not select anything when disabled", () => {
+    expect(
+      selectDueSessionHeartbeats(
+        [record()],
+        { ...config, enabled: false },
+        NOW,
+        "elon",
+      ),
+    ).toEqual([]);
+  });
+
+  it("skips sessions outside the active window", () => {
+    const due = selectDueSessionHeartbeats(
+      [record({ threadId: "om_old", lastActiveTs: NOW - 25 * 60 * 60 * 1000 })],
+      config,
+      NOW,
+      "elon",
+    );
+
+    expect(due).toEqual([]);
+  });
+});
+
+describe("buildSessionHeartbeatEvent", () => {
+  it("builds an internal trigger addressed back to the session root", () => {
+    const event = buildSessionHeartbeatEvent({
+      record: record({ threadId: "om_thread_root" }),
+      botOpenId: "ou_elon_bot",
+      nowMs: NOW,
+    });
+
+    expect(event).toMatchObject({
+      chat_id: "oc_chat",
+      thread_id: "om_thread_root",
+      root_id: "om_thread_root",
+      sender_id: "ou_elon_bot",
+      larkway_internal_trigger: "session_heartbeat",
+      reply_to_message_id: "om_thread_root",
+    });
+    expect(event?.message_id).toContain("larkway_heartbeat_elon_om_thread_root");
+    expect(JSON.parse(event?.content ?? "{}").text).toContain("定时巡查触发");
+  });
+
+  it("returns null when the record has no chatId", () => {
+    expect(
+      buildSessionHeartbeatEvent({
+        record: record({ chatId: undefined }),
+        botOpenId: "ou_elon_bot",
+        nowMs: NOW,
+      }),
+    ).toBeNull();
+  });
+});

--- a/src/bridge/sessionHeartbeat.ts
+++ b/src/bridge/sessionHeartbeat.ts
@@ -1,0 +1,69 @@
+import type { SessionRecord } from "../claude/sessionStore.js";
+import type { LarkMessageEvent } from "../lark/transport.js";
+
+export interface SessionHeartbeatConfig {
+  enabled: boolean;
+  interval_ms: number;
+  idle_after_ms: number;
+  active_within_ms: number;
+  max_sessions_per_tick: number;
+}
+
+export const DEFAULT_SESSION_HEARTBEAT_CONFIG: SessionHeartbeatConfig = {
+  enabled: false,
+  interval_ms: 30 * 60 * 1000,
+  idle_after_ms: 30 * 60 * 1000,
+  active_within_ms: 24 * 60 * 60 * 1000,
+  max_sessions_per_tick: 3,
+};
+
+export function selectDueSessionHeartbeats(
+  records: readonly SessionRecord[],
+  config: SessionHeartbeatConfig,
+  nowMs: number,
+  botId?: string,
+): SessionRecord[] {
+  if (!config.enabled) return [];
+  return records
+    .filter((record) => (botId ? record.botId === botId : true))
+    .filter((record) => typeof record.chatId === "string" && record.chatId.length > 0)
+    .filter((record) => nowMs - record.lastActiveTs >= config.idle_after_ms)
+    .filter((record) => nowMs - record.lastActiveTs <= config.active_within_ms)
+    .sort((a, b) => a.lastActiveTs - b.lastActiveTs)
+    .slice(0, config.max_sessions_per_tick);
+}
+
+function safeIdSegment(value: string): string {
+  return value.replace(/[^A-Za-z0-9_-]/g, "_").slice(0, 80);
+}
+
+export function buildSessionHeartbeatEvent(input: {
+  record: SessionRecord;
+  botOpenId: string;
+  nowMs: number;
+}): LarkMessageEvent | null {
+  const { record, botOpenId, nowMs } = input;
+  if (!record.chatId) return null;
+  const messageId = [
+    "larkway_heartbeat",
+    safeIdSegment(record.botId ?? "bot"),
+    safeIdSegment(record.threadId),
+    String(nowMs),
+  ].join("_");
+  return {
+    message_id: messageId,
+    chat_id: record.chatId,
+    chat_type: "group",
+    thread_id: record.threadId,
+    root_id: record.threadId,
+    sender_id: botOpenId,
+    mentions: [],
+    content: JSON.stringify({
+      text:
+        "[Larkway internal session heartbeat] 定时巡查触发: 这不是用户新消息。请先读取本 session 状态和话题历史,判断任务是否停住或超时;如需推进,按你的长期 memory 主动 @ 下一棒或 @Elon;如无需动作,简短说明巡查结果。",
+    }),
+    create_time: String(nowMs),
+    larkway_internal_trigger: "session_heartbeat",
+    reply_to_message_id: record.threadId,
+  };
+}

--- a/src/claude/sessionStore.test.ts
+++ b/src/claude/sessionStore.test.ts
@@ -52,6 +52,7 @@ describe("v1 → v2 migration", () => {
         sessionId: "sess-aaa",
         createdTs: 1000,
         lastActiveTs: 2000,
+        chatId: "oc_chat1",
         senderOpenId: "ou_sender1",
         stage: "developing",
       },
@@ -83,6 +84,7 @@ describe("v1 → v2 migration", () => {
     expect(rec1["botId"]).toBe("v1-default");
     expect(rec1["threadId"]).toBe("om_thread001");
     expect(rec1["sessionId"]).toBe("sess-aaa");
+    expect(rec1["chatId"]).toBe("oc_chat1");
     expect(rec1["senderOpenId"]).toBe("ou_sender1");
 
     const rec2 = records["om_thread002::v1-default"] as Record<string, unknown>;
@@ -181,6 +183,7 @@ describe("v2 normal load", () => {
         botId: "my-bot",
         createdTs: 1000,
         lastActiveTs: 2000,
+        chatId: "oc_chat",
         senderOpenId: "ou_sender",
       },
     });
@@ -190,6 +193,7 @@ describe("v2 normal load", () => {
     expect(rec).toBeDefined();
     expect(rec?.sessionId).toBe("sess-v2");
     expect(rec?.botId).toBe("my-bot");
+    expect(rec?.chatId).toBe("oc_chat");
 
     // No backup file created (no migration ran)
     const files = await readdir(tmpDir);
@@ -234,9 +238,11 @@ describe("double-key CRUD", () => {
       botId: "my-bot",
       createdTs: 100,
       lastActiveTs: 200,
+      chatId: "oc_put",
     });
 
     expect(store.get("om_t1", "my-bot")).toBeDefined();
+    expect(store.get("om_t1", "my-bot")?.chatId).toBe("oc_put");
     expect(store.get("om_t1", "other-bot")).toBeUndefined();
     expect(store.getLegacy("om_t1")).toBeUndefined();
   });

--- a/src/claude/sessionStore.ts
+++ b/src/claude/sessionStore.ts
@@ -57,6 +57,7 @@ export interface SessionRecord {
   /** ms epoch */
   createdTs: number;
   lastActiveTs: number;
+  chatId?: string;
   senderOpenId?: string;
 }
 
@@ -67,6 +68,7 @@ interface StoredRecord {
   botId: string;
   createdTs: number;
   lastActiveTs: number;
+  chatId?: string;
   senderOpenId?: string;
 }
 
@@ -227,6 +229,9 @@ export class SessionStore {
         createdTs: typeof old["createdTs"] === "number" ? old["createdTs"] : Date.now(),
         lastActiveTs:
           typeof old["lastActiveTs"] === "number" ? old["lastActiveTs"] : Date.now(),
+        ...(typeof old["chatId"] === "string"
+          ? { chatId: old["chatId"] }
+          : {}),
         ...(typeof old["senderOpenId"] === "string"
           ? { senderOpenId: old["senderOpenId"] }
           : {}),
@@ -272,6 +277,7 @@ export class SessionStore {
       botId: effectiveBotId,
       createdTs: record.createdTs,
       lastActiveTs: record.lastActiveTs,
+      ...(record.chatId !== undefined ? { chatId: record.chatId } : {}),
       ...(record.senderOpenId !== undefined ? { senderOpenId: record.senderOpenId } : {}),
     };
     this.#map.set(key, stored);
@@ -381,6 +387,7 @@ function isStoredRecord(value: unknown): value is StoredRecord {
     typeof v["botId"] === "string" &&
     typeof v["createdTs"] === "number" &&
     typeof v["lastActiveTs"] === "number" &&
+    (v["chatId"] === undefined || typeof v["chatId"] === "string") &&
     (v["senderOpenId"] === undefined || typeof v["senderOpenId"] === "string")
   );
 }

--- a/src/cli/botsStore.test.ts
+++ b/src/cli/botsStore.test.ts
@@ -9,6 +9,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import type { BotConfig } from "../config/botLoader.js";
 import { DEFAULT_RESPONSE_SURFACE_PROTOTYPE } from "../responseSurface.js";
+import { DEFAULT_SESSION_HEARTBEAT_CONFIG } from "../bridge/sessionHeartbeat.js";
 
 let tmp: string;
 let store: typeof import("./botsStore.js");
@@ -27,6 +28,7 @@ const sampleBot = (): BotConfig =>
     turn_taking_limit: 10,
     read_only: false,
     response_surface_prototype: DEFAULT_RESPONSE_SURFACE_PROTOTYPE,
+    session_heartbeat: DEFAULT_SESSION_HEARTBEAT_CONFIG,
     runtime: "legacy",
     backend: "claude",
   }) as BotConfig;

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -37,6 +37,7 @@ import { ensureAgentWorkspace, resetAgentWorkspacePermissions } from "../../agen
 import { permissionItemsFromCapabilities } from "../../agent/permissionPlan.js";
 import { resolveAgentWorkspacePathFromHome } from "../../config/paths.js";
 import { DEFAULT_RESPONSE_SURFACE_PROTOTYPE } from "../../responseSurface.js";
+import { DEFAULT_SESSION_HEARTBEAT_CONFIG } from "../../bridge/sessionHeartbeat.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -633,6 +634,7 @@ async function runCreateBot(
     turn_taking_limit: basics.turnLimit ?? 10,
     read_only: false,
     response_surface_prototype: DEFAULT_RESPONSE_SURFACE_PROTOTYPE,
+    session_heartbeat: DEFAULT_SESSION_HEARTBEAT_CONFIG,
     runtime: "agent_workspace",
     backend: basics.backend,
     memory_file: memoryFile,

--- a/src/cli/commands/memory.test.ts
+++ b/src/cli/commands/memory.test.ts
@@ -21,6 +21,7 @@ import path from "node:path";
 import type { BotConfig } from "../../config/botLoader.js";
 import type { CliContext, CommandRun } from "../types.js";
 import { DEFAULT_RESPONSE_SURFACE_PROTOTYPE } from "../../responseSurface.js";
+import { DEFAULT_SESSION_HEARTBEAT_CONFIG } from "../../bridge/sessionHeartbeat.js";
 
 // ---------------------------------------------------------------------------
 // Shared test infrastructure
@@ -45,6 +46,7 @@ const sampleBot = (id = "test-bot"): BotConfig =>
     turn_taking_limit: 10,
     read_only: false,
     response_surface_prototype: DEFAULT_RESPONSE_SURFACE_PROTOTYPE,
+    session_heartbeat: DEFAULT_SESSION_HEARTBEAT_CONFIG,
     runtime: "legacy",
     backend: "claude",
   }) as BotConfig;

--- a/src/config/botLoader.ts
+++ b/src/config/botLoader.ts
@@ -18,6 +18,7 @@ import path from "node:path";
 import { z } from "zod";
 import yaml from "js-yaml";
 import { ResponseSurfacePrototypeConfigSchema } from "../responseSurface.js";
+import { DEFAULT_SESSION_HEARTBEAT_CONFIG } from "../bridge/sessionHeartbeat.js";
 
 // ---------------------------------------------------------------------------
 // Zod schema
@@ -36,6 +37,14 @@ const GitCloneUrlSchema = z.string().min(1).refine(
   },
   "url must be an http(s), ssh://, or scp-like Git clone URL",
 );
+
+const SessionHeartbeatConfigSchema = z.object({
+  enabled: z.boolean().default(DEFAULT_SESSION_HEARTBEAT_CONFIG.enabled),
+  interval_ms: z.number().int().min(60_000).default(DEFAULT_SESSION_HEARTBEAT_CONFIG.interval_ms),
+  idle_after_ms: z.number().int().min(60_000).default(DEFAULT_SESSION_HEARTBEAT_CONFIG.idle_after_ms),
+  active_within_ms: z.number().int().min(60_000).default(DEFAULT_SESSION_HEARTBEAT_CONFIG.active_within_ms),
+  max_sessions_per_tick: z.number().int().min(1).max(20).default(DEFAULT_SESSION_HEARTBEAT_CONFIG.max_sessions_per_tick),
+}).default(DEFAULT_SESSION_HEARTBEAT_CONFIG);
 
 export const BotConfigSchema = z.object({
   /** Unique identifier, kebab-case. Used as key in sessionStore. */
@@ -210,6 +219,16 @@ export const BotConfigSchema = z.object({
    * outbound is not implemented here, so handler keeps a visible card fallback.
    */
   response_surface_prototype: ResponseSurfacePrototypeConfigSchema,
+
+  /**
+   * Optional bridge-side session heartbeat.
+   *
+   * When enabled, the bridge periodically re-enqueues recently active, idle
+   * sessions for this bot as an internal turn. This gives non-resident agents a
+   * wall-clock wake-up hook while keeping workflow decisions inside the agent.
+   * Default is disabled to avoid surprise background replies for existing bots.
+   */
+  session_heartbeat: SessionHeartbeatConfigSchema,
 
   /**
    * Runtime layout used by the bridge.

--- a/src/lark/channelClient.ts
+++ b/src/lark/channelClient.ts
@@ -701,6 +701,16 @@ export class ChannelClient {
   }
 
   /**
+   * Inject a bridge-internal turn into the same queue as real Feishu events.
+   * Used for session heartbeat wake-ups; the handler still owns all prompt,
+   * state, and response-surface behavior.
+   */
+  pushInternalEvent(event: LarkMessageEvent): void {
+    if (this.closed) return;
+    this.queue.push(event);
+  }
+
+  /**
    * Return an OutboundCardClient bound to this client's channel handle.
    *
    * Safe to call before connect: the returned client resolves the live channel

--- a/src/lark/message.test.ts
+++ b/src/lark/message.test.ts
@@ -231,3 +231,74 @@ describe("parseMessage — sender id normalization", () => {
     expect(parsed.senderOpenId).toBe("ou_sender_from_object");
   });
 });
+
+describe("parseMessage — interactive CardKit text extraction", () => {
+  it("extracts visible markdown from CardKit 2.0 body elements", () => {
+    const event = makeEvent(
+      {
+        schema: "2.0",
+        config: {
+          summary: { content: "summary only" },
+        },
+        body: {
+          elements: [
+            { tag: "markdown", content: "**完成**\n\n@Elon 已修复读卡问题。" },
+            {
+              tag: "column_set",
+              columns: [
+                {
+                  tag: "column",
+                  elements: [
+                    {
+                      tag: "button",
+                      text: { tag: "plain_text", content: "确认" },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      },
+      { message_type: "interactive" },
+    );
+
+    const parsed = parseMessage(event);
+
+    expect(parsed.text).toContain("完成");
+    expect(parsed.text).toContain("@Elon 已修复读卡问题。");
+    expect(parsed.text).toContain("确认");
+    expect(parsed.text).not.toContain("summary only");
+  });
+
+  it("extracts legacy interactive card top-level elements", () => {
+    const event = makeEvent(
+      {
+        elements: [
+          [{ tag: "text", text: "请 Turing 复验" }],
+          [{ tag: "markdown", content: "结论: 通过" }],
+        ],
+      },
+      { message_type: "interactive" },
+    );
+
+    expect(parseMessage(event).text).toBe("请 Turing 复验 结论: 通过");
+  });
+
+  it("drops client-upgrade placeholder-only interactive card content", () => {
+    const event = makeEvent(
+      {
+        title: null,
+        elements: [
+          [
+            { tag: "img", image_key: "img_placeholder" },
+            { tag: "text", text: "请升级至最新版本客户端，以查看内容" },
+          ],
+        ],
+      },
+      { message_type: "interactive" },
+    );
+
+    expect(parseMessage(event).text).toBe("");
+  });
+});

--- a/src/lark/message.ts
+++ b/src/lark/message.ts
@@ -52,6 +52,9 @@ const AT_PLACEHOLDER_RE = /@_\w+\s*/g;
 const FEISHU_DOC_RE =
   /https?:\/\/[\w-]+\.(?:feishu\.cn|larkoffice\.com)\/(?:docs|wiki|sheets|space)\/[\w%-]+(?:\/[\w%-]*)?/gi;
 
+const CLIENT_UPGRADE_PLACEHOLDER_RE =
+  /请升级至最新版本客户端[，,]?\s*以查看内容/;
+
 // ---------------------------------------------------------------------------
 // Text extraction helpers
 // ---------------------------------------------------------------------------
@@ -84,6 +87,81 @@ function extractPostText(value: unknown): string {
 }
 
 /**
+ * Recursively collect user-visible text from Feishu interactive card payloads.
+ *
+ * CardKit/Card JSON 2.0 messages arrive as msg_type=interactive. The Lark API can
+ * expose either the real card JSON (schema/body/elements/header) or, on older
+ * clients/APIs, only a fallback "please upgrade client" body. We extract from
+ * real card structures and deliberately drop the upgrade placeholder so agents
+ * do not mistake it for the user's actual instruction.
+ */
+function extractInteractiveCardText(value: unknown): string {
+  const parts = collectInteractiveCardText(value)
+    .map((part) => part.replace(/\s+/g, " ").trim())
+    .filter((part) => part.length > 0)
+    .filter((part) => !CLIENT_UPGRADE_PLACEHOLDER_RE.test(part));
+  return parts.join(" ").trim();
+}
+
+function collectInteractiveCardText(value: unknown): string[] {
+  if (typeof value === "string") return [];
+  if (Array.isArray(value)) return value.flatMap(collectInteractiveCardText);
+  if (value === null || typeof value !== "object") return [];
+
+  const obj = value as Record<string, unknown>;
+  const tag = typeof obj["tag"] === "string" ? obj["tag"] : "";
+
+  // Avoid leaking ids/image keys or treating decorative fallback images as text.
+  if (tag === "at" || tag === "img" || tag === "image") {
+    const titled = obj["title"] !== undefined
+      ? collectInteractiveCardText(obj["title"])
+      : [];
+    return titled;
+  }
+
+  const direct: string[] = [];
+  if (typeof obj["text"] === "string") direct.push(obj["text"]);
+  if (
+    typeof obj["content"] === "string" &&
+    ["markdown", "plain_text", "lark_md", "text", ""].includes(tag)
+  ) {
+    direct.push(obj["content"]);
+  }
+
+  const childKeys = [
+    "header",
+    "body",
+    "elements",
+    "columns",
+    "fields",
+    "title",
+    "subtitle",
+    "text",
+    "content",
+  ];
+  const nested: string[] = [];
+  for (const key of childKeys) {
+    if (key in obj && typeof obj[key] !== "string") {
+      nested.push(...collectInteractiveCardText(obj[key]));
+    }
+  }
+
+  return [...direct, ...nested];
+}
+
+function looksLikeInteractiveCard(
+  event: LarkMessageEvent,
+  parsed: Record<string, unknown>,
+): boolean {
+  return (
+    event["message_type"] === "interactive" ||
+    parsed["schema"] === "2.0" ||
+    parsed["body"] !== undefined ||
+    parsed["elements"] !== undefined
+  );
+}
+
+/**
  * Parse event.content (a JSON string) and extract plain text.
  * Falls back to the raw content string and emits a console.warn on parse error.
  */
@@ -108,6 +186,10 @@ function extractText(event: LarkMessageEvent): string {
   // message_type = "post": { "title": "...", "content": [[{tag, text}]] }
   else if (parsed["content"] !== undefined) {
     raw = extractPostText(parsed["content"]);
+  }
+  // message_type = "interactive": CardKit/Card JSON 2.0 or legacy card payload.
+  else if (looksLikeInteractiveCard(event, parsed)) {
+    raw = extractInteractiveCardText(parsed);
   }
   // message_type = "post" with a top-level zh_cn / en_us locale key
   else {

--- a/src/main.ts
+++ b/src/main.ts
@@ -36,6 +36,10 @@ import {
   shouldProvideResponseSurfaceCardKitClient,
   shouldProvideResponseSurfacePostClient,
 } from "./responseSurface.js";
+import {
+  buildSessionHeartbeatEvent,
+  selectDueSessionHeartbeats,
+} from "./bridge/sessionHeartbeat.js";
 
 /** How often the bridge rewrites each bot's status.json liveness heartbeat. */
 const STATUS_WRITE_INTERVAL_MS = 30_000;
@@ -177,6 +181,8 @@ async function runV2Mode({
     housekeeping: Housekeeping;
     /** Liveness heartbeat interval (status.json). Armed after wiring; unref()-ed. */
     statusTimer: ReturnType<typeof setInterval> | null;
+    /** Optional session heartbeat interval. Armed only when bot config enables it. */
+    sessionHeartbeatTimer: ReturnType<typeof setInterval> | null;
     /**
      * Bot avatar URL — filled in by a best-effort fire-and-forget fetch at boot
      * (fetchBotAvatar). undefined until/unless it resolves; the heartbeat reads
@@ -380,7 +386,7 @@ async function runV2Mode({
 
     const inst: BotInstance = {
       bot, client, sessionStore, cardRenderer, handler, housekeeping,
-      statusTimer: null, avatar: undefined,
+      statusTimer: null, sessionHeartbeatTimer: null, avatar: undefined,
     };
     instances.push(inst);
 
@@ -434,12 +440,41 @@ async function runV2Mode({
     inst.statusTimer.unref();
   }
 
+  function startSessionHeartbeat(inst: BotInstance): void {
+    const cfg = inst.bot.session_heartbeat;
+    if (!cfg.enabled) return;
+    const tick = (): void => {
+      const now = Date.now();
+      const due = selectDueSessionHeartbeats(
+        inst.sessionStore.list(),
+        cfg,
+        now,
+        inst.bot.id,
+      );
+      for (const record of due) {
+        const event = buildSessionHeartbeatEvent({
+          record,
+          botOpenId: inst.bot.bot_open_id,
+          nowMs: now,
+        });
+        if (!event) continue;
+        console.log(
+          `[larkway] bot "${inst.bot.id}" session heartbeat enqueued thread=${record.threadId}`,
+        );
+        inst.client.pushInternalEvent(event);
+      }
+    };
+    inst.sessionHeartbeatTimer = setInterval(tick, cfg.interval_ms);
+    inst.sessionHeartbeatTimer.unref();
+  }
+
   // ── Graceful shutdown ────────────────────────────────────────────────────
   async function shutdown(signal: string): Promise<void> {
     console.log(`\n[larkway] Received ${signal}, shutting down V2 bots…`);
     await Promise.all(
-      instances.map(async ({ bot, statusTimer, housekeeping, handler, sessionStore, client, avatar }) => {
+      instances.map(async ({ bot, statusTimer, sessionHeartbeatTimer, housekeeping, handler, sessionStore, client, avatar }) => {
         if (statusTimer) clearInterval(statusTimer);
+        if (sessionHeartbeatTimer) clearInterval(sessionHeartbeatTimer);
         // Mark this bot as no-longer-serving on the way out (ws:false). The Web
         // 管理面 will then show 🟡 degraded briefly, then 🔴 offline once the
         // file goes stale. Best-effort — never block shutdown on it. Preserve the
@@ -528,6 +563,7 @@ async function runV2Mode({
   // heartbeat. First write is immediate so the Web 管理面 reflects the bot at boot.
   for (const inst of instances) {
     startStatusHeartbeat(inst);
+    startSessionHeartbeat(inst);
   }
 
   // ── Enter main loop — all bots run concurrently ───────────────────────────

--- a/src/web/onboardSession.ts
+++ b/src/web/onboardSession.ts
@@ -39,6 +39,7 @@ import { ensureAgentWorkspace } from "../agent/workspaceStore.js";
 import { permissionItemsFromCapabilities } from "../agent/permissionPlan.js";
 import { resolveAgentWorkspacePathFromHome } from "../config/paths.js";
 import { DEFAULT_RESPONSE_SURFACE_PROTOTYPE } from "../responseSurface.js";
+import { DEFAULT_SESSION_HEARTBEAT_CONFIG } from "../bridge/sessionHeartbeat.js";
 
 // ---------------------------------------------------------------------------
 // registerApp SDK slice (Lark SDK has no bundled .d.ts for registerApp;
@@ -455,6 +456,7 @@ export async function createBotFromCreds(
     memory_file: memoryFile,
     read_only: false,
     response_surface_prototype: DEFAULT_RESPONSE_SURFACE_PROTOTYPE,
+    session_heartbeat: DEFAULT_SESSION_HEARTBEAT_CONFIG,
     runtime: "agent_workspace",
     backend: form.backend && form.backend.trim() ? form.backend.trim() : "codex",
     // Persist the Feishu avatar URL so the Web 管理面 can show an avatar before


### PR DESCRIPTION
## Summary
- extract visible text from interactive CardKit/Card JSON messages instead of surfacing only the client-upgrade fallback
- persist chatId on session records and add an opt-in per-bot session heartbeat that re-enqueues idle active sessions as internal turns
- route internal heartbeat replies back to the real thread root without adding/removing Feishu processing reactions

## Tests
- pnpm vitest run src/lark/message.test.ts src/bridge/sessionHeartbeat.test.ts src/claude/sessionStore.test.ts src/config/botLoader.test.ts
- pnpm typecheck
- pnpm test
- pnpm build

## Deployment note
No deploy or bridge restart performed. To enable heartbeat for Elon after merge/deploy, set session_heartbeat.enabled=true in the target bot config with the desired interval/idle window, then deploy/restart via the approved external path.