### PR TITLE
fix: stream codex answers via app server

### DIFF
--- a/src/codex/runner.test.ts
+++ b/src/codex/runner.test.ts
@@ -14,6 +14,7 @@ import {
   _parseCodexLine as parseCodexLine,
   _buildCodexCommand as buildCodexCommand,
   _buildCodexEnv as buildCodexEnv,
+  _CodexAppServerLineParser as CodexAppServerLineParser,
   _CodexLineParser as CodexLineParser,
   productizeCodexFailure,
 } from "./runner.js";
@@ -89,6 +90,93 @@ const FIXTURE_ITEM_COMPLETED_FILE_CHANGE = JSON.stringify({
     type: "file_change",
     path: "src/foo.ts",
     diff: "@@ -1 +1 @@ ...",
+  },
+});
+
+const APP_THREAD_ID = "019f0d76-a0c4-7771-b0aa-933b653ce99e";
+
+const APP_INIT_RESPONSE = JSON.stringify({
+  id: 1,
+  result: {
+    userAgent: "larkway/0.142.0",
+    codexHome: "/tmp/codex",
+    platformFamily: "unix",
+    platformOs: "macos",
+  },
+});
+
+const APP_THREAD_RESPONSE = JSON.stringify({
+  id: 2,
+  result: {
+    thread: {
+      id: APP_THREAD_ID,
+      sessionId: APP_THREAD_ID,
+      cwd: "/wt",
+      turns: [],
+    },
+  },
+});
+
+const APP_TURN_RESPONSE = JSON.stringify({
+  id: 3,
+  result: {
+    turn: {
+      id: "turn-1",
+      items: [],
+      itemsView: "notLoaded",
+      status: "inProgress",
+      error: null,
+      startedAt: null,
+      completedAt: null,
+      durationMs: null,
+    },
+  },
+});
+
+function appAgentDelta(delta: string): string {
+  return JSON.stringify({
+    method: "item/agentMessage/delta",
+    params: {
+      threadId: APP_THREAD_ID,
+      turnId: "turn-1",
+      itemId: "msg-1",
+      delta,
+    },
+  });
+}
+
+function appAgentCompleted(text: string): string {
+  return JSON.stringify({
+    method: "item/completed",
+    params: {
+      item: {
+        type: "agentMessage",
+        id: "msg-1",
+        text,
+        phase: "final_answer",
+        memoryCitation: null,
+      },
+      threadId: APP_THREAD_ID,
+      turnId: "turn-1",
+      completedAtMs: 1,
+    },
+  });
+}
+
+const APP_TURN_COMPLETED = JSON.stringify({
+  method: "turn/completed",
+  params: {
+    threadId: APP_THREAD_ID,
+    turn: {
+      id: "turn-1",
+      items: [],
+      itemsView: "notLoaded",
+      status: "completed",
+      error: null,
+      startedAt: 1,
+      completedAt: 2,
+      durationMs: 1,
+    },
   },
 });
 
@@ -215,109 +303,64 @@ describe("parseCodexLine", () => {
   });
 });
 
+describe("CodexAppServerLineParser", () => {
+  it("turns app-server agentMessage deltas into marker-gated answer deltas", () => {
+    const parser = new CodexAppServerLineParser();
+    const events = [
+      ...parser.parseMessage(JSON.parse(appAgentDelta("LARKWAY_ANSWER_BEGIN\nHel"))),
+      ...parser.parseMessage(JSON.parse(appAgentDelta("lo wor"))),
+      ...parser.parseMessage(JSON.parse(appAgentDelta("ld\nLARKWAY_ANSWER_END"))),
+    ];
+
+    const deltas = events.filter((event) => event.type === "answer_delta");
+    expect(deltas.map((event) => event.text).join("")).toBe("Hello world");
+    expect(events.some((event) => event.type === "answer_snapshot")).toBe(false);
+  });
+
+  it("uses completed agentMessage as a final snapshot fallback without duplicating prior deltas", () => {
+    const parser = new CodexAppServerLineParser();
+    const answer = "LARKWAY_ANSWER_BEGIN\nHello world\nLARKWAY_ANSWER_END";
+    const events = [
+      ...parser.parseMessage(JSON.parse(appAgentDelta(answer))),
+      ...parser.parseMessage(JSON.parse(appAgentCompleted(answer))),
+    ];
+
+    expect(events.filter((event) => event.type === "answer_delta")).not.toHaveLength(0);
+    expect(events.filter((event) => event.type === "answer_snapshot")).toHaveLength(0);
+  });
+});
+
 // ---------------------------------------------------------------------------
 // buildCodexCommand — unit tests
 // ---------------------------------------------------------------------------
 
 describe("buildCodexCommand", () => {
-  it("fresh session: codex exec --json --skip-git-repo-check + host workspace mode by default", () => {
+  it("fresh session: runs codex app-server over stdio", () => {
     const [bin, args] = buildCodexCommand({ prompt: "hello" });
     expect(bin).toBe("codex");
-    expect(args[0]).toBe("exec");
-    expect(args).toContain("--json");
-    expect(args).toContain("--skip-git-repo-check");
-    expect(args).toContain("--dangerously-bypass-approvals-and-sandbox");
-    expect(args).not.toContain("--sandbox");
-    expect(args).not.toContain("workspace-write");
-    // No 'resume' subcommand
-    expect(args).not.toContain("resume");
+    expect(args).toEqual(["app-server", "--stdio"]);
   });
 
-  it("resume session: includes 'exec resume <sessionId>'", () => {
+  it("resume session: still uses app-server; resume is a JSON-RPC request", () => {
     const [bin, args] = buildCodexCommand({
       prompt: "continue",
       resumeSessionId: "019eabc123def456",
     });
     expect(bin).toBe("codex");
-    expect(args[0]).toBe("exec");
-    expect(args[1]).toBe("resume");
-    expect(args[2]).toBe("019eabc123def456");
-    expect(args).toContain("--json");
-    expect(args).toContain("--skip-git-repo-check");
-    expect(args).toContain("--dangerously-bypass-approvals-and-sandbox");
-    expect(args).not.toContain("--sandbox");
-    expect(args).not.toContain("workspace-write");
-    expect(args.at(-1)).toBe("-");
+    expect(args).toEqual(["app-server", "--stdio"]);
   });
 
-  it("fresh session WITH cwd: includes -C <cwd>", () => {
+  it("cwd is not encoded in argv; it is sent through app-server params", () => {
     const [, args] = buildCodexCommand({ prompt: "hello", cwd: "/wt" });
-    expect(args).toContain("-C");
-    expect(args[args.indexOf("-C") + 1]).toBe("/wt");
+    expect(args).toEqual(["app-server", "--stdio"]);
   });
 
-  it("resume session WITH cwd: does NOT pass -C (codex exec resume rejects it → exit 2)", () => {
-    // Regression: `codex exec resume` has no -C/--cd flag. Passing it broke every
-    // 2nd+ turn ("unexpected argument '-C' found"). cwd is set via the spawn cwd.
-    const [, args] = buildCodexCommand({
-      prompt: "continue",
-      resumeSessionId: "019eabc123def456",
-      cwd: "/wt",
-    });
-    expect(args).not.toContain("-C");
-    expect(args).not.toContain("/wt");
-  });
-
-  it("permissionMode acceptEdits → host-level workspace mode for Codex", () => {
+  it("permission mode is not encoded in argv; it is sent through app-server params", () => {
     const [, args] = buildCodexCommand({
       prompt: "hello",
       permissionMode: "acceptEdits",
     });
-    expect(args).toContain("--dangerously-bypass-approvals-and-sandbox");
-    expect(args).not.toContain("--sandbox");
-    expect(args).not.toContain("workspace-write");
-  });
-
-  it("permissionMode ask → --sandbox read-only (non-interactive fallback)", () => {
-    const [, args] = buildCodexCommand({
-      prompt: "hello",
-      permissionMode: "ask",
-    });
-    expect(args).toContain("--sandbox");
-    expect(args).toContain("read-only");
-  });
-
-  it("permissionMode bypassPermissions → --dangerously-bypass-approvals-and-sandbox", () => {
-    const [, args] = buildCodexCommand({
-      prompt: "hello",
-      permissionMode: "bypassPermissions",
-    });
-    expect(args).toContain("--dangerously-bypass-approvals-and-sandbox");
-  });
-
-  it("resume session with bypassPermissions keeps the explicit dangerous bypass flag", () => {
-    const [, args] = buildCodexCommand({
-      prompt: "continue",
-      resumeSessionId: "019eabc123def456",
-      permissionMode: "bypassPermissions",
-    });
-    expect(args).toContain("--dangerously-bypass-approvals-and-sandbox");
-    expect(args.at(-1)).toBe("-");
-  });
-
-  it("cwd → -C <cwd> prepended before other flags", () => {
-    const [, args] = buildCodexCommand({
-      prompt: "hello",
-      cwd: "/repo/worktree",
-    });
-    const idx = args.indexOf("-C");
-    expect(idx).toBeGreaterThanOrEqual(0);
-    expect(args[idx + 1]).toBe("/repo/worktree");
-  });
-
-  it("no cwd → -C flag absent", () => {
-    const [, args] = buildCodexCommand({ prompt: "hello" });
-    expect(args).not.toContain("-C");
+    expect(args).toEqual(["app-server", "--stdio"]);
   });
 
   it("custom codexBinPath overrides default 'codex'", () => {
@@ -490,7 +533,7 @@ describe("runCodex() — spawn-level integration", () => {
     return result;
   }
 
-  it("full happy path: thread.started→system_init, cmd, result, done resolves", async () => {
+  it("full happy path: app-server agentMessage deltas stream through answer_delta", async () => {
     const fake = makeFakeCodexChild();
     __nextFakeCodexChild = fake;
 
@@ -513,14 +556,13 @@ describe("runCodex() — spawn-level integration", () => {
     })();
 
     await new Promise<void>((res) => setImmediate(() => {
-      fake.stdout.write(FIXTURE_THREAD_STARTED + "\n");
-      fake.stdout.write(FIXTURE_TURN_STARTED + "\n");
-      fake.stdout.write(FIXTURE_ITEM_STARTED_CMD + "\n");
-      fake.stdout.write(FIXTURE_ITEM_COMPLETED_CMD + "\n");
-      fake.stdout.write(FIXTURE_ITEM_COMPLETED_AGENT_ANSWER + "\n");
-      fake.stdout.write(FIXTURE_TURN_COMPLETED + "\n");
-      fake.stdout.end();
-      fake.child.emit("exit", 0);
+      fake.stdout.write(APP_INIT_RESPONSE + "\n");
+      fake.stdout.write(APP_THREAD_RESPONSE + "\n");
+      fake.stdout.write(APP_TURN_RESPONSE + "\n");
+      fake.stdout.write(appAgentDelta("LARKWAY_ANSWER_BEGIN\nHel") + "\n");
+      fake.stdout.write(appAgentDelta("lo world\nLARKWAY_ANSWER_END") + "\n");
+      fake.stdout.write(appAgentCompleted("LARKWAY_ANSWER_BEGIN\nHello world\nLARKWAY_ANSWER_END") + "\n");
+      fake.stdout.write(APP_TURN_COMPLETED + "\n");
       // Wait for events loop to observe system_init before emitting close,
       // so discoveredSessionId is populated in runner.ts before done resolves.
       void firstEventSeen.then(() => {
@@ -535,30 +577,26 @@ describe("runCodex() — spawn-level integration", () => {
     // Check event sequence
     const types = events.map((e) => e["type"]);
     expect(types).toContain("system_init");
-    expect(types).toContain("raw"); // turn.started → raw
-    expect(types).toContain("tool_use");
-    expect(types).toContain("tool_result");
-    expect(types).toContain("answer_snapshot");
+    expect(types).toContain("answer_delta");
     expect(types).toContain("result");
 
     // Validate specific events
     const systemInit = events.find((e) => e["type"] === "system_init");
-    expect(systemInit).toMatchObject({ sessionId: "019eabc123def456" });
+    expect(systemInit).toMatchObject({ sessionId: APP_THREAD_ID });
 
-    const toolUse = events.find((e) => e["type"] === "tool_use");
-    expect(toolUse).toMatchObject({ toolName: "shell", toolInput: { command: "ls -la" } });
-
-    const answerSnapshot = events.find((e) => e["type"] === "answer_snapshot");
-    expect(answerSnapshot).toMatchObject({
-      text: "I found the following files in the directory.",
-    });
+    const answerText = events
+      .filter((e) => e["type"] === "answer_delta")
+      .map((e) => e["text"])
+      .join("");
+    expect(answerText).toBe("Hello world");
+    expect(events.some((e) => e["type"] === "answer_snapshot")).toBe(false);
 
     const resultEvent = events.find((e) => e["type"] === "result");
     expect(resultEvent).toMatchObject({ stopReason: "end_turn" });
 
     // done resolves with sessionId captured from thread.started
     expect(result.exitCode).toBe(0);
-    expect(result.sessionId).toBe("019eabc123def456");
+    expect(result.sessionId).toBe(APP_THREAD_ID);
   });
 
   it("unknown events degrade to raw — no throw", async () => {
@@ -570,22 +608,23 @@ describe("runCodex() — spawn-level integration", () => {
 
     const eventsPromise = collectEvents(handle.events);
     await new Promise<void>((res) => setImmediate(() => {
-      fake.stdout.write(FIXTURE_UNKNOWN_TOP_TYPE + "\n");
-      fake.stdout.write(FIXTURE_ITEM_STARTED_REASONING + "\n");
-      fake.stdout.write(FIXTURE_ITEM_COMPLETED_FILE_CHANGE + "\n");
-      fake.stdout.write(FIXTURE_TURN_COMPLETED + "\n");
-      fake.triggerClose(0);
+      fake.stdout.write(APP_INIT_RESPONSE + "\n");
+      fake.stdout.write(APP_THREAD_RESPONSE + "\n");
+      fake.stdout.write(APP_TURN_RESPONSE + "\n");
+      fake.stdout.write(JSON.stringify({ method: "some/futureEvent", params: { x: 1 } }) + "\n");
+      fake.stdout.write(JSON.stringify({ method: "another/futureEvent", params: { x: 2 } }) + "\n");
+      fake.stdout.write(APP_TURN_COMPLETED + "\n");
       res();
     }));
 
     const events = await eventsPromise;
     const types = events.map((e) => e["type"]);
-    // All unknown lines become raw; turn.completed still emits result
-    expect(types.filter((t) => t === "raw")).toHaveLength(3);
+    // Unknown notifications become raw; turn/completed still emits result
+    expect(types.filter((t) => t === "raw")).toHaveLength(2);
     expect(types).toContain("result");
   });
 
-  it("resume: spawn receives 'exec resume <sessionId>' in args", async () => {
+  it("resume: app-server receives thread/resume over JSON-RPC", async () => {
     const fake = makeFakeCodexChild();
     __nextFakeCodexChild = fake;
 
@@ -597,8 +636,10 @@ describe("runCodex() — spawn-level integration", () => {
 
     const eventsPromise = collectEvents(handle.events);
     await new Promise<void>((res) => setImmediate(() => {
-      fake.stdout.write(FIXTURE_TURN_COMPLETED + "\n");
-      fake.triggerClose(0);
+      fake.stdout.write(APP_INIT_RESPONSE + "\n");
+      fake.stdout.write(APP_THREAD_RESPONSE + "\n");
+      fake.stdout.write(APP_TURN_RESPONSE + "\n");
+      fake.stdout.write(APP_TURN_COMPLETED + "\n");
       res();
     }));
 
@@ -607,11 +648,10 @@ describe("runCodex() — spawn-level integration", () => {
 
     // Verify spawn received correct argv for resume
     expect(__lastSpawnArgs).not.toBeNull();
-    expect(__lastSpawnArgs!.args[0]).toBe("exec");
-    expect(__lastSpawnArgs!.args[1]).toBe("resume");
-    expect(__lastSpawnArgs!.args[2]).toBe("019eabc123def456");
-    expect(__lastSpawnArgs!.args).toContain("--json");
-    expect(__lastSpawnArgs!.args).toContain("--skip-git-repo-check");
+    expect(__lastSpawnArgs!.args).toEqual(["app-server", "--stdio"]);
+    const stdinText = fake.child.stdin.read()?.toString("utf8") ?? "";
+    expect(stdinText).toContain('"method":"thread/resume"');
+    expect(stdinText).toContain('"threadId":"019eabc123def456"');
   });
 
   it("done resolves even when child exits with code 1 (killed path)", async () => {
@@ -733,8 +773,9 @@ describe("runCodex() — spawn-level integration", () => {
 
     const fake = makeFakeCodexChild({
       initialLines: [
-        FIXTURE_THREAD_STARTED,
-        FIXTURE_TURN_COMPLETED,
+        APP_INIT_RESPONSE,
+        APP_THREAD_RESPONSE,
+        APP_TURN_RESPONSE,
       ],
     });
     __nextFakeCodexChild = fake;
@@ -776,7 +817,7 @@ describe("runCodex() — spawn-level integration", () => {
     expect(eventsLoopResolved).toBe(true);
     expect(doneResolved).toBe(true);
     expect(result.exitCode).toBe(0);
-    expect(result.sessionId).toBe("019eabc123def456");
+    expect(result.sessionId).toBe(APP_THREAD_ID);
 
     vi.useRealTimers();
   }, 15_000);

--- a/src/codex/runner.test.ts
+++ b/src/codex/runner.test.ts
@@ -624,6 +624,63 @@ describe("runCodex() — spawn-level integration", () => {
     expect(types).toContain("result");
   });
 
+  it("sends cwd and policy fields through app-server JSON-RPC params", async () => {
+    const fake = makeFakeCodexChild();
+    __nextFakeCodexChild = fake;
+
+    const { runCodex } = await import("./runner.js");
+    const handle = runCodex({
+      prompt: "continue the task",
+      cwd: "/repo/worktree",
+      permissionMode: "ask",
+    });
+
+    const eventsPromise = collectEvents(handle.events);
+    await new Promise<void>((res) => setImmediate(() => {
+      fake.stdout.write(APP_INIT_RESPONSE + "\n");
+      fake.stdout.write(APP_THREAD_RESPONSE + "\n");
+      fake.stdout.write(APP_TURN_RESPONSE + "\n");
+      fake.stdout.write(APP_TURN_COMPLETED + "\n");
+      res();
+    }));
+
+    await eventsPromise;
+    await handle.done;
+
+    expect(__lastSpawnArgs).not.toBeNull();
+    expect(__lastSpawnArgs!.args).toEqual(["app-server", "--stdio"]);
+
+    const stdinText: string = fake.child.stdin.read()?.toString("utf8") ?? "";
+    const requests: Array<{
+      method?: string;
+      params?: Record<string, unknown>;
+    }> = stdinText
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((line: string) => JSON.parse(line) as {
+        method?: string;
+        params?: Record<string, unknown>;
+      });
+
+    const threadStart = requests.find((request) => request.method === "thread/start");
+    expect(threadStart?.params).toMatchObject({
+      cwd: "/repo/worktree",
+      approvalPolicy: "on-request",
+      sandbox: "read-only",
+      ephemeral: false,
+      sessionStartSource: "startup",
+    });
+
+    const turnStart = requests.find((request) => request.method === "turn/start");
+    expect(turnStart?.params).toMatchObject({
+      threadId: APP_THREAD_ID,
+      cwd: "/repo/worktree",
+      approvalPolicy: "on-request",
+      sandboxPolicy: { type: "readOnly", networkAccess: false },
+    });
+  });
+
   it("resume: app-server receives thread/resume over JSON-RPC", async () => {
     const fake = makeFakeCodexChild();
     __nextFakeCodexChild = fake;

--- a/src/codex/runner.ts
+++ b/src/codex/runner.ts
@@ -1,15 +1,15 @@
 /**
  * src/codex/runner.ts
  *
- * Spawns `codex exec --json` as a child process, parses its NDJSON output
- * line-by-line, and yields normalised AgentStreamEvents — same contract as
- * ClaudeRunner in src/claude/runner.ts.
+ * Spawns `codex app-server --stdio` as a child process, speaks the JSON-RPC
+ * app-server protocol, and yields normalised AgentStreamEvents — same contract
+ * as ClaudeRunner in src/claude/runner.ts.
  *
  * Design constraints (mirroring ClaudeRunner):
  *  - No Codex SDK — only Node built-ins + the `codex` CLI binary
  *  - OPENAI_API_KEY is stripped from env (subscription mode, not API key)
  *  - ANTHROPIC_API_KEY is also stripped (belt-and-suspenders)
- *  - --cwd/-C is passed as both a spawn option AND a CLI flag when provided
+ *  - cwd is passed as the spawn cwd and as app-server thread/turn params
  *  - done Promise resolves on any exit path (normal / error / kill / timeout)
  *  - Grandchild-holds-stdout handled identically to ClaudeRunner via
  *    rlAbortController + 5 s exit fallback
@@ -109,81 +109,31 @@ export function buildCodexEnv(
 // ---------------------------------------------------------------------------
 
 /**
- * Map RunOptions.permissionMode to the --sandbox / bypass flag for codex exec.
- */
-function sandboxFlag(mode: NonNullable<RunOptions["permissionMode"]>): string[] {
-  switch (mode) {
-    case "bypassPermissions":
-      return ["--dangerously-bypass-approvals-and-sandbox"];
-    case "acceptEdits":
-      // agent_workspace must let Codex use the host's normal developer surface:
-      // network/DNS for git remotes and macOS Keychain for lark-cli/user auth.
-      // Codex workspace-write sandbox blocks those in real dogfood runs, so the
-      // safety boundary for this mode is Larkway's human-confirmed workspace
-      // permissions + the host account/token scopes, not Codex's OS sandbox.
-      return ["--dangerously-bypass-approvals-and-sandbox"];
-    case "ask":
-      // Non-interactive; can't truly "ask" — degrade to read-only sandbox
-      return ["--sandbox", "read-only"];
-  }
-}
-
-function resumePermissionFlag(mode: NonNullable<RunOptions["permissionMode"]>): string[] {
-  // Current Codex `exec resume` does not accept `--sandbox`, so workspace-write
-  // / read-only cannot be restated on later turns. It does accept the explicit
-  // dangerous bypass flag. Agent-workspace acceptEdits also needs host-level
-  // DNS/network and local credential access on every resumed turn.
-  return mode === "bypassPermissions" || mode === "acceptEdits"
-    ? ["--dangerously-bypass-approvals-and-sandbox"]
-    : [];
-}
-
-/**
  * Build [bin, args] for spawning codex.
  *
- * Fresh session:
- *   codex exec --json [-C <cwd>] --skip-git-repo-check <sandbox flags>
- *   prompt → stdin
- *
- * Resume session:
- *   codex exec resume <sessionId> --json --skip-git-repo-check -
- *   prompt → stdin (`-` is required for resume to read stdin)
+ * Session lifecycle and the user prompt are sent over JSON-RPC after startup.
  */
 export function buildCodexCommand(
   opts: RunOptions,
   codexBinPath = "codex",
 ): [string, string[]] {
-  const mode = opts.permissionMode ?? "acceptEdits";
-  const commonFlags: string[] = [
-    "--json",
-    "--skip-git-repo-check",
-    ...sandboxFlag(mode),
-  ];
+  void opts;
+  return [codexBinPath, ["app-server", "--stdio"]];
+}
 
-  if (opts.resumeSessionId != null) {
-    // `codex exec resume` does NOT accept -C/--cd (only fresh `codex exec` does) —
-    // passing it makes codex exit 2 "unexpected argument '-C' found", breaking EVERY
-    // 2nd+ turn (resume). The working dir is set via the spawn cwd (process cwd)
-    // instead. GitLab issue: codex 多轮第二句就挂。
-    // Current `codex exec resume` also rejects `--sandbox`; for agent_workspace
-    // sessions the sandbox boundary is the original session + spawn cwd.
-    // Resume also needs an explicit `-` prompt argument to read this turn's
-    // instructions from stdin; without it the resumed topic may receive no new
-    // user message.
-    const resumeFlags = [
-      "--json",
-      "--skip-git-repo-check",
-      ...resumePermissionFlag(mode),
-    ];
-    return [
-      codexBinPath,
-      ["exec", "resume", opts.resumeSessionId, ...resumeFlags, "-"],
-    ];
-  }
+type JsonRecord = Record<string, unknown>;
 
-  // Fresh `codex exec` supports -C/--cd (cwd is also set as the spawn cwd).
-  const freshFlags = opts.cwd != null ? ["-C", opts.cwd, ...commonFlags] : commonFlags;
-  return [codexBinPath, ["exec", ...freshFlags]];
+function codexThreadSandboxMode(mode: NonNullable<RunOptions["permissionMode"]>): string {
+  return mode === "ask" ? "read-only" : "danger-full-access";
+}
+
+function codexTurnSandboxPolicy(mode: NonNullable<RunOptions["permissionMode"]>): JsonRecord {
+  if (mode === "ask") return { type: "readOnly", networkAccess: false };
+  return { type: "dangerFullAccess" };
+}
+
+function codexApprovalPolicy(mode: NonNullable<RunOptions["permissionMode"]>): string {
+  return mode === "ask" ? "on-request" : "never";
 }
 
 // ---------------------------------------------------------------------------
@@ -309,6 +259,85 @@ class CodexLineParser {
 
 }
 
+class CodexAppServerLineParser {
+  private readonly answerExtractor = new AnswerChannelExtractor();
+
+  *parseMessage(obj: unknown): Generator<AgentStreamEvent> {
+    if (typeof obj !== "object" || obj === null) {
+      yield { type: "raw", raw: obj };
+      return;
+    }
+
+    const record = obj as JsonRecord;
+    const method = record["method"];
+    if (typeof method !== "string") {
+      yield { type: "raw", raw: obj };
+      return;
+    }
+
+    const params = asRecord(record["params"]);
+
+    if (method === "thread/started") {
+      const thread = asRecord(params?.["thread"]);
+      const threadId = typeof thread?.["id"] === "string" ? thread["id"] : undefined;
+      if (threadId) yield { type: "system_init", sessionId: threadId, raw: obj };
+      return;
+    }
+
+    if (method === "turn/completed") {
+      yield { type: "result", stopReason: "end_turn", raw: obj };
+      return;
+    }
+
+    if (method === "item/agentMessage/delta") {
+      const delta = typeof params?.["delta"] === "string" ? params["delta"] : "";
+      yield* this.answerExtractor.ingestDelta(delta, obj);
+      return;
+    }
+
+    if (method === "item/started") {
+      const item = asRecord(params?.["item"]);
+      if (item?.["type"] === "commandExecution" && typeof item["command"] === "string") {
+        yield {
+          type: "tool_use",
+          toolName: "shell",
+          toolInput: { command: item["command"] },
+          raw: obj,
+        };
+        return;
+      }
+      return;
+    }
+
+    if (method === "item/completed") {
+      const item = asRecord(params?.["item"]);
+      if (item?.["type"] === "commandExecution") {
+        yield { type: "tool_result", raw: obj };
+        return;
+      }
+      if (item?.["type"] === "agentMessage" && typeof item["text"] === "string") {
+        yield* this.answerExtractor.ingestSnapshot(item["text"], obj);
+        return;
+      }
+      return;
+    }
+
+    yield { type: "raw", raw: obj };
+  }
+}
+
+function asRecord(value: unknown): JsonRecord | undefined {
+  return typeof value === "object" && value !== null ? value as JsonRecord : undefined;
+}
+
+function extractThreadIdFromThreadResponse(obj: unknown): string | undefined {
+  const record = asRecord(obj);
+  const result = asRecord(record?.["result"]);
+  const thread = asRecord(result?.["thread"]);
+  const threadId = thread?.["id"];
+  return typeof threadId === "string" ? threadId : undefined;
+}
+
 function agentMessageTextFrom(record: Record<string, unknown>): string | undefined {
   const item = record["item"];
   if (typeof item !== "object" || item === null) return undefined;
@@ -330,22 +359,25 @@ export function runCodex(opts: RunOptions, codexBinPath = "codex"): RunHandle {
   const timeoutMs = opts.timeoutMs ?? 15 * 60 * 1000;
   const [bin, args] = buildCodexCommand(opts, codexBinPath);
   const env = buildCodexEnv(opts.botGitIdentity, opts.gitlabToken);
+  const mode = opts.permissionMode ?? "acceptEdits";
+  const requestById = new Map<number, string>();
+  let nextRequestId = 1;
 
   // ── spawn ─────────────────────────────────────────────────────────────────
-  // stdin is "pipe" so we can write the prompt then end it.
-  // codex exec reads the prompt from stdin when run non-interactively.
+  // stdin/stdout carry app-server JSON-RPC. This is the Codex surface that
+  // emits item/agentMessage/delta during generation; `codex exec --json`
+  // only emits the completed agent message at the end.
   const child = spawn(bin, args, {
     env,
     stdio: ["pipe", "pipe", "pipe"],
     ...(opts.cwd != null ? { cwd: opts.cwd } : {}),
   });
 
-  // Write prompt to stdin, then close stdin to signal EOF to codex.
-  // This must be fire-and-forget (errors go to child.stdin 'error' event
-  // which we ignore — the process will fail with a non-zero exit code).
-  if (child.stdin != null) {
-    child.stdin.write(opts.prompt, "utf8");
-    child.stdin.end();
+  function sendRequest(method: string, params: unknown): number {
+    const id = nextRequestId++;
+    requestById.set(id, method);
+    child.stdin?.write(JSON.stringify({ jsonrpc: "2.0", id, method, params }) + "\n");
+    return id;
   }
 
   // Track discovered sessionId for done promise
@@ -363,6 +395,11 @@ export function runCodex(opts: RunOptions, codexBinPath = "codex"): RunHandle {
       if (!child.killed) child.kill("SIGKILL");
     }, SIGKILL_GRACE_MS);
     killTimer.unref();
+  }
+
+  function stopAppServerAfterTurn(): void {
+    if (child.killed || killScheduled) return;
+    child.kill("SIGTERM");
   }
 
   // ── timeout ───────────────────────────────────────────────────────────────
@@ -410,6 +447,8 @@ export function runCodex(opts: RunOptions, codexBinPath = "codex"): RunHandle {
   // to unblock the `for await (line of rl)` loop even when stdout hasn't drained
   // (grandchild holding stdio pipe). This ensures handler.ts reaches finalize().
   const rlAbortController = new AbortController();
+  let finishAppServerTurn: ((exitCode: number) => void) | undefined;
+  let failAppServerTurn: ((err: Error) => void) | undefined;
 
   // ── done promise ──────────────────────────────────────────────────────────
   const done = new Promise<{ exitCode: number; sessionId?: string }>(
@@ -446,6 +485,19 @@ export function runCodex(opts: RunOptions, codexBinPath = "codex"): RunHandle {
         }
         resolve({ exitCode, sessionId: discoveredSessionId });
       };
+
+      const finalizeReject = (err: Error): void => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timeoutHandle);
+        clearTimeout(killTimer);
+        clearTimeout(totalTimeoutFallbackHandle);
+        rlAbortController.abort();
+        reject(err);
+      };
+
+      finishAppServerTurn = finalizeResolve;
+      failAppServerTurn = finalizeReject;
 
       // Wire the Stage-2 total-timeout fallback.  Called by the setTimeout above
       // (after the full kill grace) to force-resolve done when the child is silent.
@@ -509,15 +561,89 @@ export function runCodex(opts: RunOptions, codexBinPath = "codex"): RunHandle {
       crlfDelay: Infinity,
       signal: rlAbortController.signal,
     });
-    const parser = new CodexLineParser();
+    const parser = new CodexAppServerLineParser();
+    let turnCompleted = false;
+
+    sendRequest("initialize", {
+      clientInfo: { name: "larkway", version: "0.3" },
+      capabilities: {},
+    });
 
     try {
       for await (const line of rl) {
-        for (const event of parser.parseLine(line)) {
+        const trimmed = line.trim();
+        if (!trimmed) continue;
+
+        let obj: unknown;
+        try {
+          obj = JSON.parse(trimmed);
+        } catch {
+          yield { type: "raw", raw: trimmed };
+          continue;
+        }
+
+        const response = asRecord(obj);
+        if (typeof response?.["id"] === "number") {
+          const id = response["id"];
+          const method = requestById.get(id);
+          requestById.delete(id);
+
+          const error = asRecord(response["error"]);
+          if (error) {
+            const message = typeof error["message"] === "string"
+              ? error["message"]
+              : JSON.stringify(error);
+            failAppServerTurn?.(new Error(`codex app-server ${method ?? "request"} failed: ${message}`));
+            stopAppServerAfterTurn();
+            return;
+          }
+
+          if (method === "initialize") {
+            const threadMethod = opts.resumeSessionId != null ? "thread/resume" : "thread/start";
+            const threadParams: JsonRecord = opts.resumeSessionId != null
+              ? { threadId: opts.resumeSessionId }
+              : { ephemeral: false, sessionStartSource: "startup" };
+            if (opts.cwd != null) threadParams["cwd"] = opts.cwd;
+            threadParams["approvalPolicy"] = codexApprovalPolicy(mode);
+            threadParams["sandbox"] = codexThreadSandboxMode(mode);
+            sendRequest(threadMethod, threadParams);
+            continue;
+          }
+
+          if (method === "thread/start" || method === "thread/resume") {
+            const threadId = extractThreadIdFromThreadResponse(obj);
+            if (threadId) {
+              discoveredSessionId = threadId;
+              yield { type: "system_init", sessionId: threadId, raw: obj };
+              const turnParams: JsonRecord = {
+                threadId,
+                input: [{ type: "text", text: opts.prompt, text_elements: [] }],
+                approvalPolicy: codexApprovalPolicy(mode),
+                sandboxPolicy: codexTurnSandboxPolicy(mode),
+              };
+              if (opts.cwd != null) turnParams["cwd"] = opts.cwd;
+              sendRequest("turn/start", turnParams);
+            }
+            continue;
+          }
+
+          continue;
+        }
+
+        for (const event of parser.parseMessage(obj)) {
           if (event.type === "system_init") {
             discoveredSessionId = event.sessionId;
           }
+          if (event.type === "result") {
+            turnCompleted = true;
+          }
           yield event;
+        }
+
+        if (turnCompleted) {
+          stopAppServerAfterTurn();
+          finishAppServerTurn?.(0);
+          return;
         }
       }
     } catch (err) {
@@ -561,6 +687,7 @@ export class CodexRunner implements AgentRunner {
 export {
   buildCodexEnv as _buildCodexEnv,
   buildCodexCommand as _buildCodexCommand,
+  CodexAppServerLineParser as _CodexAppServerLineParser,
   CodexLineParser as _CodexLineParser,
   parseCodexLine as _parseCodexLine,
 };


### PR DESCRIPTION
## Summary
- switch the Codex runner from `codex exec --json` to `codex app-server --stdio`
- consume `item/agentMessage/delta` notifications as marker-gated `answer_delta` events
- keep completed agent messages as a final snapshot fallback without duplicating streamed deltas

## Root cause
Production Codex runs only emitted one completed `agent_message` through `codex exec --json`, so the CardKit answer channel saw a single final snapshot instead of generation-time deltas. The Codex app-server protocol does emit true incremental `item/agentMessage/delta` events during generation.

## Validation
- `pnpm test src/codex/runner.test.ts`
- `pnpm test src/codex/runner.test.ts src/claude/runner.test.ts src/agent/answerChannel.test.ts src/bridge/cardkitProgress.test.ts`
- `pnpm test`
- `pnpm typecheck`
- `pnpm build`
- local long-answer probe through the modified runner: 391 `answer_delta` events over 14.255s, plus one final snapshot fallback, exitCode 0

## Deployment note
No deploy or restart was performed here. After merge/release/deploy, production acceptance should use a long Codex marker answer and verify user-visible incremental CardKit refresh plus ledger deltas spread across the generation window.