### PR TITLE
fix: keep peer mentions without response surface mode

### DIFF
--- a/docs/response-surface-prototype.md
+++ b/docs/response-surface-prototype.md
@@ -53,6 +53,8 @@ Supported fields:
 - `image_blocks` / `content_blocks`: rendered in the final card.
 - `response_surface.post.mentions`: late peer mention targets. In CardKit they
   render as final-card `<at id=...></at>` mentions after passing mention policy.
+  Mention `user_id` values must use the CardKit-renderable character set:
+  letters, numbers, `_`, `:`, and `-`.
 - `response_surface.mode` / `primary` are accepted for compatibility with older
   agents and `mode` may be omitted; omitted `mode` parses as `card`. These fields
   no longer select a post-only or hybrid main surface. CardKit is the only normal

--- a/docs/response-surface-prototype.md
+++ b/docs/response-surface-prototype.md
@@ -31,7 +31,6 @@ Agents continue to write `.larkway/state.json`:
   "choices": [{ "label": "Continue", "value": "Continue with this option" }],
   "choice_prompt": "Choose next step?",
   "response_surface": {
-    "mode": "card",
     "post": {
       "mentions": [{ "user_id": "<open_id>", "label": "Peer bot" }]
     }
@@ -55,8 +54,9 @@ Supported fields:
 - `response_surface.post.mentions`: late peer mention targets. In CardKit they
   render as final-card `<at id=...></at>` mentions after passing mention policy.
 - `response_surface.mode` / `primary` are accepted for compatibility with older
-  agents, but no longer select a post-only or hybrid main surface. CardKit is the
-  only normal response surface; legacy cards and create-only posts are fallbacks.
+  agents and `mode` may be omitted; omitted `mode` parses as `card`. These fields
+  no longer select a post-only or hybrid main surface. CardKit is the only normal
+  response surface; legacy cards and create-only posts are fallbacks.
 
 The schema soft-fails malformed `response_surface`; a typo there must not drop
 `status`, `last_message`, or final rendering fields.

--- a/src/bridge/handler.test.ts
+++ b/src/bridge/handler.test.ts
@@ -774,8 +774,6 @@ describe("handleOne — thin-channel finalize", () => {
       choices: [{ label: "继续", value: "继续处理" }],
       choice_prompt: "下一步?",
       response_surface: {
-        mode: "post",
-        primary: "post",
         post: { mentions: [{ user_id: "peer_test", label: "Peer" }] },
       },
       updated_at: "2026-06-26T10:00:00.000Z",
@@ -847,6 +845,88 @@ describe("handleOne — thin-channel finalize", () => {
     const finalUpdate = cardKitCalls.find((c) => c.kind === "updateCard");
     expect(JSON.stringify(finalUpdate?.payload)).toContain("继续");
     expect(JSON.stringify(finalUpdate?.payload)).toContain("<at id=peer_test></at>");
+  });
+
+  it("records a runtime diagnostic when CardKit mentions are policy-filtered", async () => {
+    const threadId = "om_msg";
+    const finalState = {
+      status: "ready",
+      last_message: "CardKit 最终正文",
+      response_surface: {
+        post: { mentions: [{ user_id: "peer_blocked", label: "Peer" }] },
+      },
+      updated_at: "2026-06-26T10:00:00.000Z",
+    };
+    const wt = await seedWorktree(threadId);
+    await seedRepoCachePath();
+    const { client: cardKitClient, calls: cardKitCalls } = makeCardKitClient();
+    const runtimeEvents: Array<{ statusPath?: string[]; reason?: string }> = [];
+
+    runClaudeImpl = () => ({
+      events: (async function* () {
+        yield { type: "system_init", sessionId: "sess_cardkit_policy", raw: {} };
+        await writeFile(
+          stateFileMod.stateFilePathOf(wt),
+          JSON.stringify(finalState, null, 2),
+          "utf8",
+        );
+      })(),
+      done: Promise.resolve({ exitCode: 0, sessionId: "sess_cardkit_policy" }),
+      kill: () => {},
+    });
+
+    const { renderer, startArgs, finalizeArgs } = makeCardRenderer();
+    const { store } = makeSessionStore();
+    const { client, acked } = makeClient(makeEvent());
+
+    const handler = new BridgeHandler({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      client: client as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      cardRenderer: renderer as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      sessionStore: store as any,
+      conventions: makeConventions(),
+      botConfig: {
+        id: "frontend",
+        name: "Frontend",
+        turn_taking_limit: 10,
+        backend: "claude",
+        response_surface_prototype: {
+          enabled: true,
+          allowed_chats: [],
+          allowed_threads: ["om_msg"],
+          kill_switch: false,
+          post_outbound_enabled: true,
+          cardkit_streaming_enabled: true,
+          allow_agent_mentions: true,
+          allowed_mention_open_ids: ["peer_allowed"],
+        },
+      },
+      cardKitClient,
+      recordRuntimeEvent: async (patch) => {
+        runtimeEvents.push({
+          statusPath: patch.appendPath
+            ? Array.isArray(patch.appendPath)
+              ? patch.appendPath
+              : [patch.appendPath]
+            : patch.statusPath,
+          reason: patch.reason ?? undefined,
+        });
+      },
+    });
+
+    await handler.run();
+    for (let i = 0; i < 100 && acked.length === 0; i++) {
+      await new Promise((r) => setTimeout(r, 10));
+    }
+
+    expect(startArgs).toHaveLength(0);
+    expect(finalizeArgs).toHaveLength(0);
+    const finalUpdate = cardKitCalls.find((c) => c.kind === "updateCard");
+    expect(JSON.stringify(finalUpdate?.payload)).not.toContain("<at id=peer_blocked></at>");
+    expect(runtimeEvents.some((e) => e.statusPath?.includes("mention 诊断"))).toBe(true);
+    expect(runtimeEvents.some((e) => e.reason?.includes("0/1 allowed"))).toBe(true);
   });
 
   it("updates the CardKit running footer with count-only tool usage", async () => {

--- a/src/bridge/handler.test.ts
+++ b/src/bridge/handler.test.ts
@@ -929,6 +929,88 @@ describe("handleOne — thin-channel finalize", () => {
     expect(runtimeEvents.some((e) => e.reason?.includes("0/1 allowed"))).toBe(true);
   });
 
+  it("records a state diagnostic instead of silently dropping invalid CardKit mention IDs", async () => {
+    const threadId = "om_msg";
+    const finalState = {
+      status: "ready",
+      last_message: "CardKit 最终正文",
+      response_surface: {
+        post: { mentions: [{ user_id: "bad<script>", label: "Bad" }] },
+      },
+      updated_at: "2026-06-26T10:00:00.000Z",
+    };
+    const wt = await seedWorktree(threadId);
+    await seedRepoCachePath();
+    const { client: cardKitClient, calls: cardKitCalls } = makeCardKitClient();
+    const runtimeEvents: Array<{ statusPath?: string[]; reason?: string }> = [];
+
+    runClaudeImpl = () => ({
+      events: (async function* () {
+        yield { type: "system_init", sessionId: "sess_cardkit_invalid_mention", raw: {} };
+        await writeFile(
+          stateFileMod.stateFilePathOf(wt),
+          JSON.stringify(finalState, null, 2),
+          "utf8",
+        );
+      })(),
+      done: Promise.resolve({ exitCode: 0, sessionId: "sess_cardkit_invalid_mention" }),
+      kill: () => {},
+    });
+
+    const { renderer, startArgs, finalizeArgs } = makeCardRenderer();
+    const { store } = makeSessionStore();
+    const { client, acked } = makeClient(makeEvent());
+
+    const handler = new BridgeHandler({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      client: client as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      cardRenderer: renderer as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      sessionStore: store as any,
+      conventions: makeConventions(),
+      botConfig: {
+        id: "frontend",
+        name: "Frontend",
+        turn_taking_limit: 10,
+        backend: "claude",
+        response_surface_prototype: {
+          enabled: true,
+          allowed_chats: [],
+          allowed_threads: ["om_msg"],
+          kill_switch: false,
+          post_outbound_enabled: true,
+          cardkit_streaming_enabled: true,
+          allow_agent_mentions: true,
+          allowed_mention_open_ids: [],
+        },
+      },
+      cardKitClient,
+      recordRuntimeEvent: async (patch) => {
+        runtimeEvents.push({
+          statusPath: patch.appendPath
+            ? Array.isArray(patch.appendPath)
+              ? patch.appendPath
+              : [patch.appendPath]
+            : patch.statusPath,
+          reason: patch.reason ?? undefined,
+        });
+      },
+    });
+
+    await handler.run();
+    for (let i = 0; i < 100 && acked.length === 0; i++) {
+      await new Promise((r) => setTimeout(r, 10));
+    }
+
+    expect(startArgs).toHaveLength(0);
+    expect(finalizeArgs).toHaveLength(0);
+    const finalUpdate = cardKitCalls.find((c) => c.kind === "updateCard");
+    expect(JSON.stringify(finalUpdate?.payload)).not.toContain("<at id=");
+    expect(runtimeEvents.some((e) => e.statusPath?.includes("state 诊断"))).toBe(true);
+    expect(runtimeEvents.some((e) => e.reason?.includes("post.mentions.0.user_id"))).toBe(true);
+  });
+
   it("updates the CardKit running footer with count-only tool usage", async () => {
     const threadId = "om_msg";
     const finalState = {

--- a/src/bridge/handler.ts
+++ b/src/bridge/handler.ts
@@ -31,7 +31,12 @@ import { createRunner } from "../agent/runner.js";
 import type { BotConfig } from "../config/botLoader.js";
 import { ensureSessionArtifacts } from "../agent/sessionArtifacts.js";
 import { ensureAgentWorkspace } from "../agent/workspaceStore.js";
-import { ensureStateFile, readStateFile, stateFilePathOf } from "./stateFile.js";
+import {
+  ensureStateFile,
+  readStateFile,
+  readStateFileDetailed,
+  stateFilePathOf,
+} from "./stateFile.js";
 import { writeCardFile, deleteCardFile } from "./cardFile.js";
 import {
   writeCardKitFile,
@@ -1273,7 +1278,8 @@ export class BridgeHandler {
             Date.now() - runnerStartedAt >= timeoutMs;
 
           // Step 4d-ii: read state.json the bot wrote during the response.
-          const rawReportedState = await readStateFile(worktreePath);
+          const reportedStateRead = await readStateFileDetailed(worktreePath);
+          const rawReportedState = reportedStateRead.state;
           // Stale-guard: only trust state.json if the bot actually rewrote it this
           // turn (updated_at advanced past the pre-run snapshot). A stale file =
           // "no report this turn" → treat as null, which the downstream code already
@@ -1285,6 +1291,25 @@ export class BridgeHandler {
             rawReportedState.updated_at !== preRunUpdatedAt
               ? rawReportedState
               : null;
+
+          if (reportedStateRead.diagnostics.length > 0 && reportedState !== null) {
+            await recordEvent({
+              status: "running",
+              appendPath: "state 诊断",
+              reason: reportedStateRead.diagnostics.join("; "),
+            });
+          }
+
+          if (reportedState === null) {
+            await recordEvent({
+              status: "running",
+              appendPath: "未更新 state.json",
+              reason:
+                rawReportedState === null
+                  ? "本轮结束时未读取到 state.json。"
+                  : "本轮 state.json 没有 fresh updated_at，已忽略旧状态。",
+            });
+          }
 
           // Thin-channel: NO dev_url HTTP probe, NO stage state-machine, NO
           // demotion. The finalize truth-ordering below reduces to status/exitCode
@@ -1354,11 +1379,21 @@ export class BridgeHandler {
           } else if (cardKitTimeoutFailure) {
             success = false;
             failureReason = `agent turn timed out after ${timeoutMs}ms; CardKit running card was finalized as interrupted`;
+            await recordEvent({
+              status: "running",
+              appendPath: "Agent 超时",
+              reason: failureReason,
+            });
           } else if (result.exitCode === 0) {
             success = true;
           } else {
             success = false;
             failureReason = `claude exited ${result.exitCode} 且 bot 未更新 state.json status — 可能崩溃`;
+            await recordEvent({
+              status: "running",
+              appendPath: "Agent 异常退出",
+              reason: failureReason,
+            });
           }
 
           // reportedState is null when the bot didn't rewrite state.json this
@@ -1407,9 +1442,30 @@ export class BridgeHandler {
           };
 
           if (cardKitProgress) {
-            const mentions = (reportedState?.response_surface?.post?.mentions ?? []).filter(
-              (mention) => isResponseSurfaceMentionAllowed(prototypeConfig, mention.user_id),
+            const declaredMentions = reportedState?.response_surface?.post?.mentions ?? [];
+            const responseSurfacePostDeclared = reportedState?.response_surface?.post !== undefined;
+            const mentions = declaredMentions.filter((mention) =>
+              isResponseSurfaceMentionAllowed(prototypeConfig, mention.user_id),
             );
+            if (responseSurfacePostDeclared && declaredMentions.length === 0) {
+              const reason = "response_surface.post was declared with an empty mentions array.";
+              console.warn("[bridge.handler] response_surface post has no mentions");
+              await recordEvent({
+                status: "running",
+                appendPath: "mention 诊断",
+                reason,
+              });
+            } else if (declaredMentions.length > mentions.length) {
+              const reason =
+                `response_surface mentions filtered by policy: ` +
+                `${mentions.length}/${declaredMentions.length} allowed.`;
+              console.warn("[bridge.handler] response_surface mention policy filtered targets");
+              await recordEvent({
+                status: "running",
+                appendPath: "mention 诊断",
+                reason,
+              });
+            }
             try {
               await cardKitProgress.finalize({
                 title: baseCardPayload.titleOverride,

--- a/src/bridge/stateFile.test.ts
+++ b/src/bridge/stateFile.test.ts
@@ -6,7 +6,10 @@
  * drop the `status` the bridge actually needs. See stateFile.ts `optionalUrl`.
  */
 import { describe, it, expect } from "vitest";
-import { StateFileSchema } from "./stateFile.js";
+import { mkdtemp, rm, mkdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { StateFileSchema, readStateFileDetailed, stateFilePathOf } from "./stateFile.js";
 
 describe("StateFileSchema — thin-channel URL leniency", () => {
   it("accepts a relative mr_url and still surfaces status (the bridge's only hard need)", () => {
@@ -242,6 +245,29 @@ describe("StateFileSchema — response_surface prototype declaration", () => {
     }
   });
 
+  it("defaults a mode-less response_surface to card so peer mentions survive", () => {
+    const r = StateFileSchema.safeParse({
+      status: "ready",
+      last_message: "handoff",
+      response_surface: {
+        post: {
+          mentions: [{ user_id: "peer_test", label: "Peer" }],
+        },
+      },
+      updated_at: "2026-06-26T09:00:00.000Z",
+    });
+
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.data.response_surface).toEqual({
+        mode: "card",
+        post: {
+          mentions: [{ user_id: "peer_test", label: "Peer" }],
+        },
+      });
+    }
+  });
+
   it("soft-fails malformed response_surface so status is still usable", () => {
     const r = StateFileSchema.safeParse({
       status: "ready",
@@ -258,6 +284,38 @@ describe("StateFileSchema — response_surface prototype declaration", () => {
       expect(r.data.status).toBe("ready");
       expect(r.data.last_message).toBe("must survive a bad prototype field");
       expect(r.data.response_surface).toBeUndefined();
+    }
+  });
+
+  it("reports diagnostics when response_surface soft-fails", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "larkway-state-"));
+    try {
+      await mkdir(join(dir, ".larkway"), { recursive: true });
+      await writeFile(
+        stateFilePathOf(dir),
+        JSON.stringify(
+          {
+            status: "ready",
+            last_message: "must survive a bad prototype field",
+            response_surface: {
+              mode: "card",
+              primary: "post",
+            },
+            updated_at: "2026-06-26T09:00:00.000Z",
+          },
+          null,
+          2,
+        ),
+        "utf8",
+      );
+
+      const result = await readStateFileDetailed(dir);
+      expect(result.state?.status).toBe("ready");
+      expect(result.state?.response_surface).toBeUndefined();
+      expect(result.diagnostics.join("\n")).toContain("response_surface ignored");
+      expect(result.diagnostics.join("\n")).toContain("primary");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
     }
   });
 });

--- a/src/bridge/stateFile.test.ts
+++ b/src/bridge/stateFile.test.ts
@@ -318,6 +318,40 @@ describe("StateFileSchema — response_surface prototype declaration", () => {
       await rm(dir, { recursive: true, force: true });
     }
   });
+
+  it("soft-fails invalid mention user_id with diagnostics instead of letting CardKit drop it later", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "larkway-state-"));
+    try {
+      await mkdir(join(dir, ".larkway"), { recursive: true });
+      await writeFile(
+        stateFilePathOf(dir),
+        JSON.stringify(
+          {
+            status: "ready",
+            last_message: "invalid mention id should be diagnosed",
+            response_surface: {
+              post: {
+                mentions: [{ user_id: "bad<script>", label: "Bad" }],
+              },
+            },
+            updated_at: "2026-06-26T09:00:00.000Z",
+          },
+          null,
+          2,
+        ),
+        "utf8",
+      );
+
+      const result = await readStateFileDetailed(dir);
+      expect(result.state?.status).toBe("ready");
+      expect(result.state?.last_message).toBe("invalid mention id should be diagnosed");
+      expect(result.state?.response_surface).toBeUndefined();
+      expect(result.diagnostics.join("\n")).toContain("response_surface ignored");
+      expect(result.diagnostics.join("\n")).toContain("post.mentions.0.user_id");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("StateFileSchema — V2 image blocks (agent-declared, bridge-opaque)", () => {

--- a/src/bridge/stateFile.ts
+++ b/src/bridge/stateFile.ts
@@ -16,7 +16,10 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { z } from "zod";
-import { ResponseSurfaceStateSchema } from "../responseSurface.js";
+import {
+  ResponseSurfaceStateSchema,
+  parseResponseSurfaceState,
+} from "../responseSurface.js";
 
 // ---------------------------------------------------------------------------
 // Schema
@@ -201,6 +204,11 @@ export const StateFileSchema = z.object({
 
 export type StateFile = z.infer<typeof StateFileSchema>;
 
+export interface StateFileReadResult {
+  state: StateFile | null;
+  diagnostics: string[];
+}
+
 // ---------------------------------------------------------------------------
 // Paths
 // ---------------------------------------------------------------------------
@@ -250,14 +258,22 @@ export async function ensureStateFile(worktreePath: string): Promise<void> {
 export async function readStateFile(
   worktreePath: string,
 ): Promise<StateFile | null> {
+  return (await readStateFileDetailed(worktreePath)).state;
+}
+
+export async function readStateFileDetailed(
+  worktreePath: string,
+): Promise<StateFileReadResult> {
   const file = stateFilePathOf(worktreePath);
   let raw: string;
   try {
     raw = await fs.readFile(file, "utf8");
   } catch (err) {
-    if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return { state: null, diagnostics: [] };
+    }
     console.warn(`[stateFile] read ${file} failed:`, err);
-    return null;
+    return { state: null, diagnostics: [] };
   }
 
   let parsed: unknown;
@@ -280,11 +296,11 @@ export async function readStateFile(
           `[stateFile] ${file} not valid JSON (repair also failed):`,
           err2,
         );
-        return null;
+        return { state: null, diagnostics: [] };
       }
     } else {
       console.warn(`[stateFile] ${file} not valid JSON:`, err);
-      return null;
+      return { state: null, diagnostics: [] };
     }
   }
 
@@ -294,9 +310,26 @@ export async function readStateFile(
       `[stateFile] ${file} failed schema validation:`,
       result.error.issues,
     );
-    return null;
+    return { state: null, diagnostics: [] };
   }
-  return result.data;
+  const diagnostics = diagnoseStateFile(parsed, result.data);
+  for (const diagnostic of diagnostics) {
+    console.warn(`[stateFile] ${file}: ${diagnostic}`);
+  }
+  return { state: result.data, diagnostics };
+}
+
+function diagnoseStateFile(parsed: unknown, state: StateFile): string[] {
+  if (parsed === null || typeof parsed !== "object") return [];
+  if (!Object.prototype.hasOwnProperty.call(parsed, "response_surface")) return [];
+  const rawSurface = (parsed as { response_surface?: unknown }).response_surface;
+  if (rawSurface === undefined || state.response_surface !== undefined) return [];
+  const parsedSurface = parseResponseSurfaceState(rawSurface);
+  const details =
+    parsedSurface.diagnostics.length > 0
+      ? parsedSurface.diagnostics.join("; ")
+      : "unknown parse failure";
+  return [`response_surface ignored: ${details}`];
 }
 
 // ---------------------------------------------------------------------------

--- a/src/responseSurface.ts
+++ b/src/responseSurface.ts
@@ -55,7 +55,7 @@ const ResponseSurfaceCardSchema = z.object({
 
 const StrictResponseSurfaceStateSchema = z
   .object({
-    mode: ResponseSurfaceModeSchema,
+    mode: ResponseSurfaceModeSchema.optional().default("card"),
     primary: ResponseSurfacePrimarySchema.optional(),
     post: ResponseSurfacePostSchema.optional(),
     card: ResponseSurfaceCardSchema.optional(),
@@ -77,11 +77,26 @@ const StrictResponseSurfaceStateSchema = z
  */
 export const ResponseSurfaceStateSchema = z.preprocess((value) => {
   if (value === undefined) return undefined;
-  const result = StrictResponseSurfaceStateSchema.safeParse(value);
-  return result.success ? result.data : undefined;
+  return parseResponseSurfaceState(value).state;
 }, StrictResponseSurfaceStateSchema.optional());
 
 export type ResponseSurfaceState = z.infer<typeof StrictResponseSurfaceStateSchema>;
+
+export interface ResponseSurfaceParseResult {
+  state?: ResponseSurfaceState;
+  diagnostics: string[];
+}
+
+export function parseResponseSurfaceState(value: unknown): ResponseSurfaceParseResult {
+  const result = StrictResponseSurfaceStateSchema.safeParse(value);
+  if (result.success) return { state: result.data, diagnostics: [] };
+  return {
+    diagnostics: result.error.issues.map((issue) => {
+      const path = issue.path.length > 0 ? issue.path.join(".") : "<root>";
+      return `${path}: ${issue.message}`;
+    }),
+  };
+}
 
 export const ResponseSurfacePrototypeConfigSchema = z
   .object({

--- a/src/responseSurface.ts
+++ b/src/responseSurface.ts
@@ -1,6 +1,9 @@
 import { z } from "zod";
 
 const NonEmptyString = z.string().trim().min(1);
+const CardKitMentionUserIdSchema = NonEmptyString.max(128).regex(/^[A-Za-z0-9_:-]+$/, {
+  message: "mention user_id must contain only letters, numbers, underscore, colon, or hyphen",
+});
 
 export function defaultResponseSurfacePrototypeConfig() {
   return {
@@ -40,7 +43,7 @@ export const ResponseSurfaceCapabilitySchema = z.enum([
 ]);
 
 const MentionTargetSchema = z.object({
-  user_id: NonEmptyString.max(128),
+  user_id: CardKitMentionUserIdSchema,
   label: z.string().trim().min(1).max(80).optional(),
 });
 


### PR DESCRIPTION
## Summary
- default omitted `response_surface.mode` to `card`, preserving agent-authored `post.mentions` such as `{post:{mentions:[...]}}`
- add state-file diagnostics for soft-failed `response_surface` parsing without weakening the thin-channel status contract
- record runtime diagnostics for no fresh state, CardKit timeout/crash facts, and mention policy filtering/empty declarations
- update response-surface docs to show mode-less peer mention declarations

## Tests
- `pnpm exec vitest run src/bridge/stateFile.test.ts src/bridge/handler.test.ts`
- `pnpm typecheck`
- `pnpm test`

## Deployment
No merge, deploy, release, or bridge restart performed.