### PR TITLE
docs: define team handoff P0 workflow

### DIFF
--- a/docs/agent-handoff-reliability.md
+++ b/docs/agent-handoff-reliability.md
@@ -20,6 +20,38 @@ and schema behavior, but it does not decide product ownership or reassign work.
 - Keep the bridge-managed main reply in `.larkway/state.json`; do not patch or
   overwrite bridge-managed cards/posts directly.
 
+## Coordination P0 Contract
+
+Peer-agent coordination state lives in the agent/team workflow layer, not in the
+bridge. A coordinator skill or workspace artifact should track each handoff
+with these fields:
+
+- `task_id`: unique within the topic/session;
+- `assignee`: peer bot id or stable label;
+- `source_message_id`: the Feishu message that created the handoff;
+- `expected_output`: the deliverable or terminal condition;
+- `deadline`: when missing ack or missing terminal status becomes actionable;
+- `escalation_owner`: who gets notified when the deadline is missed;
+- `status`: `dispatched`, `acked`, `in_progress`, `completed`, `failed`, or
+  `timeout`.
+
+Minimum P0 behavior:
+
+- The sender records `dispatched` before or immediately after sending the real
+  post handoff.
+- The receiver sends a lightweight real-post ack ("received / starting") before
+  long-running work and records `acked` when it can write the ledger.
+- Every receiver sends a terminal real-post update: `completed`, `failed`, or
+  explicit `blocked`. It must not let the chain stop silently.
+- The coordinator checks deadlines when it runs. If a task is overdue without
+  ack or terminal status, it marks `timeout` and escalates to the configured
+  owner in the same Feishu topic.
+
+The bridge may expose run failure, timeout, mention filtering, and stale-state
+facts through logs, cards, or session diagnostics. It must not decide retry,
+reassignment, escalation, or ownership; those are coordination workflow
+decisions.
+
 ## Mention Policy
 
 Agent-authored mentions are default-allow and deny-list based:

--- a/docs/prompt-contract.md
+++ b/docs/prompt-contract.md
@@ -156,6 +156,14 @@ Agent 通过工作区里的 `.larkway/state.json` 或 v0.3 session state artifac
 - `content_blocks`: 可选的有序 markdown/image 正文块。需要平台正文与匹配图片在同一 review card 里相邻展示时使用;优先级和示例见 [Review Card Content Blocks](review-card-content-blocks.md)。
 - `response_surface`: 可选覆盖,主要用于声明 `post.mentions` late peer @。普通回复可不写;CardKit 流式卡片是唯一正常响应面。旧 `card` / `post` / `hybrid` mode 字段仅兼容解析,不再选择 post-only/hybrid 主响应面。这里的 late @ 是最终卡片里的视觉提示;需要 peer bot 消费正文的 handoff 必须由 Agent/团队工作流发送真实 Feishu post + at 标签。协议和门禁见 [Response Surface Prototype](response-surface-prototype.md)。
 
+当 prompt 注入 `<peer-bots>` 时,peer handoff 的 P0 协作契约是:
+
+- 发起方只在能力范围之外派 peer,且必须用真实 Feishu post + `at` 标签,不要用纯文本 `@name`。
+- 发起方在协调层/工作区台账记录 `task_id`、受托人、来源、期望产出、deadline 和升级人;没有专用 skill 时至少写进本 session summary。
+- 受托方收到 handoff 后先用真实 post 做轻量 ack,再执行长任务。
+- 受托方完成、失败或阻塞时必须用真实 post 回报终态,不能让链路静默停在自己这里。
+- deadline 检查、超时升级、重试/重派属于协调层 skill/workspace 逻辑;bridge 只暴露失败事实,不做业务编排。
+
 运行中答案流另有一个显式通道:Agent stdout 里只有包在独立行
 `LARKWAY_ANSWER_BEGIN` 和 `LARKWAY_ANSWER_END` 之间的正文会被 bridge
 当作可见答案流。marker 外的计划、思考、工具叙述、原始 runner

--- a/src/claude/prompt.test.ts
+++ b/src/claude/prompt.test.ts
@@ -239,6 +239,11 @@ describe("renderPrompt — V2 mode (botName set)", () => {
     expect(prompt).toContain("ou_peerbot001");
     expect(prompt).toContain("做测试和质量检查");
     expect(prompt).toContain("Backend Bot");
+    expect(prompt).toContain("工作区台账记录 task_id");
+    expect(prompt).toContain("先用真实 post 轻量 ack");
+    expect(prompt).toContain("必须用真实 post 回报终态");
+    expect(prompt).toContain("默认 15 分钟");
+    expect(prompt).toContain("不要期待 bridge 替你编排");
     expect(prompt).toContain("</peer-bots>");
   });
 

--- a/src/claude/prompt.ts
+++ b/src/claude/prompt.ts
@@ -311,6 +311,9 @@ function renderPeersBlock(peers: PeerBot[]): string[] {
     "- 不要把同一任务同时转发给多个 peer",
     "- @ peer 必须用 **post 消息** + at 标签 `{\"tag\":\"at\",\"user_id\":\"ou_xxx\"}`(用上面的 open_id),",
     "  **严禁用纯 text 的 @xxx**(纯文本 @ 不会真正触达对方 bot)",
+    "- 发起 peer handoff 后,在你的协调层/工作区台账记录 task_id、assignee、来源、期望产出、deadline 和升级人;没有专用 skill 时至少写入本 session summary。",
+    "- 收到 peer handoff 后,先用真实 post 轻量 ack(收到/开始)再做长任务;完成、失败或阻塞时必须用真实 post 回报终态,不要让链路静默停在你这里。",
+    "- 默认 deadline 可按团队工作流设置(常见默认 15 分钟);超时检测、重试/重派/升级属于协调层 skill/workspace 逻辑,不要期待 bridge 替你编排。",
     "</peer-bots>",
   ];
 }


### PR DESCRIPTION
## Summary
- inject peer handoff P0 rules into the `<peer-bots>` prompt block: ledger record, ack, terminal report, deadline ownership
- document the coordination-layer handoff contract in `docs/agent-handoff-reliability.md`
- keep retry/reassignment/escalation decisions outside the bridge; bridge only exposes facts

## Verification
- `pnpm exec vitest run src/claude/prompt.test.ts`
- `pnpm typecheck`
- `pnpm test`
- `git diff --cached --check` before commit
- staged public diff scan for real Feishu IDs, private IP patterns, and secrets: no matches

No merge, deploy, release, or bridge restart.