### PR TITLE
fix(PRB-6/§11.3): peer-@ correct delivery — runtime live-roster open_id resolver (#33 返工)

### DIFF
--- a/src/bridge/handler.test.ts
+++ b/src/bridge/handler.test.ts
@@ -1196,6 +1196,71 @@ describe("handleOne — thin-channel finalize", () => {
     expect(JSON.stringify(settings?.payload)).toContain("本轮被中断");
   });
 
+  it("PRB-6/§11.3: injects peer @ open_ids from the live roster (same app scope), not the static config id", async () => {
+    const threadId = "om_msg";
+    await seedWorktree(threadId);
+    await seedRepoCachePath();
+    const { client: cardKitClient } = makeCardKitClient();
+    let capturedPrompt = "";
+
+    runClaudeImpl = (opts: unknown) => {
+      capturedPrompt = (opts as { prompt?: string }).prompt ?? "";
+      return {
+        events: (async function* () {
+          yield { type: "system_init", sessionId: "sess_roster", raw: {} };
+        })(),
+        done: Promise.resolve({ exitCode: 0, sessionId: "sess_roster" }),
+        kill: () => {},
+      };
+    };
+
+    const { renderer } = makeCardRenderer();
+    const { store } = makeSessionStore();
+    const { client, acked } = makeClient(makeEvent());
+
+    const handler = new BridgeHandler({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      client: client as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      cardRenderer: renderer as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      sessionStore: store as any,
+      conventions: makeConventions(),
+      botConfig: {
+        id: "frontend",
+        name: "Frontend",
+        turn_taking_limit: 10,
+        backend: "claude",
+        response_surface_prototype: {
+          enabled: true,
+          allowed_chats: [],
+          allowed_threads: ["om_msg"],
+          kill_switch: false,
+          post_outbound_enabled: false,
+          cardkit_streaming_enabled: true,
+          allow_agent_mentions: true,
+          denied_mention_open_ids: [],
+          allowed_mention_open_ids: [],
+        },
+      },
+      cardKitClient,
+      peers: [{ id: "ou_cfg_elon", name: "Elon", description: "coord" }],
+      // Live roster returns a DIFFERENT (same-app-scope) id than the static config.
+      resolveLiveRoster: async () => new Map([["Elon", "ou_live_elon"]]),
+    });
+
+    await handler.run();
+    for (let i = 0; i < 200 && acked.length === 0; i++) {
+      await new Promise((r) => setTimeout(r, 10));
+    }
+
+    // The prompt the runner received must @-target the LIVE id, never the stale
+    // config id — that's the correct-delivery guarantee (Turing rework).
+    expect(capturedPrompt).toContain("<peer-bots>");
+    expect(capturedPrompt).toContain("ou_live_elon");
+    expect(capturedPrompt).not.toContain("ou_cfg_elon");
+  });
+
   it("adopts the already-visible CardKit reply when idConvert fails instead of creating a second card", async () => {
     const threadId = "om_msg";
     const finalState = {

--- a/src/bridge/handler.test.ts
+++ b/src/bridge/handler.test.ts
@@ -107,8 +107,33 @@ afterEach(async () => {
   runnerBackends = [];
   spawnCalls = [];
   spawnShouldFail = null;
-  await rm(root, { recursive: true, force: true });
+  await rmWithRetry(root);
 });
+
+/**
+ * handler.run() dispatches handleOne fire-and-forget, so a turn keeps writing
+ * ledger files into <worktree>/.larkway (updateCardKitRecord / deleteCardFile)
+ * AFTER the visible card.finalize that tests sync on via `whenFinalized`, and
+ * only then settles. Removing `root` at that mid-turn point can race a trailing
+ * write landing between rm's unlink pass and its rmdir → ENOTEMPTY. This is a
+ * cleanup-ordering artifact, not a product bug (write-ledger-then-settle is
+ * correct): retry the removal until those in-flight writes have landed and the
+ * tree is fully removable. Deterministic — the writes complete within ms.
+ */
+async function rmWithRetry(dir: string): Promise<void> {
+  for (let attempt = 0; ; attempt++) {
+    try {
+      await rm(dir, { recursive: true, force: true });
+      return;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOTEMPTY" && attempt < 50) {
+        await new Promise((r) => setTimeout(r, 20));
+        continue;
+      }
+      throw err;
+    }
+  }
+}
 
 interface FinalizeArgs {
   finalText?: string;

--- a/src/bridge/handler.test.ts
+++ b/src/bridge/handler.test.ts
@@ -107,33 +107,8 @@ afterEach(async () => {
   runnerBackends = [];
   spawnCalls = [];
   spawnShouldFail = null;
-  await rmWithRetry(root);
+  await rm(root, { recursive: true, force: true });
 });
-
-/**
- * handler.run() dispatches handleOne fire-and-forget, so a turn keeps writing
- * ledger files into <worktree>/.larkway (updateCardKitRecord / deleteCardFile)
- * AFTER the visible card.finalize that tests sync on via `whenFinalized`, and
- * only then settles. Removing `root` at that mid-turn point can race a trailing
- * write landing between rm's unlink pass and its rmdir → ENOTEMPTY. This is a
- * cleanup-ordering artifact, not a product bug (write-ledger-then-settle is
- * correct): retry the removal until those in-flight writes have landed and the
- * tree is fully removable. Deterministic — the writes complete within ms.
- */
-async function rmWithRetry(dir: string): Promise<void> {
-  for (let attempt = 0; ; attempt++) {
-    try {
-      await rm(dir, { recursive: true, force: true });
-      return;
-    } catch (err) {
-      if ((err as NodeJS.ErrnoException).code === "ENOTEMPTY" && attempt < 50) {
-        await new Promise((r) => setTimeout(r, 20));
-        continue;
-      }
-      throw err;
-    }
-  }
-}
 
 interface FinalizeArgs {
   finalText?: string;
@@ -1429,6 +1404,10 @@ describe("handleOne — thin-channel finalize", () => {
 
     await handler.run();
     await whenFinalized;
+    // whenFinalized fires at card.finalize; the turn then writes trailing ledger
+    // files (updateCardKitRecord / deleteCardFile) before it settles. Wait for
+    // the real turn boundary so assertions + afterEach cleanup don't race them.
+    await handler.whenAllTurnsSettled();
 
     expect(startArgs).toHaveLength(1);
     expect(finalizeArgs).toHaveLength(1);
@@ -1561,9 +1540,13 @@ describe("handleOne — thin-channel finalize", () => {
     });
 
     await handler.run();
-    for (let i = 0; i < 100 && unhandled.length === 0; i++) {
-      await new Promise((r) => setTimeout(r, 10));
-    }
+    // Sync on the REAL turn boundary: the failure path settles (markUnhandled)
+    // EARLY to release the @ for re-dispatch, then still renders the fallback
+    // card + create-only post. Polling `unhandled` raced those trailing renders
+    // (startArgs / postCalls not yet populated → flaky) and cleanup raced the
+    // cardkit.json.tmp→final rename (ENOENT). whenAllTurnsSettled() waits until
+    // handleOne fully returned and all trailing I/O drained.
+    await handler.whenAllTurnsSettled();
 
     expect(acked).toEqual([]);
     expect(unhandled).toEqual(["om_msg"]);
@@ -1777,9 +1760,13 @@ describe("handleOne — thin-channel finalize", () => {
     });
 
     await handler.run();
-    for (let i = 0; i < 100 && unhandled.length === 0; i++) {
-      await new Promise((r) => setTimeout(r, 10));
-    }
+    // Sync on the REAL turn boundary: the failure path settles (markUnhandled)
+    // EARLY to release the @ for re-dispatch, then still renders the fallback
+    // card + create-only post. Polling `unhandled` raced those trailing renders
+    // (startArgs / postCalls not yet populated → flaky) and cleanup raced the
+    // cardkit.json.tmp→final rename (ENOENT). whenAllTurnsSettled() waits until
+    // handleOne fully returned and all trailing I/O drained.
+    await handler.whenAllTurnsSettled();
 
     expect(acked).toEqual([]);
     expect(unhandled).toEqual(["om_msg"]);

--- a/src/bridge/handler.ts
+++ b/src/bridge/handler.ts
@@ -26,6 +26,7 @@ import type { CardRenderer } from "../lark/card.js";
 import type { SessionStore } from "../claude/sessionStore.js";
 import { parseMessage } from "../lark/message.js";
 import { renderPrompt } from "../claude/prompt.js";
+import { remapPeersToLiveRoster, type LiveRosterResolver } from "../lark/rosterResolver.js";
 import type { PeerBot, RepoRef } from "../claude/prompt.js";
 import { createRunner } from "../agent/runner.js";
 import type { BotConfig } from "../config/botLoader.js";
@@ -620,6 +621,13 @@ export interface BridgeHandlerDeps {
    * profile name). When absent (V1), lark-cli uses the default profile.
    */
   larkCliProfile?: string;
+  /**
+   * PRB-6/§11.3 peer-@ correct delivery. Resolves the live chat bot roster (in
+   * THIS bot's app scope) so `<peer-bots>` @ targets use the same-scope open_id
+   * instead of the possibly cross-scope static config id. main.ts wires a
+   * per-chat-cached resolver; absent (V1 / tests) → static config ids are used.
+   */
+  resolveLiveRoster?: LiveRosterResolver;
   /**
    * Optional dashboard observability sink. It records the bridge lifecycle for
    * recent Feishu events, so the Web UI can explain silent @ mentions.
@@ -1226,6 +1234,44 @@ export class BridgeHandler {
 
         // Step 4b: render prompt — isNewThread reflects current attempt's state.
         const currentIsNewThread = currentExisting === undefined;
+        // PRB-6/§11.3: resolve peer @ targets to their same-app-scope open_id
+        // from the LIVE chat roster before building the prompt, so a handoff @
+        // actually wakes the peer (the static config id may be cross-scope).
+        // Best-effort: any failure keeps the static ids and never blocks the turn.
+        let effectivePeers = this.deps.peers;
+        if (effectivePeers?.length && this.deps.resolveLiveRoster) {
+          try {
+            const liveRoster = await this.deps.resolveLiveRoster(parsed.chatId);
+            if (liveRoster) {
+              const { peers: remappedPeers, remapped, unresolved } = remapPeersToLiveRoster(
+                effectivePeers,
+                liveRoster,
+              );
+              effectivePeers = remappedPeers;
+              if (remapped.length > 0 || unresolved.length > 0) {
+                await recordEvent({
+                  status: "running",
+                  appendPath: "peer roster",
+                  reason:
+                    `live-roster resolve: remapped [${remapped.join(", ") || "none"}] to ` +
+                    `same-app-scope open_id; unresolved (kept static config id, may not be ` +
+                    `deliverable) [${unresolved.join(", ") || "none"}].`,
+                });
+              }
+            } else {
+              await recordEvent({
+                status: "running",
+                appendPath: "peer roster",
+                reason:
+                  "live-roster resolve returned nothing; kept static <peer-bots> open_ids " +
+                  "(may be cross-app-scope / undeliverable).",
+              });
+            }
+          } catch (err) {
+            console.warn("[bridge.handler] live-roster resolve failed (using static peers):", err);
+          }
+        }
+
         const prompt = renderPrompt({
           parsed,
           isNewThread: currentIsNewThread,
@@ -1247,7 +1293,7 @@ export class BridgeHandler {
             readOnly: conventions.readOnly,
             gitlabTokenEnvName: conventions.gitlabTokenEnvName,
           },
-          peers: this.deps.peers,
+          peers: effectivePeers,
           turn_taking_limit: this.deps.botConfig?.turn_taking_limit,
           botName: this.deps.botConfig?.name,
           backend: this.deps.botConfig?.backend,

--- a/src/bridge/handler.ts
+++ b/src/bridge/handler.ts
@@ -649,8 +649,31 @@ export class BridgeHandler {
   private readonly deps: BridgeHandlerDeps;
   private closed = false;
 
+  /**
+   * In-flight per-turn completion promises. run() dispatches handleOne
+   * fire-and-forget (thread-serialized), so run() returning does NOT mean the
+   * turn finished. Each entry resolves only when its handleOne AND all trailing
+   * work (terminal render + ledger writes, incl. the failure-path fallback that
+   * runs after the early settle) have completed. {@link whenAllTurnsSettled}
+   * awaits these — the real turn boundary tests must sync assertions/cleanup on.
+   */
+  private readonly inFlightTurns = new Set<Promise<void>>();
+
   constructor(deps: BridgeHandlerDeps) {
     this.deps = deps;
+  }
+
+  /**
+   * Resolves when every dispatched turn has fully completed (handleOne returned
+   * and its trailing render/ledger I/O drained). Test-facing sync point; a bridge
+   * that keeps receiving events would keep finding work, so callers use this
+   * after the event source is exhausted (e.g. right after `await run()` in a
+   * single-message test).
+   */
+  async whenAllTurnsSettled(): Promise<void> {
+    while (this.inFlightTurns.size > 0) {
+      await Promise.all([...this.inFlightTurns]);
+    }
   }
 
   private runtimeWarnings(): RuntimeRequirement[] {
@@ -713,7 +736,11 @@ export class BridgeHandler {
         .finally(() => {
           release();
           if (threadQueues.get(key) === next) threadQueues.delete(key);
+          this.inFlightTurns.delete(next);
         });
+      // Track the true completion of this turn (handleOne + all trailing I/O) so
+      // whenAllTurnsSettled() can await it.
+      this.inFlightTurns.add(next);
       threadQueues.set(key, next);
     }
   }

--- a/src/lark/rosterResolver.test.ts
+++ b/src/lark/rosterResolver.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Tests for src/lark/rosterResolver.ts — PRB-6/§11.3 peer-@ correct delivery.
+ * Pure parse/remap + the injected-exec resolver + per-chat cache. No real
+ * subprocess (per CLAUDE.md).
+ */
+import { describe, it, expect } from "vitest";
+import {
+  parseBotRoster,
+  remapPeersToLiveRoster,
+  resolveChatBotRoster,
+  createCachedRosterResolver,
+} from "./rosterResolver.js";
+import type { PeerBot } from "../claude/prompt.js";
+
+const rosterStdout = JSON.stringify({
+  ok: true,
+  identity: "bot",
+  data: {
+    items: [
+      { bot_id: "ou_live_elon", bot_name: "Elon" },
+      { bot_id: "ou_live_turing", bot_name: "Turing" },
+    ],
+  },
+});
+
+describe("parseBotRoster", () => {
+  it("maps bot_name → bot_id from data.items", () => {
+    const roster = parseBotRoster(rosterStdout);
+    expect(roster.get("Elon")).toBe("ou_live_elon");
+    expect(roster.get("Turing")).toBe("ou_live_turing");
+    expect(roster.size).toBe(2);
+  });
+
+  it("returns empty map on malformed JSON or missing items (never throws)", () => {
+    expect(parseBotRoster("not json").size).toBe(0);
+    expect(parseBotRoster(JSON.stringify({ data: {} })).size).toBe(0);
+    expect(parseBotRoster(JSON.stringify({ data: { items: "x" } })).size).toBe(0);
+  });
+
+  it("skips items missing bot_name or bot_id", () => {
+    const roster = parseBotRoster(
+      JSON.stringify({ data: { items: [{ bot_name: "A" }, { bot_id: "ou_b" }, {}] } }),
+    );
+    expect(roster.size).toBe(0);
+  });
+});
+
+describe("remapPeersToLiveRoster", () => {
+  const peers: PeerBot[] = [
+    { id: "ou_cfg_elon", name: "Elon", description: "coord" },
+    { id: "ou_cfg_ghost", name: "Ghost", description: "absent" },
+  ];
+
+  it("replaces a config id with the live same-scope id and reports it", () => {
+    const roster = new Map([["Elon", "ou_live_elon"]]);
+    const { peers: out, remapped, unresolved } = remapPeersToLiveRoster(peers, roster);
+    expect(out.find((p) => p.name === "Elon")?.id).toBe("ou_live_elon");
+    expect(remapped).toEqual(["Elon"]);
+    // Ghost absent from live roster → kept static id, reported unresolved.
+    expect(out.find((p) => p.name === "Ghost")?.id).toBe("ou_cfg_ghost");
+    expect(unresolved).toEqual(["Ghost"]);
+  });
+
+  it("no-op when live id equals config id (not counted as remapped)", () => {
+    const roster = new Map([["Elon", "ou_cfg_elon"]]);
+    const { remapped, unresolved } = remapPeersToLiveRoster(
+      [{ id: "ou_cfg_elon", name: "Elon", description: "" }],
+      roster,
+    );
+    expect(remapped).toEqual([]);
+    expect(unresolved).toEqual([]);
+  });
+});
+
+describe("resolveChatBotRoster (injected exec)", () => {
+  it("returns the parsed roster from the lark-cli call", async () => {
+    const calls: string[][] = [];
+    const roster = await resolveChatBotRoster("oc_1", {
+      profile: "cli_x",
+      exec: async (cmd, args) => {
+        calls.push([cmd, ...args]);
+        return rosterStdout;
+      },
+    });
+    expect(roster?.get("Elon")).toBe("ou_live_elon");
+    // Queries in the bot's own app scope: --as bot + its profile.
+    expect(calls[0]).toContain("chat.members");
+    expect(calls[0]).toContain("bots");
+    expect(calls[0]).toContain("--chat-id");
+    expect(calls[0]).toContain("oc_1");
+    expect(calls[0]).toContain("--as");
+    expect(calls[0]).toContain("--profile");
+    expect(calls[0]).toContain("cli_x");
+  });
+
+  it("returns null on exec failure or empty roster (caller keeps static ids)", async () => {
+    expect(
+      await resolveChatBotRoster("oc_1", {
+        exec: async () => {
+          throw new Error("lark-cli not found");
+        },
+      }),
+    ).toBeNull();
+    expect(
+      await resolveChatBotRoster("oc_1", {
+        exec: async () => JSON.stringify({ data: { items: [] } }),
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("createCachedRosterResolver", () => {
+  it("caches per chat within the TTL (one lark-cli call), re-resolves after expiry", async () => {
+    let execCount = 0;
+    let clock = 1_000;
+    const resolver = createCachedRosterResolver({
+      profile: "cli_x",
+      ttlMs: 1000,
+      now: () => clock,
+      exec: async () => {
+        execCount += 1;
+        return rosterStdout;
+      },
+    });
+
+    expect((await resolver("oc_1"))?.get("Elon")).toBe("ou_live_elon");
+    await resolver("oc_1"); // within TTL → cached
+    expect(execCount).toBe(1);
+
+    clock += 2000; // past TTL
+    await resolver("oc_1");
+    expect(execCount).toBe(2);
+
+    // A different chat is resolved independently.
+    await resolver("oc_2");
+    expect(execCount).toBe(3);
+  });
+});

--- a/src/lark/rosterResolver.ts
+++ b/src/lark/rosterResolver.ts
@@ -1,0 +1,159 @@
+/**
+ * src/lark/rosterResolver.ts
+ *
+ * PRB-6/§11.3 — peer-@ CORRECT DELIVERY.
+ *
+ * Feishu `open_id` is app-scoped: the SAME bot has a different open_id in each
+ * app's view. A handoff `@` only wakes the peer when its `user_id` is the peer's
+ * open_id **in the sending bot's own app scope**. The static `<peer-bots>` roster
+ * comes from config `bot_open_id`, which can have been captured under a different
+ * app's scope → the `@` is silently dropped and the peer never wakes.
+ *
+ * This module resolves each peer's open_id AT RUNTIME from the live chat roster,
+ * queried with this bot's OWN lark-cli profile (so the ids are same-scope):
+ *   `lark-cli im chat.members bots --chat-id <chat> --as bot [--profile <p>]`
+ * then remaps the configured peers by name to those live ids. On any failure the
+ * caller keeps the static config ids (best-effort, never blocks a turn).
+ *
+ * Split into PURE (parse / remap — fully unit-testable, no fs / no subprocess)
+ * and IMPURE (the lark-cli spawn) so the hot path stays testable and the handler
+ * can inject a fake resolver in tests (no real subprocess, per CLAUDE.md).
+ */
+
+import { execFile } from "node:child_process";
+import type { PeerBot } from "../claude/prompt.js";
+
+/** bot display name → open_id, both in the querying app's scope. */
+export type LiveBotRoster = Map<string, string>;
+
+/**
+ * PURE. Parse the JSON stdout of `im chat.members bots` into a name→open_id map.
+ * Tolerant: a malformed payload / missing fields yield an empty map (caller then
+ * falls back to the static config ids), never a throw.
+ */
+export function parseBotRoster(stdout: string): LiveBotRoster {
+  const roster: LiveBotRoster = new Map();
+  let json: unknown;
+  try {
+    json = JSON.parse(stdout);
+  } catch {
+    return roster;
+  }
+  const items = (json as { data?: { items?: unknown } } | null)?.data?.items;
+  if (!Array.isArray(items)) return roster;
+  for (const item of items) {
+    if (typeof item !== "object" || item === null) continue;
+    const record = item as Record<string, unknown>;
+    const name = record["bot_name"];
+    const id = record["bot_id"];
+    if (typeof name === "string" && name && typeof id === "string" && id) {
+      roster.set(name, id);
+    }
+  }
+  return roster;
+}
+
+export interface RemapResult {
+  /** Peers with each open_id replaced by its live same-scope id where found. */
+  peers: PeerBot[];
+  /** Peer names whose id was replaced (config id ≠ live id). */
+  remapped: string[];
+  /** Peer names NOT present in the live roster (kept their static config id). */
+  unresolved: string[];
+}
+
+/**
+ * PURE. Remap configured peers to their live same-scope open_id by matching on
+ * bot name. A peer missing from the live roster keeps its static config id (and
+ * is reported as `unresolved` so the caller can surface it — PRB-2 fact).
+ */
+export function remapPeersToLiveRoster(peers: PeerBot[], liveRoster: LiveBotRoster): RemapResult {
+  const remapped: string[] = [];
+  const unresolved: string[] = [];
+  const out = peers.map((peer) => {
+    const liveId = liveRoster.get(peer.name);
+    if (!liveId) {
+      unresolved.push(peer.name);
+      return peer;
+    }
+    if (liveId !== peer.id) {
+      remapped.push(peer.name);
+      return { ...peer, id: liveId };
+    }
+    return peer;
+  });
+  return { peers: out, remapped, unresolved };
+}
+
+export interface ResolveRosterOpts {
+  larkCliPath?: string;
+  profile?: string;
+  /** Test seam: injected exec returning raw stdout. Defaults to a lark-cli spawn. */
+  exec?: (cmd: string, args: string[]) => Promise<string>;
+  timeoutMs?: number;
+}
+
+/**
+ * IMPURE. Query the live chat bot roster in this bot's app scope. Returns null on
+ * any failure (spawn error, non-zero exit, empty/malformed output) so the caller
+ * falls back to the static config ids.
+ */
+export async function resolveChatBotRoster(
+  chatId: string,
+  opts: ResolveRosterOpts = {},
+): Promise<LiveBotRoster | null> {
+  const cli = opts.larkCliPath ?? "lark-cli";
+  const args = ["im", "chat.members", "bots", "--chat-id", chatId, "--as", "bot"];
+  if (opts.profile) args.push("--profile", opts.profile);
+  const exec = opts.exec ?? defaultExec(opts.timeoutMs ?? 10_000);
+  try {
+    const stdout = await exec(cli, args);
+    const roster = parseBotRoster(stdout);
+    return roster.size > 0 ? roster : null;
+  } catch {
+    return null;
+  }
+}
+
+function defaultExec(timeoutMs: number): (cmd: string, args: string[]) => Promise<string> {
+  return (cmd, args) =>
+    new Promise((resolve, reject) => {
+      execFile(cmd, args, { timeout: timeoutMs, maxBuffer: 1024 * 1024 }, (err, stdout) => {
+        if (err) reject(err);
+        else resolve(stdout);
+      });
+    });
+}
+
+/** A per-message resolver the handler calls: chatId → live roster (or null). */
+export type LiveRosterResolver = (chatId: string) => Promise<LiveBotRoster | null>;
+
+/**
+ * Build a per-chat-cached resolver for one bot. The roster is stable per (app,
+ * chat) so a short TTL cache keeps the prompt-build path from spawning lark-cli
+ * on every message. main.ts wires one of these per bot with that bot's profile.
+ */
+export function createCachedRosterResolver(opts: {
+  profile?: string;
+  larkCliPath?: string;
+  ttlMs?: number;
+  now?: () => number;
+  exec?: ResolveRosterOpts["exec"];
+}): LiveRosterResolver {
+  const ttlMs = opts.ttlMs ?? 5 * 60 * 1000;
+  const now = opts.now ?? (() => Date.now());
+  const cache = new Map<string, { roster: LiveBotRoster | null; at: number }>();
+  return async (chatId: string) => {
+    const hit = cache.get(chatId);
+    if (hit && now() - hit.at < ttlMs) return hit.roster;
+    const roster = await resolveChatBotRoster(chatId, {
+      profile: opts.profile,
+      larkCliPath: opts.larkCliPath,
+      exec: opts.exec,
+    });
+    // Cache both hits and misses (a miss is brief per TTL) so a flaky chat does
+    // not spawn lark-cli on every message; a null just means "kept static ids".
+    cache.set(chatId, { roster, at: now() });
+    return roster;
+  };
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -29,6 +29,7 @@ import { registerRunner } from "./agent/runner.js";
 import { ClaudeRunner } from "./claude/runner.js";
 import { CodexRunner } from "./codex/runner.js";
 import { ensureLarkCliProfile, deriveLarkCliProfile } from "./lark/profileBootstrap.js";
+import { createCachedRosterResolver } from "./lark/rosterResolver.js";
 import { checkWorkspacePermissionGrant } from "./agent/permissionGate.js";
 import { runtimeRequirementsForBots } from "./runtimeRequirements.js";
 import { registerCrashGuard } from "./crashGuard.js";
@@ -370,6 +371,12 @@ async function runV2Mode({
       gitlabToken: effectiveGitlabToken,
       agentMemory: bot.agent_memory,
       larkCliProfile,
+      // PRB-6/§11.3: resolve peer @ targets to same-app-scope open_ids from the
+      // live chat roster (per-chat cached), only when this bot actually has peers.
+      resolveLiveRoster:
+        resolvedPeers.length > 0
+          ? createCachedRosterResolver({ profile: larkCliProfile })
+          : undefined,
       runtimeRequirements: runtimeRequirementsForBots([bot]),
       recordRuntimeEvent: async (patch) => {
         await upsertRuntimeEvent(larkwayHome(), bot.id, patch);


### PR DESCRIPTION
#33 rework per Turing. Turing rejected the original PR #33 as **prompt-guidance only** — no runtime resolver, no `chat.members bots` code path, no proof the actual `@` uses a same-app-scope id. This is the real correct-delivery fix.

## Root cause (recap)
Feishu `open_id` is app-scoped: a bot has a different open_id per app. The static `<peer-bots>` roster comes from config `bot_open_id`, which can be captured under a **different** app's scope → the handoff `@` is silently dropped and the peer never wakes. (Live evidence earlier: config Elon `ou_0df4…` vs live-scope `ou_e417…`.)

## Fix — runtime resolution (bridge, correct delivery; NOT orchestration)
- **`src/lark/rosterResolver.ts`** (new): 
  - PURE `parseBotRoster` (parse `im chat.members bots` JSON) + `remapPeersToLiveRoster` (remap peers by name to live ids, report remapped/unresolved).
  - IMPURE `resolveChatBotRoster` — spawns `lark-cli im chat.members bots --chat-id <chat> --as bot --profile <p>` (this bot's OWN scope); null on any failure.
  - `createCachedRosterResolver` — per-chat TTL cache so the prompt path doesn't spawn lark-cli every message.
- **`handler.ts`**: before `renderPrompt`, resolve the live roster for the message's `chatId` and remap `<peer-bots>` `@` targets to the same-scope open_id. Best-effort — any failure keeps the static ids and never blocks a turn. Remapped/unresolved peers are surfaced as a `peer roster` diagnostic (PRB-2 fact: an unresolved peer keeps its static id and is flagged as maybe-undeliverable).
- **`main.ts`**: wire a per-bot cached resolver (only when the bot has peers), using the bot's lark-cli profile.

## Delivery proof (tests)
- `rosterResolver.test.ts` (8): parse + name→live-id remap + fallback on failure/empty + per-chat cache/TTL.
- `handler.test.ts`: with a live roster returning a *different* id than config, the prompt the runner receives **@-targets the live id (`ou_live_elon`), never the stale config id (`ou_cfg_elon`)** — the correct-delivery guarantee at the bridge boundary.
- Full suite green: **843 passed**, `pnpm typecheck` clean.

## Scope
Bridge guarantees the correct same-scope open_id reaches the agent + surfaces unresolved targets as facts. The ack / deadline / retry / escalation loop stays in the coordination layer (Elon), not the bridge.

**Supersedes the prompt-only PR #33.** Routed to Turing for re-review. Merge/deploy gated on Elon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)