### PR TITLE
fix: never discard whole state.json over one bad/missing field (updated_at + field-level salvage)

### DIFF
--- a/src/bridge/handler.ts
+++ b/src/bridge/handler.ts
@@ -1569,6 +1569,17 @@ export class BridgeHandler {
             trustedAnswerText.trim() ||
             cardKitProgress?.answerText.trim() ||
             "";
+          // When there's genuinely no fresh state AND no answer text, tell the
+          // operator WHERE it broke + a concrete next step, instead of the old
+          // loop-inducing "再 @ 我一次重试" (which just reproduced the same
+          // failure — e.g. a bot that keeps writing a state.json the schema
+          // rejects). 2026-07-02 排障 fix #3.
+          const noOutputFallback =
+            "⚠️ 本轮 agent 没有产出正文，也没有写入有效状态(state.json)。\n" +
+            (result.exitCode !== 0
+              ? `agent 进程异常退出(exit code ${result.exitCode})。\n`
+              : "") +
+            "下一步：换个说法重试，或新开一个话题继续；若反复如此，请让维护者查看该 session 日志。";
           const cardBody =
             cardKitTimeoutFailure
               // PRB-9/§12.2: idle-stuck → unified explicit-failure sink, never a
@@ -1576,9 +1587,7 @@ export class BridgeHandler {
               // manually (safe auto-replay + idempotency is 批B §11.6).
               ? "⚠️ 本轮被中断（长时间无活性，判定卡死），未完成。请重试。"
               : reportedState?.last_message ??
-                (fallbackAnswer
-                  ? fallbackAnswer
-                  : "⚠️ 本轮没有拿到 agent 的新回复(可能被中断或未更新状态),再 @ 我一次重试。");
+                (fallbackAnswer ? fallbackAnswer : noOutputFallback);
 
           // When the agent didn't report status this turn (reportedState null,
           // per stale-guard) but exited cleanly, don't let the card default to

--- a/src/bridge/stateFile.test.ts
+++ b/src/bridge/stateFile.test.ts
@@ -576,3 +576,137 @@ describe("StateFileSchema — V2 content blocks (ordered card body)", () => {
     }
   });
 });
+
+describe("readStateFileDetailed — updated_at optional + server-stamp (2026-07-02 排障)", () => {
+  it("accepts a state.json missing updated_at and server-stamps it (no whole-state discard)", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "larkway-state-"));
+    try {
+      await mkdir(join(dir, ".larkway"), { recursive: true });
+      // The exact shape that stranded a live topic every turn: valid status +
+      // last_message, but NO updated_at.
+      await writeFile(
+        stateFilePathOf(dir),
+        JSON.stringify({ status: "ready", last_message: "真实回复必须活下来" }),
+        "utf8",
+      );
+
+      const result = await readStateFileDetailed(dir);
+      expect(result.state).not.toBeNull();
+      expect(result.state?.status).toBe("ready");
+      expect(result.state?.last_message).toBe("真实回复必须活下来");
+      // server-stamped from file mtime → non-empty ISO string
+      expect(typeof result.state?.updated_at).toBe("string");
+      expect(result.state?.updated_at).not.toBe("");
+      expect(() => new Date(result.state!.updated_at!).toISOString()).not.toThrow();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("stamps updated_at from mtime, which advances on rewrite (keeps the stale-guard working)", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "larkway-state-"));
+    try {
+      await mkdir(join(dir, ".larkway"), { recursive: true });
+      const body = { status: "in_progress" as const, last_message: "v1" };
+      await writeFile(stateFilePathOf(dir), JSON.stringify(body), "utf8");
+      const first = await readStateFileDetailed(dir);
+
+      // Rewrite the file after a real delay so mtime advances.
+      await new Promise((r) => setTimeout(r, 15));
+      await writeFile(
+        stateFilePathOf(dir),
+        JSON.stringify({ status: "in_progress", last_message: "v2" }),
+        "utf8",
+      );
+      const second = await readStateFileDetailed(dir);
+
+      expect(first.state?.updated_at).toBeTruthy();
+      expect(second.state?.updated_at).toBeTruthy();
+      // A rewrite advances mtime → the handler's `updated_at !== preRun` guard
+      // still detects a fresh write even though the bot never wrote updated_at.
+      expect(second.state?.updated_at).not.toBe(first.state?.updated_at);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("readStateFileDetailed — field-level degradation salvage (2026-07-02 排障)", () => {
+  it("salvages status + last_message when a non-critical field fails the full schema", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "larkway-state-"));
+    try {
+      await mkdir(join(dir, ".larkway"), { recursive: true });
+      // choices is structurally invalid (missing value) → full StateFileSchema
+      // rejects the whole object. Salvage must still surface status+last_message.
+      await writeFile(
+        stateFilePathOf(dir),
+        JSON.stringify({
+          status: "ready",
+          last_message: "operator 必须看到这条,而不是通用兜底",
+          choices: [{ label: "no value here" }],
+          updated_at: "2026-07-02T00:00:00.000Z",
+        }),
+        "utf8",
+      );
+
+      const result = await readStateFileDetailed(dir);
+      expect(result.state).not.toBeNull();
+      expect(result.state?.status).toBe("ready");
+      expect(result.state?.last_message).toBe("operator 必须看到这条,而不是通用兜底");
+      // the bad field is dropped, not the whole state
+      expect(result.state?.choices).toBeUndefined();
+      // and the drop is diagnosed (names the offending field)
+      expect(result.diagnostics.join("\n")).toContain("choices");
+      expect(result.diagnostics.join("\n")).toContain("保留 status/last_message");
+      // updated_at was present here → preserved verbatim
+      expect(result.state?.updated_at).toBe("2026-07-02T00:00:00.000Z");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("salvages + stamps updated_at when BOTH a field is bad AND updated_at is missing", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "larkway-state-"));
+    try {
+      await mkdir(join(dir, ".larkway"), { recursive: true });
+      await writeFile(
+        stateFilePathOf(dir),
+        JSON.stringify({
+          status: "failed",
+          last_message: "止血:坏字段+缺 updated_at 都要活下来",
+          error: "boom",
+          content_blocks: [{ type: "markdown" }], // missing content → invalid
+        }),
+        "utf8",
+      );
+
+      const result = await readStateFileDetailed(dir);
+      expect(result.state?.status).toBe("failed");
+      expect(result.state?.last_message).toBe("止血:坏字段+缺 updated_at 都要活下来");
+      expect(result.state?.error).toBe("boom");
+      expect(result.state?.content_blocks).toBeUndefined();
+      expect(typeof result.state?.updated_at).toBe("string");
+      expect(result.state?.updated_at).not.toBe("");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("still returns null when there is no salvageable status (genuinely no report)", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "larkway-state-"));
+    try {
+      await mkdir(join(dir, ".larkway"), { recursive: true });
+      // status is invalid → nothing usable to salvage → null (honest "no report")
+      await writeFile(
+        stateFilePathOf(dir),
+        JSON.stringify({ status: "bogus", last_message: "no valid status" }),
+        "utf8",
+      );
+
+      const result = await readStateFileDetailed(dir);
+      expect(result.state).toBeNull();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/bridge/stateFile.ts
+++ b/src/bridge/stateFile.ts
@@ -199,10 +199,47 @@ export const StateFileSchema = z.object({
    * ignored and the legacy card path remains authoritative.
    */
   response_surface: ResponseSurfaceStateSchema.optional(),
-  updated_at: z.string(),
+  /**
+   * Freshness signal for the handler's stale-guard (it compares this against a
+   * pre-run snapshot to decide whether the bot rewrote state THIS turn).
+   *
+   * **OPTIONAL by thin-channel principle.** This used to be the ONE hard-required
+   * field, so a bot that wrote a perfectly good `status` + `last_message` but
+   * omitted `updated_at` had its ENTIRE state discarded → the card stranded on
+   * "本轮没有拿到 agent 的新回复" every single turn (2026-07-02 排障: one shared
+   * topic reproduced this on every @). Same failure class as the old
+   * `z.string().url()` mr_url and the strict `stage`/`card_color` enums.
+   *
+   * When absent, {@link readStateFileDetailed} server-stamps it from the file's
+   * mtime — which advances only on a real rewrite, so the stale-guard stays
+   * correct even for bots that never write the field.
+   */
+  updated_at: z.string().optional(),
 });
 
 export type StateFile = z.infer<typeof StateFileSchema>;
+
+/**
+ * 止血 salvage schema for field-level degradation (2026-07-02).
+ *
+ * When the full {@link StateFileSchema} rejects the whole object over ONE bad
+ * field, the bridge still only truly needs `status` (+ the operator-facing
+ * `last_message`). This lenient schema keeps those and drops everything else, so
+ * a single malformed/absent field can never strand the card on the generic
+ * "没拿到新回复" fallback. `z.object` strips unknown keys (structured business
+ * fields are simply omitted on this path); scalar fields use `.catch(undefined)`
+ * so a wrong-typed one degrades instead of failing salvage. `status` stays
+ * hard-required — without a valid status there is genuinely no usable report and
+ * the caller falls through to `null`.
+ */
+const SalvageStateSchema = z.object({
+  status: z.enum(["in_progress", "ready", "failed"]),
+  last_message: z.string().optional().catch(undefined),
+  error: z.string().optional().catch(undefined),
+  card_title: z.string().optional().catch(undefined),
+  card_text: z.string().optional().catch(undefined),
+  updated_at: z.string().optional().catch(undefined),
+});
 
 export interface StateFileReadResult {
   state: StateFile | null;
@@ -276,6 +313,16 @@ export async function readStateFileDetailed(
     return { state: null, diagnostics: [] };
   }
 
+  // mtime is the server-side freshness fallback for a missing `updated_at`
+  // (advances only on a real rewrite → keeps the handler's stale-guard correct).
+  // Best-effort: never fail the read over a missing stat.
+  let mtimeIso: string | undefined;
+  try {
+    mtimeIso = (await fs.stat(file)).mtime.toISOString();
+  } catch {
+    /* leave undefined; withStampedUpdatedAt falls back to now() */
+  }
+
   let parsed: unknown;
   try {
     parsed = JSON.parse(raw);
@@ -305,18 +352,59 @@ export async function readStateFileDetailed(
   }
 
   const result = StateFileSchema.safeParse(parsed);
-  if (!result.success) {
-    console.warn(
-      `[stateFile] ${file} failed schema validation:`,
-      result.error.issues,
-    );
-    return { state: null, diagnostics: [] };
+  if (result.success) {
+    const state = withStampedUpdatedAt(result.data, mtimeIso);
+    const diagnostics = diagnoseStateFile(parsed, result.data);
+    for (const diagnostic of diagnostics) {
+      console.warn(`[stateFile] ${file}: ${diagnostic}`);
+    }
+    return { state, diagnostics };
   }
-  const diagnostics = diagnoseStateFile(parsed, result.data);
-  for (const diagnostic of diagnostics) {
+
+  // Field-level degradation (止血, 2026-07-02): the full schema rejected the
+  // whole object over some field, but the bridge only truly needs `status`
+  // (+ the operator-facing last_message). Salvage those instead of discarding
+  // everything — otherwise one malformed/absent field strands the card on the
+  // generic "本轮没有拿到 agent 的新回复" fallback every turn.
+  const salvaged = SalvageStateSchema.safeParse(parsed);
+  if (salvaged.success) {
+    const droppedFields = summarizeRejectedTopFields(result.error);
+    const state = withStampedUpdatedAt(salvaged.data, mtimeIso);
+    const diagnostic = `state.json 部分字段无效已忽略，保留 status/last_message（受影响字段：${droppedFields}）`;
     console.warn(`[stateFile] ${file}: ${diagnostic}`);
+    return { state, diagnostics: [diagnostic] };
   }
-  return { state: result.data, diagnostics };
+
+  // Unsalvageable — not even a valid `status`. Genuine "no usable report".
+  console.warn(
+    `[stateFile] ${file} failed schema validation (unsalvageable):`,
+    result.error.issues,
+  );
+  return { state: null, diagnostics: [] };
+}
+
+/**
+ * Server-stamp a missing/blank `updated_at` from the file's mtime. mtime advances
+ * only when the bot actually rewrites state.json, so the handler's stale-guard
+ * (`updated_at !== preRunUpdatedAt`) keeps working even for bots that never write
+ * the field. Falls back to now() only if mtime was unavailable (stat failed).
+ */
+function withStampedUpdatedAt(
+  state: StateFile,
+  mtimeIso: string | undefined,
+): StateFile {
+  if (state.updated_at != null && state.updated_at !== "") return state;
+  return { ...state, updated_at: mtimeIso ?? new Date().toISOString() };
+}
+
+/** Distinct top-level field names that failed full-schema validation. */
+function summarizeRejectedTopFields(error: z.ZodError): string {
+  const fields = new Set<string>();
+  for (const issue of error.issues) {
+    const top = issue.path[0];
+    fields.add(top === undefined ? "(root)" : String(top));
+  }
+  return [...fields].join(", ") || "(unknown)";
 }
 
 function diagnoseStateFile(parsed: unknown, state: StateFile): string[] {


### PR DESCRIPTION
## 根因 (已坐实 + Turing 独立验收通过)

多 bot 共用的话题里,某些 bot 每轮 @ 都回退成 `⚠️ 本轮没有拿到 agent 的新回复…再 @ 我一次重试`,新话题正常。

`state.json` 的 zod schema 把 `updated_at` 设成**唯一必填字段**(其余全 `.optional()`)。agent 写了合法的 `status` + `last_message` 但漏掉 `updated_at` 时,`StateFileSchema.safeParse` 失败 → `readStateFileDetailed` `return { state: null }` **丢弃整份 state** → handler 落到通用兜底句。re-@ 无用(每轮写的都是同一份缺字段的 state)。

证据:bridge 日志 `failed schema validation: path:['updated_at'] Required` 共 **116 次**,坏话题独占 **48 次**;该话题现存 `state.json` 实测 = `{status, last_message}`,确无 `updated_at`。与历史上 `mr_url` 的 `z.string().url()`、`stage`/`card_color` 严格枚举同一失败类(「一个字段坏 → 丢整份」)。

## 改法

| # | 文件 | 改动 |
|---|---|---|
| 1 | `stateFile.ts` | `updated_at` 改 `.optional()`;缺失时 `readStateFileDetailed` 用**文件 mtime** 服务端补戳。用 mtime 而非 read-time:mtime 只在真正 rewrite 时前进,handler 的 stale-guard(`updated_at !== preRunUpdatedAt`)因此保持正确,不会把上一轮的旧 `last_message` 误当本轮 fresh 重渲染。 |
| 2 | `stateFile.ts` | **核心止血**:full schema 失败时不再 `return null`,改用 `SalvageStateSchema` 抢救 `status` + `last_message`(+ 标量字段),只丢掉出错的那个字段并给诊断。仅当连合法 `status` 都没有时才 fall through 到 `null`(真「无有效回报」)。 |
| 3 | `handler.ts` | 无 state 无正文时的兜底文案改成「哪里断 + 下一步」(含 exit code、换说法/新开话题/查日志),不再是会诱发无限循环的「再 @ 我一次重试」。 |

## 关于 #4 / #5(对着当前 main 重新定位后的诚实结论)

- **#4 确定性失败重试上限:已存在**,不重复造。`channelClient.ts` 的 `messageAttempts` + `MAX_MESSAGE_ATTEMPTS = 5`(poison-message guard):达上限后 `markUnhandled` 提升为 seen、停止 re-dispatch 并告警。已有测试 `channelClient.test.ts` → `(e) poison-message guard: after the attempt cap, markUnhandled GIVES UP …`。
- **#5 detach grandchild:非 larkway 代码可改**。卡进程的 grandchild(dev server)是 **agent 自己 spawn** 的,larkway 不 spawn 它,无法代为 detach——正解是 agent prompt 里用 `start_new_session`。runner 侧已做缓解:结果事件后 30s `SIGTERM` + `killScheduled → resolve`(不 reject),所以这条不会变成 `claude exited code 1`。如需 runner 级进程组管理(整组 kill),建议单开 follow-up,风险独立评估。

## 测试

- `pnpm typecheck` ✅
- `pnpm test` ✅ **52 files / 848 tests pass**
- 新增 `stateFile.test.ts` 用例:缺 `updated_at` 被接受并补戳;rewrite 使 mtime 前进(stale-guard 仍成立);坏字段字段级降级保住 `status`/`last_message` + 诊断;坏字段 + 缺 `updated_at` 同时发生也活;`status` 非法仍 → `null`。

## 红线

仅开 PR:**不 merge、不部署、不重启 bridge**。合并/上线由 owner 单独拍板。诊断为只读;本改动未触碰任何线上 state/配置。
