### PR TITLE
feat: stream agent thinking into Feishu COT bubble (collapsible chain-of-thought)

### DIFF
--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -31,6 +31,16 @@ export type AgentStreamEvent =
   | { type: "answer_snapshot"; text: string; raw: unknown; seq?: number }
   /** @deprecated Backend text without answer-channel proof. Treat as internal. */
   | { type: "text_delta"; text: string; raw: unknown }
+  /**
+   * The model's reasoning / chain-of-thought narration — Claude "thinking"
+   * content blocks, Codex reasoning items. Distinct from `internal_text`: it
+   * is surfaced only in the collapsible COT (思维链) bubble, never in the
+   * answer card. `thinking_delta` appends to the reasoning buffer;
+   * `thinking_snapshot` carries a complete thinking block, used only as a
+   * catch-up when a run streamed no deltas (partial-message streaming off).
+   */
+  | { type: "thinking_delta"; text: string; raw: unknown }
+  | { type: "thinking_snapshot"; text: string; raw: unknown }
   | { type: "tool_use"; toolName: string; toolInput: unknown; raw: unknown }
   | { type: "tool_result"; raw: unknown }
   | { type: "result"; stopReason: string; raw: unknown }

--- a/src/bridge/cotProgress.test.ts
+++ b/src/bridge/cotProgress.test.ts
@@ -11,7 +11,7 @@ import type { AgentStreamEvent } from "../agent/runner.js";
 import {
   createCotProgressHandle,
   extractToolResultText,
-  resolveCotTarget,
+  resolveCotTargets,
 } from "./cotProgress.js";
 
 interface RecordingClient {
@@ -299,15 +299,18 @@ describe("CotProgressHandle end-to-end hang guard", () => {
     const client = new ChannelCotClient({ resolveChannel: () => channel });
     const handlePromise = createCotProgressHandle({
       cotClient: client,
-      target: TARGET,
+      target: TARGET, // omt_ hint → thread attempt THEN chat fallback
       detail: "brief",
       runId: "run1",
       scope: "thread1",
       inputPreview: "hi",
       throttleMs: 10_000,
     });
-    // Drive the 8s client timeout; start()'s create() rejects → handle disabled.
-    await vi.advanceTimersByTimeAsync(8_000);
+    // TARGET has an omt_ hint, so both channels are tried in turn; each hangs
+    // and is bounded by the 8s client timeout. Drive both (thread, then chat),
+    // after which every attempt has rejected → handle disabled.
+    await vi.advanceTimersByTimeAsync(8_000); // thread attempt times out
+    await vi.advanceTimersByTimeAsync(8_000); // chat fallback times out
     const handle = await handlePromise;
     expect(handle.disabled).toBe(true);
     // A disabled handle finalizes as a no-op, again without hanging.
@@ -315,7 +318,7 @@ describe("CotProgressHandle end-to-end hang guard", () => {
   });
 });
 
-describe("resolveCotTarget (om_ ≠ omt_ anchoring)", () => {
+describe("resolveCotTargets (om_/omt_ + chat fallback ordering)", () => {
   function threadIdResolver(map: Record<string, string | undefined>) {
     const calls: string[] = [];
     return {
@@ -329,97 +332,143 @@ describe("resolveCotTarget (om_ ≠ omt_ anchoring)", () => {
     };
   }
 
-  it("uses an omt_ thread hint directly, without a GET", async () => {
+  const chatFallback = { chatId: "oc_x", threadId: undefined, originMessageId: "om_trigger" };
+
+  it("omt_ hint → [thread attempt, chat fallback], no GET", async () => {
     const r = threadIdResolver({});
-    const target = await resolveCotTarget(r.client, {
+    const targets = await resolveCotTargets(r.client, {
       chatId: "oc_x",
       threadId: "omt_topic",
       originMessageId: "om_trigger",
     });
-    expect(target).toEqual({
-      chatId: "oc_x",
-      threadId: "omt_topic",
-      originMessageId: "om_trigger",
-    });
+    expect(targets).toEqual([
+      { chatId: "oc_x", threadId: "omt_topic", originMessageId: "om_trigger" },
+      chatFallback,
+    ]);
     expect(r.calls).toHaveLength(0);
   });
 
-  it("resolves an om_ thread hint via GET to the real omt_ id", async () => {
+  it("om_ hint → GET → [thread(omt_real), chat fallback]", async () => {
     const r = threadIdResolver({ om_trigger: "omt_real" });
-    const target = await resolveCotTarget(r.client, {
+    const targets = await resolveCotTargets(r.client, {
       chatId: "oc_x",
       threadId: "om_topfloor", // topic-group top-level @ gives an om_ id
       originMessageId: "om_trigger",
     });
-    expect(target).toEqual({
-      chatId: "oc_x",
-      threadId: "omt_real",
-      originMessageId: "om_trigger",
-    });
+    expect(targets).toEqual([
+      { chatId: "oc_x", threadId: "omt_real", originMessageId: "om_trigger" },
+      chatFallback,
+    ]);
     expect(r.calls).toEqual(["om_trigger"]);
   });
 
-  it("falls back to chat_id + origin when the GET yields no omt_", async () => {
+  it("GET yields no omt_ → [chat fallback] only", async () => {
     const r = threadIdResolver({ om_trigger: undefined });
-    const target = await resolveCotTarget(r.client, {
+    const targets = await resolveCotTargets(r.client, {
       chatId: "oc_x",
       threadId: "om_topfloor",
       originMessageId: "om_trigger",
     });
-    expect(target).toEqual({
-      chatId: "oc_x",
-      threadId: undefined,
-      originMessageId: "om_trigger",
-    });
+    expect(targets).toEqual([chatFallback]);
     expect(r.calls).toEqual(["om_trigger"]);
   });
 
-  it("never routes an om_ id through the thread channel", async () => {
-    // Even if resolveThreadId erroneously returned an om_ id, it must not be used.
+  it("never puts an om_ id in a thread attempt (resolveThreadId returned non-omt_)", async () => {
     const r = threadIdResolver({ om_trigger: "om_notathread" });
-    const target = await resolveCotTarget(r.client, {
+    const targets = await resolveCotTargets(r.client, {
       chatId: "oc_x",
       threadId: "om_topfloor",
       originMessageId: "om_trigger",
     });
-    expect(target.threadId).toBeUndefined();
+    expect(targets).toEqual([chatFallback]);
+    expect(targets.every((t) => !t.threadId)).toBe(true);
   });
 
-  it("non-topic chat (no thread hint) goes straight to chat_id, no GET", async () => {
+  it("non-topic chat (no thread hint) → [chat fallback] only, no GET", async () => {
     const r = threadIdResolver({ om_trigger: "omt_should_not_be_used" });
-    const target = await resolveCotTarget(r.client, {
+    const targets = await resolveCotTargets(r.client, {
       chatId: "oc_x",
       originMessageId: "om_trigger",
     });
-    expect(target).toEqual({
-      chatId: "oc_x",
-      threadId: undefined,
-      originMessageId: "om_trigger",
-    });
+    expect(targets).toEqual([chatFallback]);
     expect(r.calls).toHaveLength(0);
   });
+});
 
-  it("routes create() through the resolved target (om_ hint → GET → omt_)", async () => {
-    const rec = recordingCotClient({
-      async resolveThreadId() {
-        return "omt_resolved";
+describe("CotProgressHandle create degradation chain (thread → chat_id)", () => {
+  // A client that records every create target and can be told which channel(s)
+  // reject — the thread channel currently 10002s for our tenant.
+  function selectiveClient(opts: { failThread?: boolean; failChat?: boolean }) {
+    const state = { targets: [] as CotTarget[], completeReason: undefined as string | undefined };
+    const client: OutboundCotClient = {
+      async create(target) {
+        state.targets.push(target);
+        if (target.threadId && opts.failThread) {
+          throw new Error("COT API failed: code=10002 Bot/User can NOT be out of the chat");
+        }
+        if (!target.threadId && opts.failChat) {
+          throw new Error("COT API failed: code=99999 chat create failed");
+        }
+        return { cotId: "cot_1", messageId: "om_1" };
       },
-    });
-    const handle = await createCotProgressHandle({
-      cotClient: rec.client,
-      target: { chatId: "oc_x", threadId: "om_topfloor", originMessageId: "om_trigger" },
+      async resolveThreadId() {
+        return undefined; // unused: these tests pass an omt_ hint directly
+      },
+      async update() {},
+      async complete(_ref, reason) {
+        state.completeReason = reason;
+      },
+    };
+    return { client, state };
+  }
+
+  async function startWithHint(client: OutboundCotClient, threadId?: string) {
+    return createCotProgressHandle({
+      cotClient: client,
+      target: { chatId: "oc_x", threadId, originMessageId: "om_trigger" },
       detail: "brief",
       runId: "run1",
       scope: "thread1",
       inputPreview: "hi",
       throttleMs: 10_000,
     });
-    await handle.finalize("done");
-    expect(rec.createTargets[0]).toEqual({
+  }
+
+  it("thread channel 10002 → retries chat_id and stays enabled", async () => {
+    const { client, state } = selectiveClient({ failThread: true });
+    const handle = await startWithHint(client, "omt_topic");
+
+    expect(handle.disabled).toBe(false);
+    // Tried thread first (no origin on the wire), then chat_id + origin.
+    expect(state.targets.map((t) => t.threadId)).toEqual(["omt_topic", undefined]);
+    expect(state.targets[1]).toEqual({
       chatId: "oc_x",
-      threadId: "omt_resolved",
+      threadId: undefined,
       originMessageId: "om_trigger",
     });
+    // Publisher works: finalize completes the (chat-level) bubble.
+    await handle.finalize("done");
+    expect(state.completeReason).toBe("done");
+  });
+
+  it("both channels fail → disabled", async () => {
+    const { client, state } = selectiveClient({ failThread: true, failChat: true });
+    const handle = await startWithHint(client, "omt_topic");
+
+    expect(handle.disabled).toBe(true);
+    expect(state.targets.map((t) => t.threadId)).toEqual(["omt_topic", undefined]);
+    await expect(handle.finalize("done")).resolves.toBeUndefined();
+    expect(state.completeReason).toBeUndefined();
+  });
+
+  it("no omt_ hint → single chat_id + origin attempt (no thread try)", async () => {
+    const { client, state } = selectiveClient({});
+    const handle = await startWithHint(client, undefined);
+
+    expect(handle.disabled).toBe(false);
+    expect(state.targets).toEqual([
+      { chatId: "oc_x", threadId: undefined, originMessageId: "om_trigger" },
+    ]);
   });
 });
 

--- a/src/bridge/cotProgress.test.ts
+++ b/src/bridge/cotProgress.test.ts
@@ -1,9 +1,11 @@
-import { describe, expect, it } from "vitest";
-import type {
-  CotEvent,
-  CotRef,
-  CotTarget,
-  OutboundCotClient,
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  ChannelCotClient,
+  type CotEvent,
+  type CotRef,
+  type CotTarget,
+  type OutboundCotClient,
+  type OutboundCotLarkChannel,
 } from "../lark/channelCotClient.js";
 import type { AgentStreamEvent } from "../agent/runner.js";
 import { createCotProgressHandle, extractToolResultText } from "./cotProgress.js";
@@ -268,6 +270,38 @@ describe("CotProgressHandle degradation (bypass rule)", () => {
     const raw: AgentStreamEvent = { type: "raw", raw: { anything: true } };
     expect(() => handle.handle(raw)).not.toThrow();
     await handle.finalize("done");
+  });
+});
+
+describe("CotProgressHandle end-to-end hang guard", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("a hanging COT API is bounded by the client timeout and degrades the publisher", async () => {
+    vi.useFakeTimers();
+    // Real client over a channel whose request never settles: the per-call
+    // timeout in ChannelCotClient must turn the hang into a rejection so the
+    // publisher's create-failure path disables it — proving hang never blocks.
+    const channel: OutboundCotLarkChannel = {
+      rawClient: { request: <T>() => new Promise<T>(() => {}) },
+    };
+    const client = new ChannelCotClient({ resolveChannel: () => channel });
+    const handlePromise = createCotProgressHandle({
+      cotClient: client,
+      target: TARGET,
+      detail: "brief",
+      runId: "run1",
+      scope: "thread1",
+      inputPreview: "hi",
+      throttleMs: 10_000,
+    });
+    // Drive the 8s client timeout; start()'s create() rejects → handle disabled.
+    await vi.advanceTimersByTimeAsync(8_000);
+    const handle = await handlePromise;
+    expect(handle.disabled).toBe(true);
+    // A disabled handle finalizes as a no-op, again without hanging.
+    await expect(handle.finalize("done")).resolves.toBeUndefined();
   });
 });
 

--- a/src/bridge/cotProgress.test.ts
+++ b/src/bridge/cotProgress.test.ts
@@ -145,6 +145,99 @@ describe("CotProgressHandle finalize reliability (complete must fire)", () => {
     expect(updateCalls).toBeGreaterThan(0); // the RUN_FINISHED flush was tried and failed
     expect(completeCalled).toBe(true); // …but complete was STILL attempted
   });
+
+  it("Round B: a mid-run PUT 400 disables the handle, but finalize STILL terminal-PUTs + completes", async () => {
+    // The confirmed real-machine bug: chat bubble created + scrolling, then a
+    // mid-stream PUT 400 disables the handle. The old finalize entry guard
+    // `if (_disabled) return` then skipped RUN_FINISHED AND complete → bubble
+    // orphaned in 思考中. finalize must instead best-effort terminal-PUT + complete.
+    let updateAttempts = 0;
+    let completeReason: string | undefined;
+    const client: OutboundCotClient = {
+      async create() { return { cotId: "c", messageId: "m" }; },
+      async resolveThreadId() { return undefined; },
+      async update() {
+        updateAttempts += 1;
+        throw new Error("COT API failed: code=400 invalid");
+      },
+      async complete(_ref, reason) { completeReason = reason; },
+    };
+    const handle = await createCotProgressHandle({
+      cotClient: client, target: TARGET, detail: "brief", runId: "r",
+      scope: "s", inputPreview: "hi", throttleMs: 0,
+    });
+    handle.handle({ type: "thinking_delta", text: "x", raw: {} });
+    await new Promise((r) => setTimeout(r, 1)); // mid-run flush fails → _disabled
+    expect(handle.disabled).toBe(true);
+    const midRunAttempts = updateAttempts;
+
+    await handle.finalize("done");
+    // finalize attempted a terminal PUT even though already disabled…
+    expect(updateAttempts).toBeGreaterThan(midRunAttempts);
+    // …and completed the bubble regardless.
+    expect(completeReason).toBe("done");
+  });
+});
+
+describe("CotProgressHandle event-sequence legality (START/END balance)", () => {
+  // Every *_START must be closed by its *_END, depth never goes negative, and
+  // the stream terminates with RUN_FINISHED (or RUN_ERROR) — the shape the
+  // client state machine needs to leave 思考中 (see cot-write-probe.md).
+  function assertBalancedAndTerminated(seq: string[], terminal: "RUN_FINISHED" | "RUN_ERROR") {
+    const pairs: Record<string, string> = {
+      REASONING_MESSAGE_START: "REASONING_MESSAGE_END",
+      REASONING_START: "REASONING_END",
+      TOOL_CALL_START: "TOOL_CALL_END",
+    };
+    const opens = new Set(Object.keys(pairs));
+    const closes = new Set(Object.values(pairs));
+    const depth: Record<string, number> = {
+      REASONING_MESSAGE_START: 0,
+      REASONING_START: 0,
+      TOOL_CALL_START: 0,
+    };
+    const closeToOpen: Record<string, string> = Object.fromEntries(
+      Object.entries(pairs).map(([o, c]) => [c, o]),
+    );
+    for (const t of seq) {
+      if (opens.has(t)) depth[t] += 1;
+      else if (closes.has(t)) {
+        const o = closeToOpen[t]!;
+        depth[o] -= 1;
+        expect(depth[o], `${t} without matching open`).toBeGreaterThanOrEqual(0);
+      }
+    }
+    for (const k of Object.keys(depth)) {
+      expect(depth[k], `${k} left unbalanced`).toBe(0);
+    }
+    expect(seq[seq.length - 1]).toBe(terminal);
+  }
+
+  it("keeps START/END balanced across a thinking↔tool interleaving and terminates with RUN_FINISHED", async () => {
+    const rec = recordingCotClient();
+    const handle = await startHandle(rec, "detailed");
+    handle.handle({ type: "thinking_delta", text: "reason a", raw: {} });
+    handle.handle({ type: "thinking_delta", text: "reason b", raw: {} });
+    handle.handle({ type: "tool_use", toolName: "Bash", toolInput: { command: "ls" }, raw: {} });
+    handle.handle({ type: "tool_result", raw: { message: { content: [{ type: "tool_result", content: "ok" }] } } });
+    handle.handle({ type: "thinking_delta", text: "reason c", raw: {} });
+    // tool_use with NO following tool_result — START/END must still be balanced.
+    handle.handle({ type: "tool_use", toolName: "Read", toolInput: { file_path: "/x" }, raw: {} });
+    // reasoning left OPEN at turn end — finalize must close it.
+    handle.handle({ type: "thinking_delta", text: "reason d", raw: {} });
+    await handle.finalize("done");
+
+    assertBalancedAndTerminated(types(rec), "RUN_FINISHED");
+    expect(rec.completeReason).toBe("done");
+  });
+
+  it("closes an open reasoning block on the error path and terminates with RUN_ERROR", async () => {
+    const rec = recordingCotClient();
+    const handle = await startHandle(rec, "brief");
+    handle.handle({ type: "thinking_delta", text: "mid-thought", raw: {} }); // reasoning open
+    await handle.finalize("error", { message: "boom" });
+    assertBalancedAndTerminated(types(rec), "RUN_ERROR");
+  });
 });
 
 describe("CotProgressHandle event mapping", () => {

--- a/src/bridge/cotProgress.test.ts
+++ b/src/bridge/cotProgress.test.ts
@@ -8,13 +8,18 @@ import {
   type OutboundCotLarkChannel,
 } from "../lark/channelCotClient.js";
 import type { AgentStreamEvent } from "../agent/runner.js";
-import { createCotProgressHandle, extractToolResultText } from "./cotProgress.js";
+import {
+  createCotProgressHandle,
+  extractToolResultText,
+  resolveCotTarget,
+} from "./cotProgress.js";
 
 interface RecordingClient {
   client: OutboundCotClient;
   events: Array<{ eventType: string; content: Record<string, unknown> }>;
   completeReason: string | undefined;
   createCalls: number;
+  createTargets: CotTarget[];
 }
 
 function recordingCotClient(
@@ -24,12 +29,17 @@ function recordingCotClient(
     events: [],
     completeReason: undefined,
     createCalls: 0,
+    createTargets: [],
     client: undefined as unknown as OutboundCotClient,
   };
   rec.client = {
-    async create(_target: CotTarget): Promise<CotRef> {
+    async create(target: CotTarget): Promise<CotRef> {
       rec.createCalls += 1;
+      rec.createTargets.push(target);
       return { cotId: "cot_1", messageId: "om_msg_1" };
+    },
+    async resolveThreadId(): Promise<string | undefined> {
+      return undefined;
     },
     async update(_ref: CotRef, events: readonly CotEvent[]): Promise<void> {
       for (const e of events) {
@@ -302,6 +312,114 @@ describe("CotProgressHandle end-to-end hang guard", () => {
     expect(handle.disabled).toBe(true);
     // A disabled handle finalizes as a no-op, again without hanging.
     await expect(handle.finalize("done")).resolves.toBeUndefined();
+  });
+});
+
+describe("resolveCotTarget (om_ ≠ omt_ anchoring)", () => {
+  function threadIdResolver(map: Record<string, string | undefined>) {
+    const calls: string[] = [];
+    return {
+      calls,
+      client: {
+        async resolveThreadId(messageId: string): Promise<string | undefined> {
+          calls.push(messageId);
+          return map[messageId];
+        },
+      },
+    };
+  }
+
+  it("uses an omt_ thread hint directly, without a GET", async () => {
+    const r = threadIdResolver({});
+    const target = await resolveCotTarget(r.client, {
+      chatId: "oc_x",
+      threadId: "omt_topic",
+      originMessageId: "om_trigger",
+    });
+    expect(target).toEqual({
+      chatId: "oc_x",
+      threadId: "omt_topic",
+      originMessageId: "om_trigger",
+    });
+    expect(r.calls).toHaveLength(0);
+  });
+
+  it("resolves an om_ thread hint via GET to the real omt_ id", async () => {
+    const r = threadIdResolver({ om_trigger: "omt_real" });
+    const target = await resolveCotTarget(r.client, {
+      chatId: "oc_x",
+      threadId: "om_topfloor", // topic-group top-level @ gives an om_ id
+      originMessageId: "om_trigger",
+    });
+    expect(target).toEqual({
+      chatId: "oc_x",
+      threadId: "omt_real",
+      originMessageId: "om_trigger",
+    });
+    expect(r.calls).toEqual(["om_trigger"]);
+  });
+
+  it("falls back to chat_id + origin when the GET yields no omt_", async () => {
+    const r = threadIdResolver({ om_trigger: undefined });
+    const target = await resolveCotTarget(r.client, {
+      chatId: "oc_x",
+      threadId: "om_topfloor",
+      originMessageId: "om_trigger",
+    });
+    expect(target).toEqual({
+      chatId: "oc_x",
+      threadId: undefined,
+      originMessageId: "om_trigger",
+    });
+    expect(r.calls).toEqual(["om_trigger"]);
+  });
+
+  it("never routes an om_ id through the thread channel", async () => {
+    // Even if resolveThreadId erroneously returned an om_ id, it must not be used.
+    const r = threadIdResolver({ om_trigger: "om_notathread" });
+    const target = await resolveCotTarget(r.client, {
+      chatId: "oc_x",
+      threadId: "om_topfloor",
+      originMessageId: "om_trigger",
+    });
+    expect(target.threadId).toBeUndefined();
+  });
+
+  it("non-topic chat (no thread hint) goes straight to chat_id, no GET", async () => {
+    const r = threadIdResolver({ om_trigger: "omt_should_not_be_used" });
+    const target = await resolveCotTarget(r.client, {
+      chatId: "oc_x",
+      originMessageId: "om_trigger",
+    });
+    expect(target).toEqual({
+      chatId: "oc_x",
+      threadId: undefined,
+      originMessageId: "om_trigger",
+    });
+    expect(r.calls).toHaveLength(0);
+  });
+
+  it("routes create() through the resolved target (om_ hint → GET → omt_)", async () => {
+    const rec = recordingCotClient({
+      async resolveThreadId() {
+        return "omt_resolved";
+      },
+    });
+    const handle = await createCotProgressHandle({
+      cotClient: rec.client,
+      target: { chatId: "oc_x", threadId: "om_topfloor", originMessageId: "om_trigger" },
+      detail: "brief",
+      runId: "run1",
+      scope: "thread1",
+      inputPreview: "hi",
+      throttleMs: 10_000,
+    });
+    await handle.finalize("done");
+    expect(rec.createTargets[0]).toEqual({
+      chatId: "oc_x",
+      threadId: "omt_resolved",
+      originMessageId: "om_trigger",
+    });
   });
 });
 

--- a/src/bridge/cotProgress.test.ts
+++ b/src/bridge/cotProgress.test.ts
@@ -77,6 +77,76 @@ function types(rec: RecordingClient): string[] {
   return rec.events.map((e) => e.eventType);
 }
 
+describe("CotProgressHandle finalize reliability (complete must fire)", () => {
+  it("handler timing: void finalize() then immediate close() still calls complete", async () => {
+    // Mimics handler.ts: the success path fire-and-forgets finalize, then the
+    // finally block calls close(). complete() must still be sent (close() only
+    // cancels the throttle timer; it must not suppress an in-flight finalize).
+    const rec = recordingCotClient();
+    const handle = await startHandle(rec);
+    handle.handle({ type: "thinking_delta", text: "x", raw: {} });
+    const finalizing = handle.finalize("done"); // not awaited (handler `void`)
+    handle.close(); // handler `finally` runs concurrently
+    await finalizing;
+    expect(rec.completeReason).toBe("done");
+  });
+
+  it("with a flush genuinely in flight when finalize()+close() race, complete still fires", async () => {
+    const resolvers: Array<() => void> = [];
+    const rec: RecordingClient = {
+      events: [], completeReason: undefined, createCalls: 0, createTargets: [],
+      client: undefined as unknown as OutboundCotClient,
+    };
+    rec.client = {
+      async create() { return { cotId: "c", messageId: "m" }; },
+      async resolveThreadId() { return undefined; },
+      update(_ref, events) {
+        for (const e of events) rec.events.push({ eventType: e.event_type, content: {} });
+        return new Promise<void>((res) => resolvers.push(res)); // caller-controlled
+      },
+      async complete(_ref, reason) { rec.completeReason = reason; },
+    };
+    const handle = await createCotProgressHandle({
+      cotClient: rec.client, target: TARGET, detail: "brief", runId: "r",
+      scope: "s", inputPreview: "hi", throttleMs: 0,
+    });
+    handle.handle({ type: "thinking_delta", text: "x", raw: {} });
+    await new Promise((r) => setTimeout(r, 1)); // let the first flush go in-flight
+    const finalizing = handle.finalize("done");
+    handle.close();
+    // Drain every deferred update so finalize can progress to complete.
+    while (resolvers.length) resolvers.shift()!();
+    await new Promise((r) => setTimeout(r, 1));
+    while (resolvers.length) resolvers.shift()!();
+    await finalizing;
+    expect(rec.completeReason).toBe("done");
+  });
+
+  it("still attempts complete even if the final RUN_FINISHED flush fails (transient PUT blip)", async () => {
+    // The real gap behind "scrolls fine then never completes": a single failed
+    // finalize-flush used to disable the handle and skip complete. complete must
+    // be attempted regardless (it's bounded + caught).
+    let updateCalls = 0;
+    let completeCalled = false;
+    const client: OutboundCotClient = {
+      async create() { return { cotId: "c", messageId: "m" }; },
+      async resolveThreadId() { return undefined; },
+      async update() {
+        updateCalls += 1;
+        throw new Error("COT API failed: code=500 transient PUT blip");
+      },
+      async complete() { completeCalled = true; },
+    };
+    const handle = await createCotProgressHandle({
+      cotClient: client, target: TARGET, detail: "brief", runId: "r",
+      scope: "s", inputPreview: "hi", throttleMs: 10_000,
+    });
+    await handle.finalize("done");
+    expect(updateCalls).toBeGreaterThan(0); // the RUN_FINISHED flush was tried and failed
+    expect(completeCalled).toBe(true); // …but complete was STILL attempted
+  });
+});
+
 describe("CotProgressHandle event mapping", () => {
   it("opens with RUN_STARTED and closes with RUN_FINISHED + complete(done)", async () => {
     const rec = recordingCotClient();
@@ -249,7 +319,11 @@ describe("CotProgressHandle degradation (bypass rule)", () => {
     expect(rec.completeReason).toBeUndefined();
   });
 
-  it("an update failure disables the handle and skips complete, without throwing", async () => {
+  it("an update failure during finalize does NOT suppress the complete attempt", async () => {
+    // A transient failure on the finalize flush (the RUN_FINISHED PUT) must not
+    // also skip complete — otherwise a bubble that scrolled fine hangs forever
+    // in "thinking". finalize swallows the flush error and still best-effort
+    // completes.
     const rec = recordingCotClient({
       update: async () => {
         throw new Error("network reset");
@@ -257,13 +331,11 @@ describe("CotProgressHandle degradation (bypass rule)", () => {
     });
     const handle = await startHandle(rec);
     handle.handle({ type: "thinking_delta", text: "x", raw: {} });
-    // finalize triggers the flush that throws; must swallow + skip complete.
     await expect(handle.finalize("done")).resolves.toBeUndefined();
-    expect(handle.disabled).toBe(true);
-    expect(rec.completeReason).toBeUndefined();
+    expect(rec.completeReason).toBe("done");
   });
 
-  it("a complete failure is swallowed", async () => {
+  it("a complete failure is swallowed (finalize never throws)", async () => {
     const rec = recordingCotClient({
       complete: async () => {
         throw new Error("complete blew up");
@@ -271,7 +343,6 @@ describe("CotProgressHandle degradation (bypass rule)", () => {
     });
     const handle = await startHandle(rec);
     await expect(handle.finalize("done")).resolves.toBeUndefined();
-    expect(handle.disabled).toBe(true);
   });
 
   it("feeding an unknown/raw event never throws", async () => {

--- a/src/bridge/cotProgress.test.ts
+++ b/src/bridge/cotProgress.test.ts
@@ -1,0 +1,306 @@
+import { describe, expect, it } from "vitest";
+import type {
+  CotEvent,
+  CotRef,
+  CotTarget,
+  OutboundCotClient,
+} from "../lark/channelCotClient.js";
+import type { AgentStreamEvent } from "../agent/runner.js";
+import { createCotProgressHandle, extractToolResultText } from "./cotProgress.js";
+
+interface RecordingClient {
+  client: OutboundCotClient;
+  events: Array<{ eventType: string; content: Record<string, unknown> }>;
+  completeReason: string | undefined;
+  createCalls: number;
+}
+
+function recordingCotClient(
+  overrides: Partial<OutboundCotClient> = {},
+): RecordingClient {
+  const rec: RecordingClient = {
+    events: [],
+    completeReason: undefined,
+    createCalls: 0,
+    client: undefined as unknown as OutboundCotClient,
+  };
+  rec.client = {
+    async create(_target: CotTarget): Promise<CotRef> {
+      rec.createCalls += 1;
+      return { cotId: "cot_1", messageId: "om_msg_1" };
+    },
+    async update(_ref: CotRef, events: readonly CotEvent[]): Promise<void> {
+      for (const e of events) {
+        rec.events.push({ eventType: e.event_type, content: JSON.parse(e.content) });
+      }
+    },
+    async complete(_ref: CotRef, reason: string): Promise<void> {
+      rec.completeReason = reason;
+    },
+    ...overrides,
+  };
+  return rec;
+}
+
+const TARGET: CotTarget = { chatId: "oc_x", threadId: "omt_x", originMessageId: "om_x" };
+
+// A large throttle keeps the flush timer from firing mid-test; finalize()
+// clears it and flushes everything in one deterministic batch.
+async function startHandle(
+  rec: RecordingClient,
+  detail: "brief" | "detailed" = "brief",
+) {
+  return createCotProgressHandle({
+    cotClient: rec.client,
+    target: TARGET,
+    detail,
+    runId: "run1",
+    scope: "thread1",
+    inputPreview: "please do the thing",
+    throttleMs: 10_000,
+  });
+}
+
+function types(rec: RecordingClient): string[] {
+  return rec.events.map((e) => e.eventType);
+}
+
+describe("CotProgressHandle event mapping", () => {
+  it("opens with RUN_STARTED and closes with RUN_FINISHED + complete(done)", async () => {
+    const rec = recordingCotClient();
+    const handle = await startHandle(rec);
+    await handle.finalize("done");
+
+    expect(rec.createCalls).toBe(1);
+    expect(types(rec)).toEqual(["RUN_STARTED", "RUN_FINISHED"]);
+    expect(rec.events[0].content).toMatchObject({
+      runId: "run1",
+      input: { query: "please do the thing" },
+    });
+    expect(rec.completeReason).toBe("done");
+  });
+
+  it("wraps thinking_delta in REASONING_START/MESSAGE_START once, then content per delta", async () => {
+    const rec = recordingCotClient();
+    const handle = await startHandle(rec);
+    handle.handle({ type: "thinking_delta", text: "step one ", raw: {} });
+    handle.handle({ type: "thinking_delta", text: "step two", raw: {} });
+    await handle.finalize("done");
+
+    expect(types(rec)).toEqual([
+      "RUN_STARTED",
+      "REASONING_START",
+      "REASONING_MESSAGE_START",
+      "REASONING_MESSAGE_CONTENT",
+      "REASONING_MESSAGE_CONTENT",
+      "REASONING_MESSAGE_END",
+      "REASONING_END",
+      "RUN_FINISHED",
+    ]);
+    const contents = rec.events
+      .filter((e) => e.eventType === "REASONING_MESSAGE_CONTENT")
+      .map((e) => e.content.delta);
+    expect(contents).toEqual(["step one ", "step two"]);
+  });
+
+  it("renders thinking_snapshot only when no delta streamed (catch-up)", async () => {
+    const rec = recordingCotClient();
+    const handle = await startHandle(rec);
+    handle.handle({ type: "thinking_snapshot", text: "whole trace", raw: {} });
+    await handle.finalize("done");
+    const contents = rec.events
+      .filter((e) => e.eventType === "REASONING_MESSAGE_CONTENT")
+      .map((e) => e.content.delta);
+    expect(contents).toEqual(["whole trace"]);
+  });
+
+  it("ignores thinking_snapshot once a delta was seen (no double reasoning)", async () => {
+    const rec = recordingCotClient();
+    const handle = await startHandle(rec);
+    handle.handle({ type: "thinking_delta", text: "delta text", raw: {} });
+    handle.handle({ type: "thinking_snapshot", text: "delta text", raw: {} });
+    await handle.finalize("done");
+    const contents = rec.events
+      .filter((e) => e.eventType === "REASONING_MESSAGE_CONTENT")
+      .map((e) => e.content.delta);
+    expect(contents).toEqual(["delta text"]);
+  });
+
+  it("brief tier: tool_use emits START + END with a name summary, no ARGS", async () => {
+    const rec = recordingCotClient();
+    const handle = await startHandle(rec, "brief");
+    handle.handle({
+      type: "tool_use",
+      toolName: "Bash",
+      toolInput: { command: "ls -la" },
+      raw: {},
+    });
+    await handle.finalize("done");
+
+    const toolTypes = types(rec).filter((t) => t.startsWith("TOOL_CALL"));
+    expect(toolTypes).toEqual(["TOOL_CALL_START", "TOOL_CALL_END"]);
+    const start = rec.events.find((e) => e.eventType === "TOOL_CALL_START")!;
+    expect(start.content).toMatchObject({ toolCallName: "Bash" });
+    expect(String(start.content.title)).toContain("Bash");
+    expect(String(start.content.title)).toContain("ls -la");
+  });
+
+  it("detailed tier: tool_use adds TOOL_CALL_ARGS and tool_result emits TOOL_CALL_RESULT", async () => {
+    const rec = recordingCotClient();
+    const handle = await startHandle(rec, "detailed");
+    handle.handle({
+      type: "tool_use",
+      toolName: "Read",
+      toolInput: { file_path: "/etc/hosts" },
+      raw: {},
+    });
+    handle.handle({
+      type: "tool_result",
+      raw: {
+        message: { content: [{ type: "tool_result", content: "127.0.0.1 localhost" }] },
+      },
+    });
+    await handle.finalize("done");
+
+    const toolTypes = types(rec).filter((t) => t.startsWith("TOOL_CALL"));
+    expect(toolTypes).toEqual([
+      "TOOL_CALL_START",
+      "TOOL_CALL_ARGS",
+      "TOOL_CALL_END",
+      "TOOL_CALL_RESULT",
+    ]);
+    const args = rec.events.find((e) => e.eventType === "TOOL_CALL_ARGS")!;
+    expect(String(args.content.delta)).toContain("/etc/hosts");
+    const result = rec.events.find((e) => e.eventType === "TOOL_CALL_RESULT")!;
+    expect(result.content.content).toBe("127.0.0.1 localhost");
+    // FIFO id correlation: result targets the same synthetic tool call id.
+    expect(result.content.toolCallId).toBe(
+      rec.events.find((e) => e.eventType === "TOOL_CALL_START")!.content.toolCallId,
+    );
+  });
+
+  it("brief tier: tool_result emits no TOOL_CALL_RESULT", async () => {
+    const rec = recordingCotClient();
+    const handle = await startHandle(rec, "brief");
+    handle.handle({ type: "tool_use", toolName: "Read", toolInput: {}, raw: {} });
+    handle.handle({ type: "tool_result", raw: {} });
+    await handle.finalize("done");
+    expect(types(rec)).not.toContain("TOOL_CALL_RESULT");
+  });
+
+  it("closes an open reasoning block before a tool call", async () => {
+    const rec = recordingCotClient();
+    const handle = await startHandle(rec);
+    handle.handle({ type: "thinking_delta", text: "hmm", raw: {} });
+    handle.handle({ type: "tool_use", toolName: "Bash", toolInput: {}, raw: {} });
+    await handle.finalize("done");
+    const order = types(rec);
+    expect(order.indexOf("REASONING_END")).toBeLessThan(order.indexOf("TOOL_CALL_START"));
+  });
+
+  it("never surfaces answer/internal text in the COT bubble", async () => {
+    const rec = recordingCotClient();
+    const handle = await startHandle(rec);
+    handle.handle({ type: "answer_delta", text: "the answer", raw: {} });
+    handle.handle({ type: "answer_snapshot", text: "the answer", raw: {} });
+    handle.handle({ type: "internal_text", text: "noise", raw: {} });
+    handle.handle({ type: "text_delta", text: "noise", raw: {} });
+    handle.handle({ type: "system_init", sessionId: "s", raw: {} });
+    await handle.finalize("done");
+    // Only the run bookends — no reasoning/tool/text events from the above.
+    expect(types(rec)).toEqual(["RUN_STARTED", "RUN_FINISHED"]);
+  });
+
+  it("finalize(error) emits RUN_ERROR and completes with reason error", async () => {
+    const rec = recordingCotClient();
+    const handle = await startHandle(rec);
+    await handle.finalize("error", { message: "boom" });
+    expect(types(rec)).toContain("RUN_ERROR");
+    expect(rec.events.find((e) => e.eventType === "RUN_ERROR")!.content.message).toBe("boom");
+    expect(rec.completeReason).toBe("error");
+  });
+});
+
+describe("CotProgressHandle degradation (bypass rule)", () => {
+  it("a create failure disables the handle without throwing", async () => {
+    const rec = recordingCotClient({
+      create: async () => {
+        throw new Error("404 message_cot not found");
+      },
+    });
+    const handle = await startHandle(rec);
+    expect(handle.disabled).toBe(true);
+    // Feeding events + finalizing must be safe no-ops.
+    expect(() => handle.handle({ type: "thinking_delta", text: "x", raw: {} })).not.toThrow();
+    await expect(handle.finalize("done")).resolves.toBeUndefined();
+    expect(rec.events).toHaveLength(0);
+    expect(rec.completeReason).toBeUndefined();
+  });
+
+  it("an update failure disables the handle and skips complete, without throwing", async () => {
+    const rec = recordingCotClient({
+      update: async () => {
+        throw new Error("network reset");
+      },
+    });
+    const handle = await startHandle(rec);
+    handle.handle({ type: "thinking_delta", text: "x", raw: {} });
+    // finalize triggers the flush that throws; must swallow + skip complete.
+    await expect(handle.finalize("done")).resolves.toBeUndefined();
+    expect(handle.disabled).toBe(true);
+    expect(rec.completeReason).toBeUndefined();
+  });
+
+  it("a complete failure is swallowed", async () => {
+    const rec = recordingCotClient({
+      complete: async () => {
+        throw new Error("complete blew up");
+      },
+    });
+    const handle = await startHandle(rec);
+    await expect(handle.finalize("done")).resolves.toBeUndefined();
+    expect(handle.disabled).toBe(true);
+  });
+
+  it("feeding an unknown/raw event never throws", async () => {
+    const rec = recordingCotClient();
+    const handle = await startHandle(rec);
+    const raw: AgentStreamEvent = { type: "raw", raw: { anything: true } };
+    expect(() => handle.handle(raw)).not.toThrow();
+    await handle.finalize("done");
+  });
+});
+
+describe("extractToolResultText", () => {
+  it("reads a string tool_result content", () => {
+    expect(
+      extractToolResultText({
+        message: { content: [{ type: "tool_result", content: "hello" }] },
+      }),
+    ).toBe("hello");
+  });
+
+  it("reads an array-of-text tool_result content", () => {
+    expect(
+      extractToolResultText({
+        message: {
+          content: [
+            {
+              type: "tool_result",
+              content: [
+                { type: "text", text: "line 1" },
+                { type: "text", text: "line 2" },
+              ],
+            },
+          ],
+        },
+      }),
+    ).toBe("line 1\nline 2");
+  });
+
+  it("returns empty string for an unrecognized shape", () => {
+    expect(extractToolResultText({ nope: true })).toBe("");
+    expect(extractToolResultText(null)).toBe("");
+    expect(extractToolResultText("string")).toBe("");
+  });
+});

--- a/src/bridge/cotProgress.ts
+++ b/src/bridge/cotProgress.ts
@@ -1,0 +1,352 @@
+/**
+ * src/bridge/cotProgress.ts
+ *
+ * Streams a turn's reasoning + tool activity into a Feishu COT (思维链)
+ * bubble, in parallel with (and independent of) the answer card. Mirrors the
+ * shape of src/bridge/cardkitProgress.ts: a live handle fed one
+ * AgentStreamEvent at a time, batching outbound writes on a throttle, with a
+ * finalize step that completes the bubble.
+ *
+ * Iron rule — bypass degrade: the COT bubble is a best-effort, undocumented
+ * side channel. ANY failure (create/update/complete throwing) permanently
+ * disables COT for this run and is swallowed with a warn. It must never throw
+ * into the handler or affect the answer card / final reply. Callers can feed
+ * every event unconditionally; a disabled handle is a no-op.
+ *
+ * Only reasoning + tool events reach the bubble. The final answer text stays
+ * exclusively on the card — `answer_delta`/`answer_snapshot`/`internal_text`
+ * are ignored here on purpose.
+ */
+
+import type { AgentStreamEvent } from "../agent/runner.js";
+import type {
+  CotEvent,
+  CotRef,
+  CotTarget,
+  OutboundCotClient,
+} from "../lark/channelCotClient.js";
+
+/** Bot-level verbosity knob (see BotConfig.cot). "off" never constructs a handle. */
+export type CotDetail = "brief" | "detailed";
+
+const DEFAULT_THROTTLE_MS = 600;
+const COT_TOOL_RESULT_MAX = 1200;
+const COT_TEXT_MAX = 1200;
+const COT_INPUT_PREVIEW_MAX = 200;
+
+export interface CotProgressHandle {
+  /** True once COT has been disabled (create/write failure) — handle is a no-op. */
+  readonly disabled: boolean;
+  /** Feed one runner event. Reasoning + tool events map to COT; others ignored. */
+  handle(event: AgentStreamEvent): void;
+  /** Flush + complete the bubble. `done` on normal end, `error` otherwise. */
+  finalize(reason: "done" | "error", opts?: { message?: string }): Promise<void>;
+  /** Cancel any pending flush without completing (e.g. the run threw). */
+  close(): void;
+}
+
+export interface CreateCotProgressHandleOpts {
+  cotClient: OutboundCotClient;
+  target: CotTarget;
+  detail: CotDetail;
+  runId: string;
+  /** Session/thread key, echoed into RUN_STARTED/RUN_FINISHED for grouping. */
+  scope: string;
+  /** The user's trigger text, shown as the run input. Truncated. */
+  inputPreview: string;
+  throttleMs?: number;
+}
+
+function truncate(value: unknown, max: number): string {
+  const text = String(value ?? "");
+  return text.length > max ? `${text.slice(0, max)}...` : text;
+}
+
+function summarizeError(err: unknown): string {
+  const message = err instanceof Error ? err.message : String(err);
+  return message.replace(/\s+/g, " ").trim().slice(0, 240) || "unknown error";
+}
+
+/**
+ * A short tool title for the brief tier — just the tool name plus, for shell
+ * commands, a clipped command preview. Never renders full arbitrary input.
+ */
+function briefToolTitle(name: string, input: unknown): string {
+  if (input && typeof input === "object") {
+    const record = input as Record<string, unknown>;
+    const command = record["command"] ?? record["cmd"];
+    if (typeof command === "string" && command.trim()) {
+      return `${name}: ${truncate(command.trim(), 80)}`;
+    }
+    const filePath = record["file_path"] ?? record["path"] ?? record["notebook_path"];
+    if (typeof filePath === "string" && filePath.trim()) {
+      return `${name}: ${truncate(filePath.trim(), 80)}`;
+    }
+  }
+  return name;
+}
+
+/**
+ * Best-effort extraction of a tool_result's text for the detailed tier.
+ * larkway's `tool_result` event carries only `raw` (no correlation id, no
+ * parsed output — see src/claude/runner.ts), so dig into the raw claude
+ * `user` message shape. Any miss returns "" and the caller falls back to a
+ * generic marker; this is cosmetic COT rendering, never load-bearing.
+ */
+export function extractToolResultText(raw: unknown): string {
+  if (typeof raw !== "object" || raw === null) return "";
+  const message = (raw as Record<string, unknown>)["message"];
+  if (typeof message !== "object" || message === null) return "";
+  const content = (message as Record<string, unknown>)["content"];
+  if (!Array.isArray(content)) return "";
+  const parts: string[] = [];
+  for (const item of content) {
+    if (typeof item !== "object" || item === null) continue;
+    const block = item as Record<string, unknown>;
+    if (block["type"] !== "tool_result") continue;
+    const inner = block["content"];
+    if (typeof inner === "string") {
+      parts.push(inner);
+    } else if (Array.isArray(inner)) {
+      for (const piece of inner) {
+        if (typeof piece === "object" && piece !== null) {
+          const text = (piece as Record<string, unknown>)["text"];
+          if (typeof text === "string") parts.push(text);
+        }
+      }
+    }
+  }
+  return parts.join("\n").trim();
+}
+
+class LiveCotProgressHandle implements CotProgressHandle {
+  private readonly cotClient: OutboundCotClient;
+  private readonly detail: CotDetail;
+  private readonly runId: string;
+  private readonly scope: string;
+  private readonly throttleMs: number;
+  private readonly reasoningMessageId: string;
+
+  private ref: CotRef | undefined;
+  private _disabled = false;
+  private closed = false;
+  private buffer: CotEvent[] = [];
+  private timer: ReturnType<typeof setTimeout> | undefined;
+  private flushing: Promise<void> | undefined;
+
+  private reasoningOpen = false;
+  private sawThinkingDelta = false;
+  private toolIndex = 0;
+  /** FIFO of tool_use awaiting a tool_result — larkway events carry no id. */
+  private readonly pendingTools: Array<{ id: string; name: string; input: unknown }> = [];
+
+  constructor(opts: {
+    cotClient: OutboundCotClient;
+    detail: CotDetail;
+    runId: string;
+    scope: string;
+    throttleMs: number;
+  }) {
+    this.cotClient = opts.cotClient;
+    this.detail = opts.detail;
+    this.runId = opts.runId;
+    this.scope = opts.scope;
+    this.throttleMs = opts.throttleMs;
+    this.reasoningMessageId = `reasoning-${opts.runId}`;
+  }
+
+  get disabled(): boolean {
+    return this._disabled;
+  }
+
+  async start(target: CotTarget, inputPreview: string): Promise<void> {
+    try {
+      this.ref = await this.cotClient.create(target);
+      this.enqueue("RUN_STARTED", {
+        threadId: this.scope,
+        runId: this.runId,
+        input: { query: truncate(inputPreview, COT_INPUT_PREVIEW_MAX) },
+      });
+    } catch (err) {
+      this._disabled = true;
+      console.warn("[cot_progress] create failed; COT disabled for this run:", summarizeError(err));
+    }
+  }
+
+  handle(event: AgentStreamEvent): void {
+    if (this._disabled || this.closed || !this.ref) return;
+    switch (event.type) {
+      case "thinking_delta":
+        this.sawThinkingDelta = true;
+        this.openReasoning();
+        this.enqueue("REASONING_MESSAGE_CONTENT", {
+          messageId: this.reasoningMessageId,
+          delta: truncate(event.text, COT_TEXT_MAX),
+        });
+        break;
+      case "thinking_snapshot":
+        // Catch-up only: with --include-partial-messages on (always), deltas
+        // are the source of truth and the block's snapshot is redundant. Only
+        // render it when no delta streamed this run (partial streaming off).
+        if (this.sawThinkingDelta) break;
+        this.openReasoning();
+        this.enqueue("REASONING_MESSAGE_CONTENT", {
+          messageId: this.reasoningMessageId,
+          delta: truncate(event.text, COT_TEXT_MAX),
+        });
+        break;
+      case "tool_use":
+        this.onToolUse(event.toolName, event.toolInput);
+        break;
+      case "tool_result":
+        this.onToolResult(event.raw);
+        break;
+      default:
+        // answer_delta / answer_snapshot / internal_text / text_delta /
+        // system_init / result / raw — deliberately not surfaced in the COT.
+        break;
+    }
+  }
+
+  private onToolUse(toolName: string, toolInput: unknown): void {
+    this.closeReasoning();
+    const toolCallId = `tool-${this.runId}-${++this.toolIndex}`;
+    this.pendingTools.push({ id: toolCallId, name: toolName, input: toolInput });
+    this.enqueue("TOOL_CALL_START", {
+      toolCallId,
+      toolCallName: toolName,
+      title: briefToolTitle(toolName, toolInput),
+    });
+    if (this.detail === "detailed" && toolInput !== undefined && toolInput !== null) {
+      this.enqueue("TOOL_CALL_ARGS", {
+        toolCallId,
+        delta: truncate(JSON.stringify(toolInput), COT_TEXT_MAX),
+      });
+    }
+    this.enqueue("TOOL_CALL_END", { toolCallId });
+  }
+
+  private onToolResult(raw: unknown): void {
+    // FIFO-match to the oldest still-open tool_use (no id on the event).
+    const pending = this.pendingTools.shift();
+    if (this.detail !== "detailed") return;
+    const toolCallId = pending?.id ?? `tool-${this.runId}-${this.toolIndex}`;
+    const text = extractToolResultText(raw);
+    this.enqueue("TOOL_CALL_RESULT", {
+      toolCallId,
+      content: text ? truncate(text, COT_TOOL_RESULT_MAX) : "工具调用已完成",
+    });
+  }
+
+  private openReasoning(): void {
+    if (this.reasoningOpen) return;
+    this.reasoningOpen = true;
+    this.enqueue("REASONING_START", { messageId: this.reasoningMessageId });
+    this.enqueue("REASONING_MESSAGE_START", {
+      messageId: this.reasoningMessageId,
+      role: "reasoning",
+    });
+  }
+
+  private closeReasoning(): void {
+    if (!this.reasoningOpen) return;
+    this.reasoningOpen = false;
+    this.enqueue("REASONING_MESSAGE_END", { messageId: this.reasoningMessageId });
+    this.enqueue("REASONING_END", { messageId: this.reasoningMessageId });
+  }
+
+  async finalize(reason: "done" | "error", opts?: { message?: string }): Promise<void> {
+    if (this.closed) return;
+    if (this._disabled || !this.ref) {
+      this.closed = true;
+      return;
+    }
+    this.closeReasoning();
+    if (reason === "error") {
+      this.enqueue("RUN_ERROR", { message: truncate(opts?.message ?? "run failed", COT_TEXT_MAX) });
+    } else {
+      this.enqueue("RUN_FINISHED", { threadId: this.scope, runId: this.runId, status: "done" });
+    }
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = undefined;
+    }
+    await this.flush();
+    this.closed = true;
+    if (this._disabled || !this.ref) return;
+    try {
+      await this.cotClient.complete(this.ref, reason);
+    } catch (err) {
+      this._disabled = true;
+      console.warn("[cot_progress] complete failed (continuing):", summarizeError(err));
+    }
+  }
+
+  close(): void {
+    this.closed = true;
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = undefined;
+    }
+  }
+
+  private enqueue(eventType: string, content: unknown): void {
+    if (this._disabled || !this.ref) return;
+    this.buffer.push({
+      event_type: eventType,
+      content: JSON.stringify(content),
+      timestamp: Date.now(),
+    });
+    this.scheduleFlush();
+  }
+
+  private scheduleFlush(): void {
+    if (this.timer || this.flushing || this._disabled) return;
+    this.timer = setTimeout(() => {
+      this.timer = undefined;
+      void this.flush();
+    }, this.throttleMs);
+    this.timer.unref?.();
+  }
+
+  private async flush(): Promise<void> {
+    if (this._disabled || !this.ref) return;
+    if (this.flushing) {
+      await this.flushing;
+      if (this.buffer.length > 0 && !this._disabled) await this.flush();
+      return;
+    }
+    const events = this.buffer.splice(0);
+    if (events.length === 0) return;
+    this.flushing = this.cotClient
+      .update(this.ref, events)
+      .catch((err) => {
+        this._disabled = true;
+        console.warn("[cot_progress] update failed; COT disabled for this run:", summarizeError(err));
+      })
+      .finally(() => {
+        this.flushing = undefined;
+        if (this.buffer.length > 0 && !this._disabled) this.scheduleFlush();
+      });
+    await this.flushing;
+  }
+}
+
+/**
+ * Create + start a COT progress handle. Never throws: a create failure returns
+ * an already-disabled (no-op) handle, so the caller wires it in unconditionally
+ * and the turn proceeds regardless.
+ */
+export async function createCotProgressHandle(
+  opts: CreateCotProgressHandleOpts,
+): Promise<CotProgressHandle> {
+  const handle = new LiveCotProgressHandle({
+    cotClient: opts.cotClient,
+    detail: opts.detail,
+    runId: opts.runId,
+    scope: opts.scope,
+    throttleMs: opts.throttleMs ?? DEFAULT_THROTTLE_MS,
+  });
+  await handle.start(opts.target, opts.inputPreview);
+  return handle;
+}

--- a/src/bridge/cotProgress.ts
+++ b/src/bridge/cotProgress.ts
@@ -359,11 +359,16 @@ class LiveCotProgressHandle implements CotProgressHandle {
     }
     await this.flush();
     this.closed = true;
-    if (this._disabled || !this.ref) return;
+    // Always ATTEMPT complete when a bubble exists — do NOT gate on _disabled.
+    // The flush above can disable us on a single transient RUN_FINISHED PUT
+    // failure; gating complete on that (the old `if (_disabled) return`) is
+    // exactly what left a bubble that scrolled fine hung in its "thinking"
+    // state. complete is bounded (8s timeout in ChannelCotClient) and caught,
+    // so a best-effort attempt can only help the bubble finish — never blocks.
+    if (!this.ref) return;
     try {
       await this.cotClient.complete(this.ref, reason);
     } catch (err) {
-      this._disabled = true;
       console.warn("[cot_progress] complete failed (continuing):", summarizeError(err));
     }
   }

--- a/src/bridge/cotProgress.ts
+++ b/src/bridge/cotProgress.ts
@@ -119,6 +119,19 @@ function summarizeError(err: unknown): string {
   return message.replace(/\s+/g, " ").trim().slice(0, 240) || "unknown error";
 }
 
+function makeEvent(eventType: string, content: unknown): CotEvent {
+  return { event_type: eventType, content: JSON.stringify(content), timestamp: Date.now() };
+}
+
+/**
+ * A content-free summary of a failed PUT's payload for the warn log: the
+ * event_type list + each content's length only (never the content itself).
+ * Enough to diagnose a rejected batch shape without logging user text.
+ */
+function payloadSummary(events: readonly CotEvent[]): string {
+  return `payload=[${events.map((e) => `${e.event_type}:${e.content.length}`).join(",")}]`;
+}
+
 /**
  * A short tool title for the brief tier — just the tool name plus, for shell
  * commands, a clipped command preview. Never renders full arbitrary input.
@@ -240,8 +253,16 @@ class LiveCotProgressHandle implements CotProgressHandle {
    */
   private async createWithFallback(attempts: readonly CotTarget[]): Promise<CotRef | undefined> {
     for (let i = 0; i < attempts.length; i++) {
+      const attempt = attempts[i]!;
       try {
-        return await this.cotClient.create(attempts[i]!);
+        const ref = await this.cotClient.create(attempt);
+        console.info(
+          "[cot_progress] created",
+          `cotId=${ref.cotId}`,
+          `channel=${attempt.threadId ? "thread" : "chat_id"}`,
+          `messageId=${ref.messageId}`,
+        );
+        return ref;
       } catch (err) {
         if (i < attempts.length - 1) {
           console.info(
@@ -341,36 +362,84 @@ class LiveCotProgressHandle implements CotProgressHandle {
     this.enqueue("REASONING_END", { messageId: this.reasoningMessageId });
   }
 
+  /**
+   * Terminal-state invariant: once a bubble exists (ref set), finalize ALWAYS
+   * best-effort tears it down — even if a mid-run PUT already disabled us. A
+   * "half-way self-disable" must never equal "bubble orphaned forever in
+   * 思考中" (the real-machine Round B bug: a mid-stream PUT 400 disabled the
+   * handle, and the old `if (_disabled) return` guards then skipped BOTH
+   * RUN_FINISHED and complete). We stop accepting new stream events, then drive
+   * teardown directly, each step independently try/caught:
+   *   (1) flush the backlog — only while still healthy (a disabled handle
+   *       abandons the backlog and jumps straight to the terminal PUT);
+   *   (2) a MINIMAL, balanced terminal PUT (close any open reasoning block +
+   *       RUN_FINISHED/RUN_ERROR) sent DIRECTLY, bypassing the _disabled gate;
+   *   (3) complete.
+   * Any step failing warns and continues — the bubble must leave 思考中.
+   */
   async finalize(reason: "done" | "error", opts?: { message?: string }): Promise<void> {
-    if (this.closed) return;
-    if (this._disabled || !this.ref) {
+    if (this.closed || !this.ref) {
       this.closed = true;
       return;
     }
-    this.closeReasoning();
-    if (reason === "error") {
-      this.enqueue("RUN_ERROR", { message: truncate(opts?.message ?? "run failed", COT_TEXT_MAX) });
-    } else {
-      this.enqueue("RUN_FINISHED", { threadId: this.scope, runId: this.runId, status: "done" });
-    }
+    this.closed = true;
     if (this.timer) {
       clearTimeout(this.timer);
       this.timer = undefined;
     }
-    await this.flush();
-    this.closed = true;
-    // Always ATTEMPT complete when a bubble exists — do NOT gate on _disabled.
-    // The flush above can disable us on a single transient RUN_FINISHED PUT
-    // failure; gating complete on that (the old `if (_disabled) return`) is
-    // exactly what left a bubble that scrolled fine hung in its "thinking"
-    // state. complete is bounded (8s timeout in ChannelCotClient) and caught,
-    // so a best-effort attempt can only help the bubble finish — never blocks.
-    if (!this.ref) return;
+    const ref = this.ref;
+
+    // (1) Best-effort backlog flush — only while healthy.
+    if (!this._disabled) {
+      try {
+        await this.flush();
+      } catch {
+        /* flush swallows its own errors; guard is belt-and-suspenders */
+      }
+    }
+
+    // (2) Minimal, balanced terminal PUT — sent directly so a mid-run disable
+    // can't suppress it.
+    const terminal = this.buildTerminalEvents(reason, opts);
     try {
-      await this.cotClient.complete(this.ref, reason);
+      await this.cotClient.update(ref, terminal);
+    } catch (err) {
+      console.warn(
+        "[cot_progress] terminal update failed (continuing to complete):",
+        summarizeError(err),
+        payloadSummary(terminal),
+      );
+    }
+
+    // (3) complete — independent; the bubble must finish even if (2) failed.
+    try {
+      await this.cotClient.complete(ref, reason);
+      console.info("[cot_progress] completed", `cotId=${ref.cotId}`, `reason=${reason}`);
     } catch (err) {
       console.warn("[cot_progress] complete failed (continuing):", summarizeError(err));
     }
+  }
+
+  /**
+   * The minimal terminal event batch: close any still-open reasoning block so
+   * REASONING_MESSAGE/REASONING START/END stay balanced, then the run's
+   * terminal marker. Tool calls need no closing here — onToolUse always emits
+   * TOOL_CALL_END synchronously alongside START. Built directly (not via the
+   * _disabled-gated enqueue) so it survives a mid-run disable.
+   */
+  private buildTerminalEvents(reason: "done" | "error", opts?: { message?: string }): CotEvent[] {
+    const events: CotEvent[] = [];
+    if (this.reasoningOpen) {
+      this.reasoningOpen = false;
+      events.push(makeEvent("REASONING_MESSAGE_END", { messageId: this.reasoningMessageId }));
+      events.push(makeEvent("REASONING_END", { messageId: this.reasoningMessageId }));
+    }
+    if (reason === "error") {
+      events.push(makeEvent("RUN_ERROR", { message: truncate(opts?.message ?? "run failed", COT_TEXT_MAX) }));
+    } else {
+      events.push(makeEvent("RUN_FINISHED", { threadId: this.scope, runId: this.runId, status: "done" }));
+    }
+    return events;
   }
 
   close(): void {
@@ -383,11 +452,7 @@ class LiveCotProgressHandle implements CotProgressHandle {
 
   private enqueue(eventType: string, content: unknown): void {
     if (this._disabled || !this.ref) return;
-    this.buffer.push({
-      event_type: eventType,
-      content: JSON.stringify(content),
-      timestamp: Date.now(),
-    });
+    this.buffer.push(makeEvent(eventType, content));
     this.scheduleFlush();
   }
 
@@ -413,7 +478,11 @@ class LiveCotProgressHandle implements CotProgressHandle {
       .update(this.ref, events)
       .catch((err) => {
         this._disabled = true;
-        console.warn("[cot_progress] update failed; COT disabled for this run:", summarizeError(err));
+        console.warn(
+          "[cot_progress] update failed; COT disabled for this run:",
+          summarizeError(err),
+          payloadSummary(events),
+        );
       })
       .finally(() => {
         this.flushing = undefined;

--- a/src/bridge/cotProgress.ts
+++ b/src/bridge/cotProgress.ts
@@ -57,6 +57,48 @@ export interface CreateCotProgressHandleOpts {
   throttleMs?: number;
 }
 
+/**
+ * Resolve where the COT bubble anchors, per the om_ ≠ omt_ rule.
+ *
+ * message_cot's `receive_id_type=thread_id` channel ONLY accepts an omt_*
+ * topic id. A top-level @ in a topic group arrives with an om_* message id in
+ * its thread hint, which 10001s ("invalid receive_id"). So:
+ *   1. omt_* hint → use it directly (thread channel).
+ *   2. a non-omt_ thread hint (topic-group message) → GET the message for its
+ *      real omt_* thread id (cached: this runs once at run start, not per flush).
+ *   3. no usable omt_ (non-topic chat, or the GET failed/was empty) → fall back
+ *      to the chat_id channel + origin_message_id (validated to be accepted).
+ *
+ * `resolveThreadId` never throws (bypass rule), so this never throws either.
+ */
+export async function resolveCotTarget(
+  client: Pick<OutboundCotClient, "resolveThreadId">,
+  hint: CotTarget,
+): Promise<CotTarget> {
+  if (hint.threadId && hint.threadId.startsWith("omt_")) {
+    return {
+      chatId: hint.chatId,
+      threadId: hint.threadId,
+      originMessageId: hint.originMessageId,
+    };
+  }
+  if (hint.threadId && hint.originMessageId) {
+    const omt = await client.resolveThreadId(hint.originMessageId);
+    if (omt && omt.startsWith("omt_")) {
+      return {
+        chatId: hint.chatId,
+        threadId: omt,
+        originMessageId: hint.originMessageId,
+      };
+    }
+  }
+  return {
+    chatId: hint.chatId,
+    threadId: undefined,
+    originMessageId: hint.originMessageId,
+  };
+}
+
 function truncate(value: unknown, max: number): string {
   const text = String(value ?? "");
   return text.length > max ? `${text.slice(0, max)}...` : text;
@@ -161,7 +203,9 @@ class LiveCotProgressHandle implements CotProgressHandle {
 
   async start(target: CotTarget, inputPreview: string): Promise<void> {
     try {
-      this.ref = await this.cotClient.create(target);
+      // Resolve om_/omt_ once here (run start), not per flush.
+      const resolved = await resolveCotTarget(this.cotClient, target);
+      this.ref = await this.cotClient.create(resolved);
       this.enqueue("RUN_STARTED", {
         threadId: this.scope,
         runId: this.runId,

--- a/src/bridge/cotProgress.ts
+++ b/src/bridge/cotProgress.ts
@@ -58,45 +58,55 @@ export interface CreateCotProgressHandleOpts {
 }
 
 /**
- * Resolve where the COT bubble anchors, per the om_ ≠ omt_ rule.
+ * Resolve an ORDERED list of COT-create attempts, per the om_/omt_ + tenant
+ * reality (full experiment matrix, 2026-07):
  *
- * message_cot's `receive_id_type=thread_id` channel ONLY accepts an omt_*
- * topic id. A top-level @ in a topic group arrives with an om_* message id in
- * its thread hint, which 10001s ("invalid receive_id"). So:
- *   1. omt_* hint → use it directly (thread channel).
- *   2. a non-omt_ thread hint (topic-group message) → GET the message for its
- *      real omt_* thread id (cached: this runs once at run start, not per flush).
- *   3. no usable omt_ (non-topic chat, or the GET failed/was empty) → fall back
- *      to the chat_id channel + origin_message_id (validated to be accepted).
+ *   - `receive_id_type=thread_id` only accepts an omt_* topic id, and even a
+ *     valid omt_ is rejected for our tenant (code=10002 "Bot/User can NOT be
+ *     out of the chat", regardless of origin_message_id) — the thread channel
+ *     is effectively closed for us today. We still TRY it first when we have an
+ *     omt_, so the moment the tenant opens it up the bubble anchors in-topic
+ *     with zero code change; on failure we degrade.
+ *   - `chat_id` succeeds (create/PUT/complete all code=0). With
+ *     origin_message_id set it renders as a "reply to <msg>" pointer back to
+ *     the trigger message (the bubble still lives at the group top level —
+ *     Feishu gives no in-topic anchoring here; the competitor's screenshots
+ *     show the same reply-pointer style).
  *
+ * So the attempt order is:
+ *   1. omt_ available → [thread channel, then chat_id+origin fallback].
+ *   2. no usable omt_ (non-topic chat, or the GET failed/empty) → [chat_id+origin].
+ *
+ * The caller (start()) tries them in order and keeps the first that succeeds.
  * `resolveThreadId` never throws (bypass rule), so this never throws either.
  */
-export async function resolveCotTarget(
+export async function resolveCotTargets(
   client: Pick<OutboundCotClient, "resolveThreadId">,
   hint: CotTarget,
-): Promise<CotTarget> {
-  if (hint.threadId && hint.threadId.startsWith("omt_")) {
-    return {
-      chatId: hint.chatId,
-      threadId: hint.threadId,
-      originMessageId: hint.originMessageId,
-    };
-  }
-  if (hint.threadId && hint.originMessageId) {
-    const omt = await client.resolveThreadId(hint.originMessageId);
-    if (omt && omt.startsWith("omt_")) {
-      return {
-        chatId: hint.chatId,
-        threadId: omt,
-        originMessageId: hint.originMessageId,
-      };
-    }
-  }
-  return {
+): Promise<CotTarget[]> {
+  const chatFallback: CotTarget = {
     chatId: hint.chatId,
     threadId: undefined,
     originMessageId: hint.originMessageId,
   };
+  const threadAttempt = (threadId: string): CotTarget => ({
+    chatId: hint.chatId,
+    threadId,
+    // origin is omitted on the wire for the thread channel (see
+    // ChannelCotClient.create), so keeping it here is harmless.
+    originMessageId: hint.originMessageId,
+  });
+
+  if (hint.threadId && hint.threadId.startsWith("omt_")) {
+    return [threadAttempt(hint.threadId), chatFallback];
+  }
+  if (hint.threadId && hint.originMessageId) {
+    const omt = await client.resolveThreadId(hint.originMessageId);
+    if (omt && omt.startsWith("omt_")) {
+      return [threadAttempt(omt), chatFallback];
+    }
+  }
+  return [chatFallback];
 }
 
 function truncate(value: unknown, max: number): string {
@@ -204,8 +214,12 @@ class LiveCotProgressHandle implements CotProgressHandle {
   async start(target: CotTarget, inputPreview: string): Promise<void> {
     try {
       // Resolve om_/omt_ once here (run start), not per flush.
-      const resolved = await resolveCotTarget(this.cotClient, target);
-      this.ref = await this.cotClient.create(resolved);
+      const attempts = await resolveCotTargets(this.cotClient, target);
+      this.ref = await this.createWithFallback(attempts);
+      if (!this.ref) {
+        this._disabled = true;
+        return;
+      }
       this.enqueue("RUN_STARTED", {
         threadId: this.scope,
         runId: this.runId,
@@ -215,6 +229,34 @@ class LiveCotProgressHandle implements CotProgressHandle {
       this._disabled = true;
       console.warn("[cot_progress] create failed; COT disabled for this run:", summarizeError(err));
     }
+  }
+
+  /**
+   * Try each create target in order, returning the first that succeeds. A
+   * failed attempt with a next one queued (i.e. the thread channel, which our
+   * tenant currently rejects) logs an info line and degrades to the next
+   * (chat-level) channel — NOT a disable. Only when the last attempt fails do
+   * we give up (caller disables). Never throws.
+   */
+  private async createWithFallback(attempts: readonly CotTarget[]): Promise<CotRef | undefined> {
+    for (let i = 0; i < attempts.length; i++) {
+      try {
+        return await this.cotClient.create(attempts[i]!);
+      } catch (err) {
+        if (i < attempts.length - 1) {
+          console.info(
+            "[cot_progress] thread channel rejected, falling back to chat-level bubble:",
+            summarizeError(err),
+          );
+        } else {
+          console.warn(
+            "[cot_progress] create failed on all channels; COT disabled for this run:",
+            summarizeError(err),
+          );
+        }
+      }
+    }
+    return undefined;
   }
 
   handle(event: AgentStreamEvent): void {

--- a/src/bridge/handler.ts
+++ b/src/bridge/handler.ts
@@ -55,6 +55,11 @@ import {
   type CardKitProgressHandle,
   type CardKitLiveMetrics,
 } from "./cardkitProgress.js";
+import {
+  createCotProgressHandle,
+  type CotProgressHandle,
+} from "./cotProgress.js";
+import type { OutboundCotClient } from "../lark/channelCotClient.js";
 import type { RuntimeEventPatch } from "./eventLog.js";
 import type { PerfSample } from "./perfLog.js";
 import type { RuntimeRequirement } from "../runtimeRequirements.js";
@@ -624,6 +629,11 @@ export interface BridgeHandlerDeps {
     /** Perf plan 批C model/effort knobs — passed through to RunOptions verbatim. */
     model?: string;
     effort?: string;
+    /**
+     * COT (思维链) 气泡档位。"off" = 不推;"brief"/"detailed" 见 BotConfig.cot。
+     * 缺省视为 "brief"。仅在非 "off" 时 main.ts 才注入 cotClient。
+     */
+    cot?: "off" | "brief" | "detailed";
   };
   /**
    * Optional outbound post transport. main.ts only injects this when the bot's
@@ -638,6 +648,12 @@ export interface BridgeHandlerDeps {
    * fallback.
    */
   cardKitClient?: OutboundCardKitClient;
+  /**
+   * Optional COT (思维链) transport. main.ts injects it only when the bot's
+   * `cot` config is not "off". Drives the client-native collapsible reasoning
+   * bubble alongside the answer card; every failure degrades silently.
+   */
+  cotClient?: OutboundCotClient;
   /**
    * V2: L2 Agent Memory content (职能定义) — loaded from the bot's memory_file by
    * botLoader. Injected into the prompt as a `<agent-memory>` role preamble.
@@ -915,6 +931,11 @@ export class BridgeHandler {
     // raw event (== parsed.messageId) so it's available even before parsing.
     const settleMessageId = event.message_id;
     let settled = false;
+    // COT (思维链) side channel — declared at function scope so the finally
+    // safety net below can close() it on any exit path. Created once per turn
+    // inside the try, fed every event, finalized on success/error. Always
+    // best-effort; a disabled handle is a no-op (see src/bridge/cotProgress.ts).
+    let cotPublisher: CotProgressHandle | undefined;
     const settle = (ok: boolean): void => {
       if (settled) return;
       settled = true;
@@ -1544,6 +1565,33 @@ export class BridgeHandler {
         }
       }
 
+      // COT (思维链) bubble — a parallel side channel to the answer card,
+      // created ONCE per turn here (outside the retry loop, so a stale-session
+      // respawn never opens a second bubble). Best-effort in every respect:
+      // createCotProgressHandle never throws (a create failure returns a
+      // disabled no-op handle), and each handle()/finalize() below degrades
+      // silently. Only reasoning + tool activity flow here; the final answer
+      // stays exclusively on the card. Topic groups anchor on the omt_ thread
+      // id; other chats fall back to chat_id + the trigger message.
+      const cotDetail = this.deps.botConfig?.cot ?? "brief";
+      if (this.deps.cotClient && cotDetail !== "off") {
+        cotPublisher = await createCotProgressHandle({
+          cotClient: this.deps.cotClient,
+          detail: cotDetail,
+          runId: messageId,
+          scope: threadId,
+          inputPreview: parsed.text,
+          target: {
+            chatId: parsed.chatId,
+            threadId:
+              typeof parsed.raw.thread_id === "string" && parsed.raw.thread_id
+                ? parsed.raw.thread_id
+                : undefined,
+            originMessageId: messageId,
+          },
+        });
+      }
+
       // Step 4b–4f: spawn + stream + finalize, with one stale-session retry.
       // `currentExisting` may be reset to undefined on retry (ghost session cleared).
       let currentExisting = existing;
@@ -1769,6 +1817,9 @@ export class BridgeHandler {
             }
             if (cardKitProgress) cardKitProgress.handle(ev);
             else if (card) card.handle(ev);
+            // COT is a parallel channel, not an either/or with the card: feed
+            // it every event regardless of which primary surface is live.
+            if (cotPublisher) cotPublisher.handle(ev);
             if (ev.type === "system_init") {
               sessionId = ev.sessionId;
             }
@@ -1783,6 +1834,16 @@ export class BridgeHandler {
           if (idleWatchdog) {
             clearInterval(idleWatchdog);
             idleWatchdog = undefined;
+          }
+
+          // Complete the COT bubble for this (successful/idle-cut) turn. An
+          // idle-watchdog kill is a real hang → complete as error; otherwise
+          // done. finalize() is idempotent + never throws.
+          if (cotPublisher) {
+            await cotPublisher.finalize(
+              interruptedByIdle ? "error" : "done",
+              interruptedByIdle ? { message: "idle timeout" } : undefined,
+            );
           }
 
           // M3 regression fix (Workflow review of 批B Phase 1): a POOLED
@@ -2279,6 +2340,12 @@ export class BridgeHandler {
       }
     } catch (err) {
       console.error("[bridge.handler] handleOne failed for thread", threadId, err);
+      // Close the COT bubble as errored (idempotent + never throws). The turn
+      // crashed before its success-path finalize, so complete it with reason
+      // error so the client-side bubble doesn't hang open.
+      if (cotPublisher) {
+        await cotPublisher.finalize("error", { message: String(err) });
+      }
       await this.deps.client.removeProcessingReaction?.(messageId);
       await recordEvent({
         status: "failed",
@@ -2374,6 +2441,11 @@ export class BridgeHandler {
       }
     }
     } finally {
+      // COT safety net: cancel any pending flush on every exit path. If a
+      // finalize already ran (success/error site), this is a no-op; if the
+      // turn escaped both (e.g. threw before finalize), close() at least stops
+      // a dangling throttle timer. Never completes the bubble on its own.
+      cotPublisher?.close();
       // Safety net for EVERY exit path of handleOne. The success site calls
       // settle(true) and the failure catch calls settle(false); both make
       // settled=true so this is a no-op for them. But if anything threw BEFORE

--- a/src/bridge/handler.ts
+++ b/src/bridge/handler.ts
@@ -1838,12 +1838,22 @@ export class BridgeHandler {
 
           // Complete the COT bubble for this (successful/idle-cut) turn. An
           // idle-watchdog kill is a real hang → complete as error; otherwise
-          // done. finalize() is idempotent + never throws.
+          // done. Fire-and-forget on PURPOSE: COT is a best-effort side channel
+          // and must never sit in front of the real deliverables that follow
+          // (final answer card finalize + session persistence). Even with the
+          // per-call timeout in ChannelCotClient, we don't want up to 8s of COT
+          // teardown delaying the card. finalize() is idempotent + never throws;
+          // the finally's close() only cancels the throttle timer, so it stays
+          // compatible with an in-flight finalize.
           if (cotPublisher) {
-            await cotPublisher.finalize(
-              interruptedByIdle ? "error" : "done",
-              interruptedByIdle ? { message: "idle timeout" } : undefined,
-            );
+            void cotPublisher
+              .finalize(
+                interruptedByIdle ? "error" : "done",
+                interruptedByIdle ? { message: "idle timeout" } : undefined,
+              )
+              .catch(() => {
+                /* best-effort COT completion — never affects the turn */
+              });
           }
 
           // M3 regression fix (Workflow review of 批B Phase 1): a POOLED
@@ -2340,11 +2350,15 @@ export class BridgeHandler {
       }
     } catch (err) {
       console.error("[bridge.handler] handleOne failed for thread", threadId, err);
-      // Close the COT bubble as errored (idempotent + never throws). The turn
-      // crashed before its success-path finalize, so complete it with reason
-      // error so the client-side bubble doesn't hang open.
+      // Close the COT bubble as errored. Fire-and-forget (same rationale as the
+      // success path): the error teardown below — reaction removal, event log,
+      // markUnhandled self-heal — must not wait on a best-effort COT call.
+      // finalize() is idempotent + never throws; the finally's close() only
+      // cancels the throttle timer.
       if (cotPublisher) {
-        await cotPublisher.finalize("error", { message: String(err) });
+        void cotPublisher.finalize("error", { message: String(err) }).catch(() => {
+          /* best-effort COT completion — never affects error teardown */
+        });
       }
       await this.deps.client.removeProcessingReaction?.(messageId);
       await recordEvent({

--- a/src/claude/runner.test.ts
+++ b/src/claude/runner.test.ts
@@ -327,6 +327,79 @@ describe("parseLinesMulti", () => {
     // positive (2 increments, 1 decrement) for the rest of the turn.
     expect(toolResultEvents).toHaveLength(2);
   });
+
+  it("emits thinking_delta from stream_event thinking_delta (COT reasoning)", () => {
+    const extractor = new AnswerChannelExtractor();
+    // Real claude stream-json shape for streamed reasoning under
+    // --include-partial-messages: a content_block_delta carrying a
+    // thinking_delta whose text lives in `delta.thinking`, not `delta.text`.
+    const line = JSON.stringify({
+      type: "stream_event",
+      event: {
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "thinking_delta", thinking: "Let me weigh the options" },
+      },
+    });
+
+    const events = [...parseLinesMulti(line, extractor)];
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({ type: "thinking_delta", text: "Let me weigh the options" });
+    // Reasoning must not leak into the answer channel.
+    expect(events.some((e) => e.type === "answer_delta" || e.type === "answer_snapshot")).toBe(false);
+  });
+
+  it("emits thinking_snapshot from an assistant thinking content block", () => {
+    const extractor = new AnswerChannelExtractor();
+    // The final assistant message carries the complete thinking block; its
+    // text is in `thinking` (with a `signature`), a sibling of text/tool_use.
+    const line = JSON.stringify({
+      type: "assistant",
+      message: {
+        content: [
+          { type: "thinking", thinking: "Full reasoning trace", signature: "sig-abc" },
+        ],
+      },
+    });
+
+    const events = [...parseLinesMulti(line, extractor)];
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({ type: "thinking_snapshot", text: "Full reasoning trace" });
+    expect(events.some((e) => e.type === "answer_delta" || e.type === "answer_snapshot")).toBe(false);
+  });
+
+  it("emits thinking + tool_use + answer from a mixed assistant message in block order", () => {
+    const extractor = new AnswerChannelExtractor();
+    const line = JSON.stringify({
+      type: "assistant",
+      message: {
+        content: [
+          { type: "thinking", thinking: "think first", signature: "s" },
+          { type: "tool_use", id: "call_1", name: "Read", input: { file_path: "/x" } },
+          { type: "text", text: "LARKWAY_ANSWER_BEGIN\nHi there\nLARKWAY_ANSWER_END" },
+        ],
+      },
+    });
+
+    const events = [...parseLinesMulti(line, extractor)];
+    expect(events.map((e) => e.type)).toEqual([
+      "thinking_snapshot",
+      "tool_use",
+      "answer_delta",
+    ]);
+  });
+
+  it("does not treat a thinking block as tool_use or text", () => {
+    const extractor = new AnswerChannelExtractor();
+    const line = JSON.stringify({
+      type: "assistant",
+      message: { content: [{ type: "thinking", thinking: "x", signature: "s" }] },
+    });
+    const events = [...parseLinesMulti(line, extractor)];
+    expect(events.some((e) => e.type === "tool_use")).toBe(false);
+    expect(events.some((e) => e.type === "text_delta")).toBe(false);
+    expect(events.some((e) => e.type === "raw")).toBe(false);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/claude/runner.ts
+++ b/src/claude/runner.ts
@@ -226,6 +226,14 @@ function* parseLinesMulti(
         if (block["type"] === "text" && typeof block["text"] === "string") {
           yield* answerExtractor.ingestGrowingSnapshot(block["text"], obj);
           emitted = true;
+        } else if (block["type"] === "thinking" && typeof block["thinking"] === "string") {
+          // Reasoning content block. Distinct from the answer channel — no
+          // marker gate. Emitted as a full-block snapshot; the COT consumer
+          // treats it as a catch-up only when no thinking_delta streamed this
+          // run (see src/bridge/cotProgress.ts), so with --include-partial-
+          // messages on (always, see buildCommand) this never double-renders.
+          yield { type: "thinking_snapshot", text: block["thinking"], raw: obj };
+          emitted = true;
         } else if (block["type"] === "tool_use") {
           yield {
             type: "tool_use",
@@ -257,6 +265,18 @@ function* parseLinesMulti(
           typeof deltaRecord["text"] === "string"
         ) {
           yield* answerExtractor.ingestDelta(deltaRecord["text"], obj);
+          return;
+        }
+        // Incremental reasoning. A thinking content block streams its text as
+        // content_block_delta events carrying delta.type "thinking_delta" +
+        // delta.thinking — the reasoning counterpart of text_delta above.
+        // Surfaced only in the COT bubble, never the answer card.
+        if (
+          streamEvent["type"] === "content_block_delta" &&
+          deltaRecord["type"] === "thinking_delta" &&
+          typeof deltaRecord["thinking"] === "string"
+        ) {
+          yield { type: "thinking_delta", text: deltaRecord["thinking"], raw: obj };
           return;
         }
       }

--- a/src/cli/botsStore.test.ts
+++ b/src/cli/botsStore.test.ts
@@ -29,6 +29,7 @@ const sampleBot = (): BotConfig =>
     response_surface_prototype: DEFAULT_RESPONSE_SURFACE_PROTOTYPE,
     runtime: "legacy",
     backend: "claude",
+    cot: "brief",
   }) as BotConfig;
 
 beforeEach(async () => {

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -635,6 +635,7 @@ async function runCreateBot(
     response_surface_prototype: DEFAULT_RESPONSE_SURFACE_PROTOTYPE,
     runtime: "agent_workspace",
     backend: basics.backend,
+    cot: "brief",
     memory_file: memoryFile,
     ...(basics.gitlabTokenEnv ? { gitlab_token_env: basics.gitlabTokenEnv } : {}),
     ...(basics.gitName && basics.gitEmail

--- a/src/cli/commands/memory.test.ts
+++ b/src/cli/commands/memory.test.ts
@@ -47,6 +47,7 @@ const sampleBot = (id = "test-bot"): BotConfig =>
     response_surface_prototype: DEFAULT_RESPONSE_SURFACE_PROTOTYPE,
     runtime: "legacy",
     backend: "claude",
+    cot: "brief",
   }) as BotConfig;
 
 /** Collected output lines (stdout / stderr) across a run. */

--- a/src/codex/runner.test.ts
+++ b/src/codex/runner.test.ts
@@ -164,6 +164,59 @@ function appAgentCompleted(text: string): string {
   });
 }
 
+// Reasoning fixtures — shapes taken verbatim from a real codex-cli 0.140.0
+// app-server capture (ids replaced with obvious fakes).
+const APP_REASONING_ITEM_ID = "rs_fakereasoning01";
+
+function appReasoningDelta(delta: string, summaryIndex = 0): string {
+  return JSON.stringify({
+    method: "item/reasoning/summaryTextDelta",
+    params: {
+      threadId: APP_THREAD_ID,
+      turnId: "turn-1",
+      itemId: APP_REASONING_ITEM_ID,
+      delta,
+      summaryIndex,
+    },
+  });
+}
+
+function appReasoningPartAdded(summaryIndex: number): string {
+  return JSON.stringify({
+    method: "item/reasoning/summaryPartAdded",
+    params: {
+      threadId: APP_THREAD_ID,
+      turnId: "turn-1",
+      itemId: APP_REASONING_ITEM_ID,
+      summaryIndex,
+    },
+  });
+}
+
+function appReasoningStarted(): string {
+  return JSON.stringify({
+    method: "item/started",
+    params: {
+      item: { type: "reasoning", id: APP_REASONING_ITEM_ID, summary: [], content: [] },
+      threadId: APP_THREAD_ID,
+      turnId: "turn-1",
+      startedAtMs: 1,
+    },
+  });
+}
+
+function appReasoningCompleted(summary: string[]): string {
+  return JSON.stringify({
+    method: "item/completed",
+    params: {
+      item: { type: "reasoning", id: APP_REASONING_ITEM_ID, summary, content: [] },
+      threadId: APP_THREAD_ID,
+      turnId: "turn-1",
+      completedAtMs: 2,
+    },
+  });
+}
+
 const APP_TURN_COMPLETED = JSON.stringify({
   method: "turn/completed",
   params: {
@@ -329,6 +382,61 @@ describe("CodexAppServerLineParser", () => {
     expect(events.filter((event) => event.type === "answer_delta")).not.toHaveLength(0);
     expect(events.filter((event) => event.type === "answer_snapshot")).toHaveLength(0);
   });
+
+  it("maps reasoning summaryTextDelta to thinking_delta (not the answer channel)", () => {
+    const parser = new CodexAppServerLineParser();
+    const events = [
+      ...parser.parseMessage(JSON.parse(appReasoningDelta("**Analyzing the riddle**\n\nI"))),
+      ...parser.parseMessage(JSON.parse(appReasoningDelta(" need to think"))),
+    ];
+
+    const thinking = events.filter((e) => e.type === "thinking_delta");
+    expect(thinking.map((e) => (e as { text: string }).text).join("")).toBe(
+      "**Analyzing the riddle**\n\nI need to think",
+    );
+    expect(events.some((e) => e.type === "answer_delta" || e.type === "answer_snapshot")).toBe(false);
+  });
+
+  it("ignores an empty reasoning delta", () => {
+    const parser = new CodexAppServerLineParser();
+    const events = [...parser.parseMessage(JSON.parse(appReasoningDelta("")))];
+    expect(events).toHaveLength(0);
+  });
+
+  it("inserts a blank-line separator only between reasoning summary parts", () => {
+    const parser = new CodexAppServerLineParser();
+    const first = [...parser.parseMessage(JSON.parse(appReasoningPartAdded(0)))];
+    const second = [...parser.parseMessage(JSON.parse(appReasoningPartAdded(1)))];
+
+    // Part 0 opens the first summary — no leading separator.
+    expect(first).toHaveLength(0);
+    // Part 1+ gets a "\n\n" separator delta so parts don't run together.
+    expect(second).toEqual([{ type: "thinking_delta", text: "\n\n", raw: expect.anything() }]);
+  });
+
+  it("emits nothing for a started (empty-shell) reasoning item", () => {
+    const parser = new CodexAppServerLineParser();
+    const events = [...parser.parseMessage(JSON.parse(appReasoningStarted()))];
+    expect(events).toHaveLength(0);
+  });
+
+  it("emits completed reasoning summary as a thinking_snapshot fallback", () => {
+    const parser = new CodexAppServerLineParser();
+    const events = [
+      ...parser.parseMessage(
+        JSON.parse(appReasoningCompleted(["**Analyzing**\n\nfull trace here", "second part"])),
+      ),
+    ];
+    expect(events).toEqual([
+      { type: "thinking_snapshot", text: "**Analyzing**\n\nfull trace here\n\nsecond part", raw: expect.anything() },
+    ]);
+  });
+
+  it("tolerates a completed reasoning item with an empty summary (no event)", () => {
+    const parser = new CodexAppServerLineParser();
+    const events = [...parser.parseMessage(JSON.parse(appReasoningCompleted([])))];
+    expect(events).toHaveLength(0);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -339,7 +447,7 @@ describe("buildCodexCommand", () => {
   it("fresh session: runs codex app-server over stdio", () => {
     const [bin, args] = buildCodexCommand({ prompt: "hello" });
     expect(bin).toBe("codex");
-    expect(args).toEqual(["app-server", "--stdio"]);
+    expect(args).toEqual(["-c", "model_reasoning_summary=detailed", "app-server", "--stdio"]);
   });
 
   it("resume session: still uses app-server; resume is a JSON-RPC request", () => {
@@ -348,12 +456,12 @@ describe("buildCodexCommand", () => {
       resumeSessionId: "019eabc123def456",
     });
     expect(bin).toBe("codex");
-    expect(args).toEqual(["app-server", "--stdio"]);
+    expect(args).toEqual(["-c", "model_reasoning_summary=detailed", "app-server", "--stdio"]);
   });
 
   it("cwd is not encoded in argv; it is sent through app-server params", () => {
     const [, args] = buildCodexCommand({ prompt: "hello", cwd: "/wt" });
-    expect(args).toEqual(["app-server", "--stdio"]);
+    expect(args).toEqual(["-c", "model_reasoning_summary=detailed", "app-server", "--stdio"]);
   });
 
   it("permission mode is not encoded in argv; it is sent through app-server params", () => {
@@ -361,7 +469,7 @@ describe("buildCodexCommand", () => {
       prompt: "hello",
       permissionMode: "acceptEdits",
     });
-    expect(args).toEqual(["app-server", "--stdio"]);
+    expect(args).toEqual(["-c", "model_reasoning_summary=detailed", "app-server", "--stdio"]);
   });
 
   it("custom codexBinPath overrides default 'codex'", () => {
@@ -706,7 +814,7 @@ describe("runCodex() — spawn-level integration", () => {
     await handle.done;
 
     expect(__lastSpawnArgs).not.toBeNull();
-    expect(__lastSpawnArgs!.args).toEqual(["app-server", "--stdio"]);
+    expect(__lastSpawnArgs!.args).toEqual(["-c", "model_reasoning_summary=detailed", "app-server", "--stdio"]);
 
     const stdinText: string = fake.child.stdin.read()?.toString("utf8") ?? "";
     const requests: Array<{
@@ -883,7 +991,7 @@ describe("runCodex() — spawn-level integration", () => {
 
     // Verify spawn received correct argv for resume
     expect(__lastSpawnArgs).not.toBeNull();
-    expect(__lastSpawnArgs!.args).toEqual(["app-server", "--stdio"]);
+    expect(__lastSpawnArgs!.args).toEqual(["-c", "model_reasoning_summary=detailed", "app-server", "--stdio"]);
     const stdinText = fake.child.stdin.read()?.toString("utf8") ?? "";
     expect(stdinText).toContain('"method":"thread/resume"');
     expect(stdinText).toContain('"threadId":"019eabc123def456"');

--- a/src/codex/runner.ts
+++ b/src/codex/runner.ts
@@ -291,6 +291,16 @@ class CodexLineParser {
     return;
   }
 
+  // ── reasoning → thinking_delta (COT) — extension point ──────────────────
+  // TODO(cot): map Codex reasoning items to `thinking_delta` (see
+  // src/agent/runner.ts + src/bridge/cotProgress.ts) once the exact
+  // `codex exec --json` reasoning item schema is confirmed. Candidate shapes
+  // observed but NOT yet verified: item.started/completed with
+  // item.type === "reasoning" (+ a text/summary field), or a dedicated
+  // reasoning delta type. Left unmapped on purpose — do not guess the field
+  // names; reasoning currently falls through to `raw` (dropped), byte-
+  // identical to pre-COT behavior.
+
   // ── everything else (turn.started, error, reasoning, file_change, …) ────
   yield { type: "raw", raw: obj };
   }
@@ -359,6 +369,14 @@ class CodexAppServerLineParser {
       }
       return;
     }
+
+    // ── reasoning → thinking_delta (COT) — extension point ────────────────
+    // TODO(cot): map Codex app-server reasoning notifications to
+    // `thinking_delta` (see src/agent/runner.ts + src/bridge/cotProgress.ts)
+    // once the exact method name is confirmed. Candidate methods observed but
+    // NOT yet verified: "item/agentReasoning/delta", "item/reasoning/delta".
+    // Left unmapped on purpose — do not guess; reasoning currently falls
+    // through to `raw` (dropped), byte-identical to pre-COT behavior.
 
     yield { type: "raw", raw: obj };
   }

--- a/src/codex/runner.ts
+++ b/src/codex/runner.ts
@@ -120,7 +120,17 @@ export function buildCodexCommand(
   codexBinPath = "codex",
 ): [string, string[]] {
   void opts;
-  return [codexBinPath, ["app-server", "--stdio"]];
+  // `-c model_reasoning_summary=detailed`: a per-invocation config override
+  // (global codex flag, so it precedes the subcommand) that makes the model
+  // emit its reasoning summary as item/reasoning/summaryTextDelta events —
+  // without it, app-server yields zero reasoning output and the COT bubble
+  // stays empty. `detailed` is the richest of auto/concise/detailed. This is
+  // a CLI flag, NOT a mutation of the user's ~/.codex/config.toml (confirmed
+  // supported, codex-cli 0.140.0).
+  return [
+    codexBinPath,
+    ["-c", "model_reasoning_summary=detailed", "app-server", "--stdio"],
+  ];
 }
 
 type JsonRecord = Record<string, unknown>;
@@ -292,14 +302,13 @@ class CodexLineParser {
   }
 
   // ── reasoning → thinking_delta (COT) — extension point ──────────────────
-  // TODO(cot): map Codex reasoning items to `thinking_delta` (see
-  // src/agent/runner.ts + src/bridge/cotProgress.ts) once the exact
-  // `codex exec --json` reasoning item schema is confirmed. Candidate shapes
-  // observed but NOT yet verified: item.started/completed with
-  // item.type === "reasoning" (+ a text/summary field), or a dedicated
-  // reasoning delta type. Left unmapped on purpose — do not guess the field
-  // names; reasoning currently falls through to `raw` (dropped), byte-
-  // identical to pre-COT behavior.
+  // NOTE: this parser handles the legacy `codex exec --json` surface, which
+  // is NOT the live path — buildCodexCommand always spawns `app-server`, whose
+  // reasoning IS mapped (see CodexAppServerLineParser: item/reasoning/
+  // summaryTextDelta → thinking_delta, completed reasoning summary →
+  // thinking_snapshot). The `codex exec --json` reasoning item schema is
+  // unconfirmed, so it is deliberately NOT guessed here; reasoning falls
+  // through to `raw` (dropped), byte-identical to pre-COT behavior.
 
   // ── everything else (turn.started, error, reasoning, file_change, …) ────
   yield { type: "raw", raw: obj };
@@ -343,6 +352,28 @@ class CodexAppServerLineParser {
       return;
     }
 
+    // ── reasoning summary deltas → thinking_delta (COT) ──────────────────
+    // Enabled by `-c model_reasoning_summary=detailed` (see buildCodexCommand).
+    // Mirrors item/agentMessage/delta exactly: incremental text in
+    // params.delta. params.summaryIndex segments the summary into parts; a
+    // new part is announced by summaryPartAdded below. Confirmed live shape,
+    // codex-cli 0.140.0.
+    if (method === "item/reasoning/summaryTextDelta") {
+      const delta = typeof params?.["delta"] === "string" ? params["delta"] : "";
+      if (delta) yield { type: "thinking_delta", text: delta, raw: obj };
+      return;
+    }
+
+    // A new reasoning summary part begins. Insert a blank line between parts
+    // so concatenated segments in the COT bubble stay readable. summaryIndex 0
+    // is the first part — no separator before it.
+    if (method === "item/reasoning/summaryPartAdded") {
+      const summaryIndex =
+        typeof params?.["summaryIndex"] === "number" ? params["summaryIndex"] : 0;
+      if (summaryIndex > 0) yield { type: "thinking_delta", text: "\n\n", raw: obj };
+      return;
+    }
+
     if (method === "item/started") {
       const item = asRecord(params?.["item"]);
       if (item?.["type"] === "commandExecution" && typeof item["command"] === "string") {
@@ -367,19 +398,34 @@ class CodexAppServerLineParser {
         yield* this.answerExtractor.ingestSnapshot(item["text"], obj);
         return;
       }
+      // Completed reasoning item: the full summary lives in item.summary (a
+      // string array, one element per part; item.content is always empty —
+      // raw thoughts are never exposed). Emit as a thinking_snapshot catch-up
+      // for trivial turns where the model produced no summaryTextDelta at all;
+      // cotProgress ignores it when deltas already streamed. Tolerates an
+      // empty summary (a short task can complete an empty reasoning shell).
+      if (item?.["type"] === "reasoning") {
+        const summary = reasoningSummaryText(item["summary"]);
+        if (summary) yield { type: "thinking_snapshot", text: summary, raw: obj };
+        return;
+      }
       return;
     }
 
-    // ── reasoning → thinking_delta (COT) — extension point ────────────────
-    // TODO(cot): map Codex app-server reasoning notifications to
-    // `thinking_delta` (see src/agent/runner.ts + src/bridge/cotProgress.ts)
-    // once the exact method name is confirmed. Candidate methods observed but
-    // NOT yet verified: "item/agentReasoning/delta", "item/reasoning/delta".
-    // Left unmapped on purpose — do not guess; reasoning currently falls
-    // through to `raw` (dropped), byte-identical to pre-COT behavior.
-
     yield { type: "raw", raw: obj };
   }
+}
+
+/**
+ * Join a codex reasoning item's `summary` (a string array, one entry per
+ * summary part) into a single reasoning trace. Non-string / empty entries are
+ * dropped; returns "" when there is nothing to show.
+ */
+function reasoningSummaryText(summary: unknown): string {
+  if (!Array.isArray(summary)) return "";
+  return summary
+    .filter((s): s is string => typeof s === "string" && s.length > 0)
+    .join("\n\n");
 }
 
 function asRecord(value: unknown): JsonRecord | undefined {

--- a/src/config/botLoader.ts
+++ b/src/config/botLoader.ts
@@ -327,6 +327,19 @@ export const BotConfigSchema = z.object({
   backend: z.string().min(1).default("claude"),
 
   /**
+   * COT (思维链) 气泡:把 agent 的 thinking 思考过程 + 工具调用摘要实时推到飞书
+   * 原生的可折叠思维链气泡(与最终答案卡片互不干扰,最终答案永远只走卡片)。
+   *
+   * - "off":完全不调用 message_cot API(零网络、零副作用)。
+   * - "brief"(默认):思考过程 + 工具名摘要。
+   * - "detailed":额外推工具入参(TOOL_CALL_ARGS)与截断后的工具结果。
+   *
+   * message_cot 是无公开文档的 API —— 任何一步失败都会在本次会话内自动降级、
+   * 只记 warn,绝不影响卡片和最终答案(见 src/bridge/cotProgress.ts)。
+   */
+  cot: z.enum(["off", "brief", "detailed"]).default("brief"),
+
+  /**
    * 话题 ↔ 飞书任务句柄(docs/task-handle.md,v2)。省略此字段不代表关闭,但也
    * 不会触发任何自动建清单——main.ts 在 startup 时只做只读解析(yaml 里的
    * tasklistGuid,或共享注册文件里已有的 guid);清单本身只由

--- a/src/lark/channelClient.ts
+++ b/src/lark/channelClient.ts
@@ -35,6 +35,11 @@ import {
   type OutboundCardKitLarkChannel,
 } from "./channelCardKitClient.js";
 import { ChannelPostClient, type OutboundPostLarkChannel } from "./channelPostClient.js";
+import {
+  ChannelCotClient,
+  type OutboundCotClient,
+  type OutboundCotLarkChannel,
+} from "./channelCotClient.js";
 import type { OutboundCardClient } from "./outboundCardClient.js";
 import type { OutboundPostClient } from "./outboundPostClient.js";
 
@@ -556,6 +561,8 @@ export class ChannelClient {
   private cardKitClient: ChannelCardKitClient | null = null;
   /** Lazily built and only requested by main.ts when post outbound gates are configured. */
   private postClient: ChannelPostClient | null = null;
+  /** Lazily built COT (思维链) client; only requested when a bot enables cot != off. */
+  private cotClient: ChannelCotClient | null = null;
 
   constructor(opts: LarkClientOptions) {
     if (!opts.appId || !opts.appSecret) {
@@ -857,6 +864,24 @@ export class ChannelClient {
       });
     }
     return this.cardKitClient;
+  }
+
+  /**
+   * Return an OutboundCotClient bound to this client's channel handle.
+   *
+   * main.ts only calls this when the bot's `cot` config is not "off". The COT
+   * bubble uses the SDK's generic rawClient.request() (tenant token auto-
+   * injected via the same token manager as every other outbound call), so it
+   * adds no auth surface. Resolves the live channel lazily at call time.
+   */
+  outboundCotClient(): OutboundCotClient {
+    if (!this.cotClient) {
+      this.cotClient = new ChannelCotClient({
+        resolveChannel: () =>
+          this.channel as unknown as OutboundCotLarkChannel | null,
+      });
+    }
+    return this.cotClient;
   }
 
   /**

--- a/src/lark/channelCotClient.test.ts
+++ b/src/lark/channelCotClient.test.ts
@@ -120,6 +120,58 @@ describe("ChannelCotClient", () => {
   });
 });
 
+describe("ChannelCotClient.resolveThreadId", () => {
+  it("returns the omt_ thread id from GET /messages/{id} items", async () => {
+    const { channel, requests } = fakeChannel(() => ({
+      code: 0,
+      data: { items: [{ message_id: "om_1", thread_id: "omt_real", root_id: "om_1" }] },
+    }));
+    const client = new ChannelCotClient({ resolveChannel: () => channel });
+
+    await expect(client.resolveThreadId("om_1")).resolves.toBe("omt_real");
+    expect(requests[0]).toMatchObject({
+      url: "/open-apis/im/v1/messages/om_1",
+      method: "GET",
+    });
+  });
+
+  it("returns undefined when thread_id is absent (non-topic message)", async () => {
+    const { channel } = fakeChannel(() => ({
+      code: 0,
+      data: { items: [{ message_id: "om_1" }] },
+    }));
+    const client = new ChannelCotClient({ resolveChannel: () => channel });
+    await expect(client.resolveThreadId("om_1")).resolves.toBeUndefined();
+  });
+
+  it("returns undefined for a non-omt_ thread_id", async () => {
+    const { channel } = fakeChannel(() => ({
+      code: 0,
+      data: { items: [{ message_id: "om_1", thread_id: "om_notathread" }] },
+    }));
+    const client = new ChannelCotClient({ resolveChannel: () => channel });
+    await expect(client.resolveThreadId("om_1")).resolves.toBeUndefined();
+  });
+
+  it("returns undefined (never throws) on a non-zero API code", async () => {
+    const { channel } = fakeChannel(() => ({ code: 230002, msg: "bad message id" }));
+    const client = new ChannelCotClient({ resolveChannel: () => channel });
+    await expect(client.resolveThreadId("om_bad")).resolves.toBeUndefined();
+  });
+
+  it("returns undefined (never throws) when the request rejects", async () => {
+    const channel: OutboundCotLarkChannel = {
+      rawClient: {
+        async request<T>(): Promise<T> {
+          throw new Error("network down");
+        },
+      },
+    };
+    const client = new ChannelCotClient({ resolveChannel: () => channel });
+    await expect(client.resolveThreadId("om_1")).resolves.toBeUndefined();
+  });
+});
+
 describe("ChannelCotClient timeout (hang guard)", () => {
   afterEach(() => {
     vi.useRealTimers();

--- a/src/lark/channelCotClient.test.ts
+++ b/src/lark/channelCotClient.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import {
+  ChannelCotClient,
+  type OutboundCotLarkChannel,
+  type RawCotRequestOptions,
+} from "./channelCotClient.js";
+
+function fakeChannel(responder: (opts: RawCotRequestOptions) => unknown) {
+  const requests: RawCotRequestOptions[] = [];
+  const channel: OutboundCotLarkChannel = {
+    rawClient: {
+      async request<T>(opts: RawCotRequestOptions): Promise<T> {
+        requests.push(opts);
+        return responder(opts) as T;
+      },
+    },
+  };
+  return { channel, requests };
+}
+
+describe("ChannelCotClient", () => {
+  it("create in a topic addresses the thread (receive_id_type=thread_id, no origin)", async () => {
+    const { channel, requests } = fakeChannel(() => ({
+      code: 0,
+      data: { cot_id: "cot_1", message_id: "om_1" },
+    }));
+    const client = new ChannelCotClient({ resolveChannel: () => channel });
+
+    const ref = await client.create({
+      chatId: "oc_x",
+      threadId: "omt_x",
+      originMessageId: "om_trigger",
+    });
+
+    expect(ref).toEqual({ cotId: "cot_1", messageId: "om_1" });
+    expect(requests).toHaveLength(1);
+    expect(requests[0]).toMatchObject({
+      url: "/open-apis/im/v1/message_cot",
+      method: "POST",
+      params: { receive_id_type: "thread_id" },
+    });
+    expect(requests[0].data).toEqual({ receive_id: "omt_x" });
+    expect(requests[0].data).not.toHaveProperty("origin_message_id");
+  });
+
+  it("create in a non-topic chat uses chat_id + origin_message_id", async () => {
+    const { channel, requests } = fakeChannel(() => ({
+      code: 0,
+      data: { cot_id: "cot_2", message_id: "om_2" },
+    }));
+    const client = new ChannelCotClient({ resolveChannel: () => channel });
+
+    await client.create({ chatId: "oc_y", originMessageId: "om_trigger" });
+
+    expect(requests[0].params).toEqual({ receive_id_type: "chat_id" });
+    expect(requests[0].data).toEqual({
+      receive_id: "oc_y",
+      origin_message_id: "om_trigger",
+    });
+  });
+
+  it("update PUTs cot_id, message_id and the events array", async () => {
+    const { channel, requests } = fakeChannel(() => ({ code: 0 }));
+    const client = new ChannelCotClient({ resolveChannel: () => channel });
+
+    await client.update(
+      { cotId: "cot_1", messageId: "om_1" },
+      [{ event_type: "RUN_STARTED", content: "{}", timestamp: 123 }],
+    );
+
+    expect(requests[0]).toMatchObject({
+      url: "/open-apis/im/v1/message_cot",
+      method: "PUT",
+    });
+    expect(requests[0].data).toMatchObject({ cot_id: "cot_1", message_id: "om_1" });
+    expect((requests[0].data as { events: unknown[] }).events).toHaveLength(1);
+  });
+
+  it("update with no events makes no request", async () => {
+    const { channel, requests } = fakeChannel(() => ({ code: 0 }));
+    const client = new ChannelCotClient({ resolveChannel: () => channel });
+    await client.update({ cotId: "cot_1", messageId: "om_1" }, []);
+    expect(requests).toHaveLength(0);
+  });
+
+  it("complete POSTs to complete/<cotId> with message_id + reason params", async () => {
+    const { channel, requests } = fakeChannel(() => ({ code: 0 }));
+    const client = new ChannelCotClient({ resolveChannel: () => channel });
+
+    await client.complete({ cotId: "cot_1", messageId: "om_1" }, "done");
+
+    expect(requests[0]).toMatchObject({
+      url: "/open-apis/im/v1/message_cot/complete/cot_1",
+      method: "POST",
+      params: { message_id: "om_1", reason: "done" },
+    });
+  });
+
+  it("throws on a non-zero API code", async () => {
+    const { channel } = fakeChannel(() => ({ code: 99991663, msg: "permission denied" }));
+    const client = new ChannelCotClient({ resolveChannel: () => channel });
+    await expect(
+      client.create({ chatId: "oc_x", threadId: "omt_x" }),
+    ).rejects.toThrow(/code=99991663/);
+  });
+
+  it("throws when create returns no cot_id/message_id", async () => {
+    const { channel } = fakeChannel(() => ({ code: 0, data: {} }));
+    const client = new ChannelCotClient({ resolveChannel: () => channel });
+    await expect(
+      client.create({ chatId: "oc_x", threadId: "omt_x" }),
+    ).rejects.toThrow(/no cot_id/);
+  });
+
+  it("throws when the channel is not connected", async () => {
+    const client = new ChannelCotClient({ resolveChannel: () => null });
+    await expect(
+      client.create({ chatId: "oc_x", threadId: "omt_x" }),
+    ).rejects.toThrow(/before the Channel SDK connected/);
+  });
+});

--- a/src/lark/channelCotClient.test.ts
+++ b/src/lark/channelCotClient.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   ChannelCotClient,
   type OutboundCotLarkChannel,
@@ -117,5 +117,49 @@ describe("ChannelCotClient", () => {
     await expect(
       client.create({ chatId: "oc_x", threadId: "omt_x" }),
     ).rejects.toThrow(/before the Channel SDK connected/);
+  });
+});
+
+describe("ChannelCotClient timeout (hang guard)", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function hangingChannel(): OutboundCotLarkChannel {
+    // A request that never settles — the exact failure mode the timer guards.
+    return { rawClient: { request: <T>() => new Promise<T>(() => {}) } };
+  }
+
+  it("create rejects (not hangs) once the request exceeds the timeout", async () => {
+    vi.useFakeTimers();
+    const client = new ChannelCotClient({ resolveChannel: () => hangingChannel() });
+    const p = client.create({ chatId: "oc_x", threadId: "omt_x" });
+    const expectation = expect(p).rejects.toThrow(/timed out after 8000ms/);
+    await vi.advanceTimersByTimeAsync(8_000);
+    await expectation;
+  });
+
+  it("complete rejects once the request exceeds the timeout", async () => {
+    vi.useFakeTimers();
+    const client = new ChannelCotClient({ resolveChannel: () => hangingChannel() });
+    const p = client.complete({ cotId: "cot_1", messageId: "om_1" }, "done");
+    const expectation = expect(p).rejects.toThrow(/timed out after 8000ms/);
+    await vi.advanceTimersByTimeAsync(8_000);
+    await expectation;
+  });
+
+  it("does not time out a request that resolves in time", async () => {
+    vi.useFakeTimers();
+    const channel: OutboundCotLarkChannel = {
+      rawClient: {
+        async request<T>() {
+          return { code: 0, data: { cot_id: "cot_1", message_id: "om_1" } } as T;
+        },
+      },
+    };
+    const client = new ChannelCotClient({ resolveChannel: () => channel });
+    await expect(
+      client.create({ chatId: "oc_x", threadId: "omt_x" }),
+    ).resolves.toEqual({ cotId: "cot_1", messageId: "om_1" });
   });
 });

--- a/src/lark/channelCotClient.ts
+++ b/src/lark/channelCotClient.ts
@@ -1,0 +1,152 @@
+/**
+ * Channel-SDK-backed COT (思维链 / chain-of-thought) client.
+ *
+ * Drives Feishu's `im/v1/message_cot` endpoints — the client-native
+ * collapsible reasoning bubble — reusing the vendored Channel SDK's generic
+ * `rawClient.request()`. That method injects the tenant_access_token through
+ * the SDK's own token manager (the same cached token path every other
+ * outbound call uses), so this adds no new auth surface and no SDK/API-key
+ * dependency, matching the ChannelCardKitClient pattern.
+ *
+ * ⚠️ `message_cot` is an undocumented API. Every method here can throw; the
+ * caller (src/bridge/cotProgress.ts) treats ANY failure as a permanent
+ * per-run disable — it must never affect the answer card or final reply.
+ * There is deliberately no retry here: on an API that can change or vanish,
+ * failing fast into the degrade path is safer than hammering it.
+ */
+
+// ---------------------------------------------------------------------------
+// Structural view of the Channel SDK handle this client needs.
+// ---------------------------------------------------------------------------
+
+export interface RawCotRequestOptions {
+  url: string;
+  method: "GET" | "POST" | "PUT" | "DELETE";
+  params?: Record<string, unknown>;
+  data?: Record<string, unknown>;
+}
+
+interface RawCotResponse {
+  code?: number;
+  msg?: string;
+  data?: Record<string, unknown>;
+}
+
+export interface OutboundCotLarkChannel {
+  rawClient: {
+    request<T = RawCotResponse>(opts: RawCotRequestOptions): Promise<T>;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface CotRef {
+  cotId: string;
+  messageId: string;
+}
+
+export interface CotEvent {
+  event_type: string;
+  /** Per-event payload, already JSON-stringified (Feishu's wire format). */
+  content: string;
+  timestamp: number;
+}
+
+/**
+ * Where the COT bubble is anchored. Topic groups MUST address the thread
+ * (`receive_id_type=thread_id` + the `omt_*` thread id), otherwise the bubble
+ * lands at the group top level instead of inside the topic. Non-topic chats
+ * fall back to the chat id + the trigger message as `origin_message_id`.
+ */
+export interface CotTarget {
+  chatId: string;
+  threadId?: string;
+  originMessageId?: string;
+}
+
+export interface OutboundCotClient {
+  create(target: CotTarget): Promise<CotRef>;
+  update(ref: CotRef, events: readonly CotEvent[]): Promise<void>;
+  complete(ref: CotRef, reason: string): Promise<void>;
+}
+
+// ---------------------------------------------------------------------------
+// Implementation
+// ---------------------------------------------------------------------------
+
+function assertOk(res: RawCotResponse, label: string): void {
+  if (res.code !== undefined && res.code !== 0) {
+    throw new Error(
+      `[channel.cot] ${label} failed: code=${res.code} msg=${res.msg ?? "<no msg>"}`,
+    );
+  }
+}
+
+export class ChannelCotClient implements OutboundCotClient {
+  private readonly resolveChannel: () => OutboundCotLarkChannel | null;
+
+  constructor(opts: { resolveChannel: () => OutboundCotLarkChannel | null }) {
+    this.resolveChannel = opts.resolveChannel;
+  }
+
+  private channel(): OutboundCotLarkChannel {
+    const ch = this.resolveChannel();
+    if (!ch) {
+      throw new Error("[channel.cot] outbound called before the Channel SDK connected");
+    }
+    return ch;
+  }
+
+  async create(target: CotTarget): Promise<CotRef> {
+    const receiveIdType = target.threadId ? "thread_id" : "chat_id";
+    const receiveId = target.threadId ?? target.chatId;
+    const res = await this.channel().rawClient.request<RawCotResponse>({
+      url: "/open-apis/im/v1/message_cot",
+      method: "POST",
+      params: { receive_id_type: receiveIdType },
+      data: {
+        receive_id: receiveId,
+        // origin_message_id only anchors non-thread bubbles; harmless if set,
+        // but omitted for topic threads where the thread id already anchors.
+        ...(!target.threadId && target.originMessageId
+          ? { origin_message_id: target.originMessageId }
+          : {}),
+      },
+    });
+    assertOk(res, "create");
+    const cotId = stringField(res.data, "cot_id");
+    const messageId = stringField(res.data, "message_id");
+    if (!cotId || !messageId) {
+      throw new Error(
+        `[channel.cot] create returned no cot_id/message_id (${JSON.stringify(res.data ?? {}).slice(0, 200)})`,
+      );
+    }
+    return { cotId, messageId };
+  }
+
+  async update(ref: CotRef, events: readonly CotEvent[]): Promise<void> {
+    if (events.length === 0) return;
+    const res = await this.channel().rawClient.request<RawCotResponse>({
+      url: "/open-apis/im/v1/message_cot",
+      method: "PUT",
+      data: { cot_id: ref.cotId, message_id: ref.messageId, events: [...events] },
+    });
+    assertOk(res, "update");
+  }
+
+  async complete(ref: CotRef, reason: string): Promise<void> {
+    const res = await this.channel().rawClient.request<RawCotResponse>({
+      url: `/open-apis/im/v1/message_cot/complete/${encodeURIComponent(ref.cotId)}`,
+      method: "POST",
+      params: { message_id: ref.messageId, reason },
+    });
+    assertOk(res, "complete");
+  }
+}
+
+function stringField(data: Record<string, unknown> | undefined, key: string): string | undefined {
+  const value = data?.[key];
+  return typeof value === "string" ? value : undefined;
+}

--- a/src/lark/channelCotClient.ts
+++ b/src/lark/channelCotClient.ts
@@ -70,6 +70,14 @@ export interface OutboundCotClient {
   create(target: CotTarget): Promise<CotRef>;
   update(ref: CotRef, events: readonly CotEvent[]): Promise<void>;
   complete(ref: CotRef, reason: string): Promise<void>;
+  /**
+   * Resolve a message's real Feishu thread id (omt_*) by GET-ing the message.
+   * Returns undefined for anything that isn't a usable omt_ id (non-topic
+   * message, GET failure/timeout, empty field) — the caller then falls back to
+   * the chat_id channel. Never throws: this is on the create hot path and must
+   * obey the same bypass rule as every other COT call.
+   */
+  resolveThreadId(messageId: string): Promise<string | undefined>;
 }
 
 // ---------------------------------------------------------------------------
@@ -177,6 +185,33 @@ export class ChannelCotClient implements OutboundCotClient {
       params: { message_id: ref.messageId, reason },
     });
     assertOk(res, "complete");
+  }
+
+  async resolveThreadId(messageId: string): Promise<string | undefined> {
+    try {
+      // GET /im/v1/messages/{id} → data.items[].thread_id. A topic-group
+      // message carries an omt_* thread id here even when the inbound event
+      // only gave us the om_* message id.
+      const res = await this.request({
+        url: `/open-apis/im/v1/messages/${encodeURIComponent(messageId)}`,
+        method: "GET",
+      });
+      if (res.code !== undefined && res.code !== 0) return undefined;
+      const items = res.data?.["items"];
+      if (!Array.isArray(items)) return undefined;
+      for (const item of items) {
+        if (item && typeof item === "object") {
+          const threadId = (item as Record<string, unknown>)["thread_id"];
+          if (typeof threadId === "string" && threadId.startsWith("omt_")) {
+            return threadId;
+          }
+        }
+      }
+      return undefined;
+    } catch {
+      // Bypass rule: a GET failure/timeout must never block create — fall back.
+      return undefined;
+    }
   }
 }
 

--- a/src/lark/channelCotClient.ts
+++ b/src/lark/channelCotClient.ts
@@ -76,6 +76,31 @@ export interface OutboundCotClient {
 // Implementation
 // ---------------------------------------------------------------------------
 
+/**
+ * Hard ceiling on every COT network call. message_cot is undocumented — a hung
+ * request (never resolves, never rejects) would otherwise sit forever, and the
+ * caller's degrade-on-throw path only fires on rejection. Racing a timer that
+ * REJECTS converts any hang (network stall, token-fetch stall inside the SDK,
+ * or a silently-dropped connection) into a normal failure → degrade.
+ */
+const COT_REQUEST_TIMEOUT_MS = 8_000;
+
+async function withTimeout<T>(p: Promise<T>, ms: number, label: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(
+      () => reject(new Error(`[channel.cot] ${label} timed out after ${ms}ms`)),
+      ms,
+    );
+    timer.unref?.();
+  });
+  try {
+    return await Promise.race([p, timeout]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
 function assertOk(res: RawCotResponse, label: string): void {
   if (res.code !== undefined && res.code !== 0) {
     throw new Error(
@@ -99,10 +124,19 @@ export class ChannelCotClient implements OutboundCotClient {
     return ch;
   }
 
+  /** Every COT call goes through here, so all get the same hard timeout. */
+  private request(opts: RawCotRequestOptions): Promise<RawCotResponse> {
+    return withTimeout(
+      this.channel().rawClient.request<RawCotResponse>(opts),
+      COT_REQUEST_TIMEOUT_MS,
+      `${opts.method} ${opts.url}`,
+    );
+  }
+
   async create(target: CotTarget): Promise<CotRef> {
     const receiveIdType = target.threadId ? "thread_id" : "chat_id";
     const receiveId = target.threadId ?? target.chatId;
-    const res = await this.channel().rawClient.request<RawCotResponse>({
+    const res = await this.request({
       url: "/open-apis/im/v1/message_cot",
       method: "POST",
       params: { receive_id_type: receiveIdType },
@@ -128,7 +162,7 @@ export class ChannelCotClient implements OutboundCotClient {
 
   async update(ref: CotRef, events: readonly CotEvent[]): Promise<void> {
     if (events.length === 0) return;
-    const res = await this.channel().rawClient.request<RawCotResponse>({
+    const res = await this.request({
       url: "/open-apis/im/v1/message_cot",
       method: "PUT",
       data: { cot_id: ref.cotId, message_id: ref.messageId, events: [...events] },
@@ -137,7 +171,7 @@ export class ChannelCotClient implements OutboundCotClient {
   }
 
   async complete(ref: CotRef, reason: string): Promise<void> {
-    const res = await this.channel().rawClient.request<RawCotResponse>({
+    const res = await this.request({
       url: `/open-apis/im/v1/message_cot/complete/${encodeURIComponent(ref.cotId)}`,
       method: "POST",
       params: { message_id: ref.messageId, reason },

--- a/src/main.ts
+++ b/src/main.ts
@@ -429,6 +429,10 @@ async function runV2Mode({
     )
       ? client.outboundCardKitClient()
       : undefined;
+    // COT (思维链) bubble transport — provisioned only when the bot opts in
+    // (cot != "off"). Uses the SDK's generic rawClient.request(), so no new
+    // auth surface; the handler degrades silently on any failure.
+    const cotClient = bot.cot !== "off" ? client.outboundCotClient() : undefined;
 
     // Task-handle (docs/task-handle.md v2: team-shared single tasklist).
     // No `enabled` flag gates this — the real gate is whether a LIVE guid
@@ -747,8 +751,10 @@ async function runV2Mode({
         taskHandle: effectiveTaskHandleTasklistGuid ? { tasklistGuid: effectiveTaskHandleTasklistGuid } : undefined,
         model: bot.model,
         effort: bot.effort,
+        cot: bot.cot,
       },
       cardKitClient,
+      cotClient,
       postClient,
       gitlabToken: effectiveGitlabToken,
       agentMemory: bot.agent_memory,

--- a/src/web/onboardSession.ts
+++ b/src/web/onboardSession.ts
@@ -457,6 +457,7 @@ export async function createBotFromCreds(
     response_surface_prototype: DEFAULT_RESPONSE_SURFACE_PROTOTYPE,
     runtime: "agent_workspace",
     backend: form.backend && form.backend.trim() ? form.backend.trim() : "codex",
+    cot: "brief",
     // Persist the Feishu avatar URL so the Web 管理面 can show an avatar before
     // the bridge writes status.json (pre-bridge / central roster). Best-effort:
     // only set when resolveBotIdentity returned a valid url.


### PR DESCRIPTION
## What

Streams the agent's chain-of-thought (thinking) and tool-call activity into Feishu's native COT bubble (`im/v1/message_cot`) in real time, collapsible client-side. The final answer keeps flowing through the existing CardKit streaming card — the COT bubble is a pure side channel.

Addresses the top UX complaint: after @-ing the bot, users only saw a "using tools (N)" counter and perceived the agent as slow. Now the waiting time is filled with visible progress, matching the experience of running the CLI directly.

## How

- **Event layer**: new `thinking_delta` / `thinking_snapshot` members in `AgentStreamEvent`.
- **Claude backend**: parse `thinking` content blocks + `thinking_delta` stream events from `claude --output-format stream-json` (previously dropped as `raw`).
- **Codex backend**: parse `item/reasoning/summaryTextDelta` / `summaryPartAdded` / completed reasoning items from app-server; spawn now passes `-c model_reasoning_summary=detailed` (without it Codex emits no reasoning). Verified against captured real app-server output.
- **COT push layer**: `ChannelCotClient` (mirrors `ChannelCardKitClient`) + `cotProgress` handle (mirrors `cardkitProgress`): 600ms throttled batching, thread-aware targeting (`thread_id` in topic groups, `chat_id` + `origin_message_id` otherwise), `complete(done|error)` on finalize.
- **Config**: per-bot `cot: "off" | "brief" | "detailed"` (default `brief` = thinking + tool-name summaries; `detailed` adds tool args + truncated results, ≤1200 chars per event).

## Resilience (undocumented API — assume it can vanish)

`message_cot` has no public docs (probed working, no extra scopes). Every COT failure degrades silently and never touches the main flow:
- all COT network calls bounded by an 8s timeout (`Promise.race`, covers SDK token fetch; timers unref'd + cleared);
- any error/timeout → session-scoped disable, card + answer unaffected;
- finalize is fire-and-forget, off the critical path of card finalize / session persistence / reaction cleanup.

Known bounded worst case: while the API is failing, each turn start pays ≤8s before degrading (create is awaited once per turn).

## Testing

- `pnpm typecheck` / `pnpm build` clean; `pnpm test` **1338 passed / 69 files** (+10 new).
- New tests: Claude thinking parsing (real stream-json shapes), Codex reasoning parsing (fixtures from captured app-server output, ids faked), COT event mapping (brief/detailed), degradation on client errors, timeout→disable on hanging channel, disabled finalize no-op.
- Independently reviewed (protocol field-by-field vs probed baseline, regression, resource bounds, sanitization): one major found (finalize hang risk) and fixed in 20f6972; re-review PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)