### PR TITLE
fix(task-handle): strip leading @mentions in auto-bind exact match

### DIFF
--- a/src/tasklist/tasklistPoller.test.ts
+++ b/src/tasklist/tasklistPoller.test.ts
@@ -274,11 +274,12 @@ describe("TasklistPoller", () => {
 });
 
 describe("normalizeForExactMatch", () => {
-  // Adversarial-review fix: an earlier version also stripped a leading
-  // @-mention token, but the regex was unanchored and collapsed clearly
-  // DIFFERENT messages onto the same string (see the function's own doc
-  // comment for the full incident writeup). These tests pin the fixed
-  // behavior: no @-stripping at all, whitespace-only normalization.
+  // Real-machine fix (2026-07): a converted Feishu task keeps the literal
+  // "@Name " prefix in its summary while inbound rootText already has it
+  // stripped, so a LEADING-mention strip is applied to both sides. It is
+  // anchored (^) + whitespace-terminated so it never touches an in-text "@"
+  // (the class of collision the earlier unanchored version caused). See the
+  // function's own doc comment.
 
   it("collapses repeated/incidental whitespace", () => {
     expect(normalizeForExactMatch("帮我修一下   登录页\n\n")).toBe("帮我修一下 登录页");
@@ -288,25 +289,47 @@ describe("normalizeForExactMatch", () => {
     expect(normalizeForExactMatch("帮我修一下登录页")).toBe("帮我修一下登录页");
   });
 
-  it("does NOT strip a leading @-mention — a mention prefix makes two messages genuinely different", () => {
-    expect(normalizeForExactMatch("@张三 帮我修一下登录页")).toBe("@张三 帮我修一下登录页");
-    expect(normalizeForExactMatch("@张三 帮我修一下登录页")).not.toBe(
+  it("strips a leading @-mention so a mentioned title aligns with the un-mentioned rootText", () => {
+    // The exact real-machine shape: "@BotA  自我介绍一下" (double space) vs the
+    // @-stripped "自我介绍一下" must now compare equal.
+    expect(normalizeForExactMatch("@张三  帮我修一下登录页")).toBe("帮我修一下登录页");
+    expect(normalizeForExactMatch("@张三 帮我修一下登录页")).toBe(
       normalizeForExactMatch("帮我修一下登录页"),
     );
   });
 
-  it("regression: @张三 在吗 vs @李四 在吗 must never normalize equal (the exact case adversarial review flagged)", () => {
-    expect(normalizeForExactMatch("@张三 在吗")).not.toBe(normalizeForExactMatch("@李四 在吗"));
+  it("strips multiple consecutive leading @-mentions", () => {
+    expect(normalizeForExactMatch("@张三 @李四 帮我修一下登录页")).toBe("帮我修一下登录页");
   });
 
-  it("regression: email-domain collision must never normalize equal", () => {
+  it("does NOT strip an in-text @ — only leading mentions are removed", () => {
+    // Anchored strip leaves the message body untouched: a message that merely
+    // contains an @ mid-text is unchanged (and stays distinct from a peer).
+    expect(normalizeForExactMatch("帮我查 user@example.com 的账号")).toBe(
+      "帮我查 user@example.com 的账号",
+    );
     expect(normalizeForExactMatch("帮我查 user@example.com 的账号")).not.toBe(
       normalizeForExactMatch("帮我查 user@other.org 的账号"),
     );
   });
 
-  it("regression: CJK no-space mid-sentence mentions must never normalize equal", () => {
-    expect(normalizeForExactMatch("请@张三处理登录崩溃")).not.toBe(normalizeForExactMatch("请@李四买咖啡"));
+  it("regression: CJK no-space mid-sentence mentions are NOT stripped and stay distinct", () => {
+    expect(normalizeForExactMatch("请@张三处理登录崩溃")).toBe("请@张三处理登录崩溃");
+    expect(normalizeForExactMatch("请@张三处理登录崩溃")).not.toBe(
+      normalizeForExactMatch("请@李四买咖啡"),
+    );
+  });
+
+  it("does not over-strip a message that is only a mention (no trailing content)", () => {
+    // No whitespace-terminated body after the mention → nothing to strip to;
+    // must not collapse to an empty string.
+    expect(normalizeForExactMatch("@张三")).toBe("@张三");
+  });
+
+  it("leading-mention-only variants collapse equal by design — the bidirectional 1:1 auto-bind guard, not this function, prevents a wrong bind", () => {
+    // Intentional: two short messages differing only in the @target normalize
+    // the same. Bind-level safety is asserted in the auto-bind suite below.
+    expect(normalizeForExactMatch("@张三 在吗")).toBe(normalizeForExactMatch("@李四 在吗"));
   });
 });
 
@@ -345,7 +368,7 @@ describe("TasklistPoller — exact root-text auto-bind", () => {
     expect(poller.getCandidates()).toEqual([]);
   });
 
-  it("matches across incidental whitespace differences only (no @-mention stripping — see normalizeForExactMatch)", async () => {
+  it("matches across incidental whitespace differences (see normalizeForExactMatch)", async () => {
     const { requester } = makeFakeRequester({ tasks: [{ guid: "task-1", summary: "帮我修一下   登录页" }] });
     const client = new TaskListClient(requester);
     const bindThreadToTask = vi.fn(async () => {});
@@ -364,7 +387,9 @@ describe("TasklistPoller — exact root-text auto-bind", () => {
     expect(bindThreadToTask).toHaveBeenCalledTimes(1);
   });
 
-  it("does NOT bind when the task title carries a leading @-mention the rootText lacks (accepted degradation, not a false match)", async () => {
+  it("binds a task whose summary carries a leading @-mention against the @-stripped rootText (real-machine fix)", async () => {
+    // The bug: "@BotA 自我介绍一下" → task summary keeps "@BotA ", rootText has
+    // it stripped → auto-bind never fired. Now the leading strip realigns them.
     const { requester } = makeFakeRequester({ tasks: [{ guid: "task-1", summary: "@张三 帮我修一下登录页" }] });
     const client = new TaskListClient(requester);
     const bindThreadToTask = vi.fn(async () => {});
@@ -380,8 +405,40 @@ describe("TasklistPoller — exact root-text auto-bind", () => {
 
     await poller.pollOnceForTest();
 
+    expect(bindThreadToTask).toHaveBeenCalledWith({
+      botId: "bot-a",
+      threadId: "t1",
+      chatId: "oc_1",
+      taskGuid: "task-1",
+    });
+    expect(poller.getCandidates()).toEqual([]);
+  });
+
+  it("still refuses to bind when a leading-@ task normalizes onto more than one thread (guard holds post-strip)", async () => {
+    // Two threads whose rootText both normalize to "在吗"; a task "@张三 在吗"
+    // also normalizes to "在吗". The leading strip must NOT bypass the strict
+    // 1:1 guard — >1 matching thread → ambiguous → no bind. This is the safety
+    // that replaces the old "never normalize equal" property.
+    const { requester } = makeFakeRequester({ tasks: [{ guid: "task-1", summary: "@张三 在吗" }] });
+    const client = new TaskListClient(requester);
+    const bindThreadToTask = vi.fn(async () => {});
+    const poller = new TasklistPoller({
+      client,
+      tasklistGuid: "guid-1",
+      isClaimedByAnyBot: () => false,
+      rootTextMatch: {
+        listRootTexts: () => [
+          rootTextEntry({ threadId: "t1", rootText: "在吗" }),
+          rootTextEntry({ threadId: "t2", rootText: "在吗" }),
+        ],
+        bindThreadToTask,
+      },
+    });
+
+    await poller.pollOnceForTest();
+
     expect(bindThreadToTask).not.toHaveBeenCalled();
-    expect(poller.getCandidates().length).toBe(1); // left for the agent path
+    expect(poller.getCandidates().length).toBe(1);
   });
 
   it("does NOT bind when a candidate matches more than one thread (ambiguous)", async () => {

--- a/src/tasklist/tasklistPoller.ts
+++ b/src/tasklist/tasklistPoller.ts
@@ -36,9 +36,9 @@
  * root — no new network call, no per-poll cost). Every poll cycle, after
  * building the candidate snapshot above, this module compares each
  * candidate's summary against every known thread's rootText (both sides run
- * through {@link normalizeForExactMatch} — whitespace collapse ONLY, see its
- * own doc for why an earlier @-mention-stripping version was removed after
- * adversarial review). Only a STRICT 1:1 match — exactly one thread matches
+ * through {@link normalizeForExactMatch} — whitespace collapse + a strip of
+ * LEADING @-mentions only, see its own doc for why the strip is anchored to
+ * the start). Only a STRICT 1:1 match — exactly one thread matches
  * this candidate, AND that thread matches no other candidate, AND the
  * thread does not already hold some OTHER claim (main.ts's listRootTexts
  * excludes already-claimed threads entirely; store.ts's claim() also
@@ -151,40 +151,45 @@ export function renderCandidateUnboundAlertComment(): string {
 /**
  * Fixed, documented normalization applied to BOTH sides of the exact-match
  * comparison (docs/task-handle.md §5.2 v3 addendum) — deliberately NOT
- * fuzzy/prefix/similarity matching. Only canonicalizes incidental whitespace
- * (leading/trailing/repeated); does NOT strip @-mentions.
+ * fuzzy/prefix/similarity matching. It (1) canonicalizes incidental whitespace
+ * (leading/trailing/repeated) and (2) strips a run of LEADING @-mention tokens.
  *
- * History (adversarial review, docs/task-handle.md §9.9): an earlier version
- * also stripped a leading `@\S+` token, on the theory that Feishu renders a
- * human-readable "@张三 " into a converted task's title while our own
- * message parsing (lark/message.ts's AT_PLACEHOLDER_RE) already strips its
- * placeholder form out of rootText, so the two sides needed reconciling.
- * That regex was unanchored (matched an @-token ANYWHERE in the text) and
- * collapsed clearly DIFFERENT messages onto the same normalized string —
- * confirmed by execution: "帮我查 user@example.com 的账号" and "帮我查
- * user@other.org 的账号" both collapsed to "帮我查 user的账号"; "@张三 在吗"
- * and "@李四 在吗" both collapsed to "在吗". Because the bidirectional 1:1
- * uniqueness check only catches collisions between candidates/threads
- * PRESENT IN THE SAME CYCLE, an asymmetric collision (e.g. a manually
- * created task whose title happens to normalize the same as some unrelated
- * thread's rootText) would pass as a unique match and silently auto-bind the
- * wrong pair. The theorized asymmetry (task title keeps a literal "@Name ",
- * rootText never does) could not be verified against a live Feishu response
- * in this dev environment, and a real fix would need a MUCH narrower rule
- * (anchor to a genuine leading-mention prefix only, plus a minimum
- * post-strip specificity threshold) to avoid reintroducing the same class
- * of bug — see the finding's own P1 discussion. Given the uncertainty, the
- * conservative choice is the one this function now implements: no
- * @-stripping at all. The accepted cost is a real but narrow one — an exact
- * match legitimately fails whenever a title DOES carry a literal leading
- * mention rootText doesn't (same accepted-degradation shape as the 200-char
- * truncation mismatch case) — which just falls back to the agent-path
- * candidate injection, never a silent wrong bind.
+ * Why strip leading mentions (real-machine bug, 2026-07): a topic-group
+ * top-level "@BotA 自我介绍一下" converts to a Feishu task whose summary keeps
+ * the literal "@BotA  自我介绍一下" prefix, while our own inbound parsing
+ * (lark/message.ts's AT_PLACEHOLDER_RE) already stripped the mention out of
+ * rootText ("自我介绍一下"). With whitespace-only normalization the two sides
+ * never compared equal, so auto-bind NEVER fired for any @-prefixed task.
+ * Running the same leading-mention strip over BOTH sides realigns them.
+ *
+ * Why the strip is ANCHORED (`^(@\S+\s+)+`), not the earlier unanchored form
+ * (adversarial review, docs/task-handle.md §9.9): the old `@\S+` matched an
+ * @-token ANYWHERE, collapsing genuinely different messages —
+ * "帮我查 user@example.com 的账号" vs "…user@other.org…" both became
+ * "帮我查 user的账号". Anchoring to the start and requiring a trailing space
+ * leaves every in-text "@" untouched (`user@example.com`, CJK `请@张三…`), so
+ * those never collide.
+ *
+ * Residual risk + why it's contained: two SHORT messages that differ only in
+ * their leading @target still collapse equal ("@张三 在吗" and "@李四 在吗"
+ * both → "在吗"). The bidirectional strict-1:1 guard in #autoBindExactMatches
+ * is what keeps that safe: a task matching >1 such thread (or a thread
+ * matching >1 task) is ruled ambiguous and left to the agent path, never
+ * auto-bound. The only way a genuinely wrong pair could slip through is an
+ * asymmetric 1:1 collision (the task's real source thread absent from
+ * listRootTexts while an unrelated same-normalizing thread is present) — a
+ * narrow, pre-existing shape, not one this change introduces at the bind
+ * layer. A future hardening (minimum post-strip length threshold) could shrink
+ * it further; see the finding's P1 discussion.
  *
  * Exported for direct unit testing — pure, no I/O.
  */
 export function normalizeForExactMatch(text: string): string {
-  return text.replace(/\s+/g, " ").trim();
+  const collapsed = text.replace(/\s+/g, " ").trim();
+  // Anchored, whitespace-terminated, one-or-more: strips "@Name " and
+  // "@A @B " runs at the very start ONLY. `\S+` = the display name (any
+  // non-space run), so it never reaches into the message body.
+  return collapsed.replace(/^(?:@\S+\s+)+/, "").trim();
 }
 
 /** Internal cache entry — keeps the RAW description so a re-poll's marker check never operates on an already-truncated excerpt. */


### PR DESCRIPTION
## Root cause

A topic-group top-level `@BotA 自我介绍一下` converts to a Feishu task whose **summary keeps the literal `@BotA ` prefix**, while our own inbound parsing (`lark/message.ts`'s `AT_PLACEHOLDER_RE`) already strips the mention out of `rootText`. `TasklistPoller`'s `normalizeForExactMatch` only collapsed whitespace, so the two sides never compared equal → **auto-bind never fired for any @-prefixed task** (confirmed on real hardware).

## Fix

`normalizeForExactMatch` now also strips a run of **leading** @mention tokens on both sides, via an **anchored, whitespace-terminated** `/^(@\S+\s+)+/`:

- Anchoring to the start (unlike the earlier *unanchored* version that was reverted after adversarial review, docs/task-handle.md §9.9) leaves every in-text `@` untouched — `user@example.com`, CJK `请@张三…` are unchanged, so those never collide.
- Short messages that differ only by their leading @target now normalize equal (`@张三 在吗` / `@李四 在吗` → `在吗`). Bind-level safety is preserved by the existing **bidirectional strict-1:1 guard** in `#autoBindExactMatches`: a task matching >1 such thread (or vice-versa) is ruled ambiguous and left to the agent path, never auto-bound.

## Tests

- `normalizeForExactMatch`: single + multiple leading-mention strip; in-text `@` (email / CJK) left intact and still distinct; mention-only message not over-stripped to empty; leading-@ variants collapse equal by design.
- auto-bind: a leading-@ task now binds against the @-stripped rootText (the fix); a leading-@ task matching two same-normalizing threads still refuses to bind (guard holds post-strip).

`pnpm typecheck` / `pnpm test` (1302) / `pnpm build` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)