### PR TITLE
feat(cot): fold reasoning into an in-card collapsible panel (方案 B, default)

### DIFF
--- a/src/bridge/cardkitProgress.test.ts
+++ b/src/bridge/cardkitProgress.test.ts
@@ -350,3 +350,170 @@ describe("CardKitProgressHandle", () => {
     });
   });
 });
+
+// ---------------------------------------------------------------------------
+// COT-in-card collapsible panel (方案 B)
+// ---------------------------------------------------------------------------
+
+describe("CardKitProgressHandle — COT-in-card panel (方案 B)", () => {
+  function makeHandle(detail: "brief" | "detailed", extra: Record<string, unknown> = {}) {
+    const { client, calls } = fakeCardKitClient();
+    return { client, calls, promise: createCardKitProgressHandle({
+      cardKitClient: client,
+      replyToMessageId: "trigger_message",
+      replyInThread: true,
+      facts: { botId: "bot", threadId: "thread", triggerMessageId: "trigger_message" },
+      patchIntervalMs: 0,
+      cot: { detail },
+      ...extra,
+    }) };
+  }
+
+  it("lazily creates NO panel when no thinking/tool events arrive", async () => {
+    const { calls, promise } = makeHandle("brief");
+    const handle = await promise;
+    handle.handle({ type: "answer_snapshot", text: "答案", raw: {} });
+    await handle.drain();
+    const panelCreate = calls.find(
+      (c) => c.name === "createElements" &&
+        JSON.stringify(c.args[1]).includes("collapsible_panel"),
+    );
+    expect(panelCreate).toBeUndefined();
+  });
+
+  it("lazily creates the panel on first thinking and streams reasoning into cot_inner_md", async () => {
+    let panelElementId: string | undefined;
+    const { calls, promise } = makeHandle("brief", {
+      onCotPanelCreated: (id: string) => { panelElementId = id; },
+    });
+    const handle = await promise;
+    handle.handle({ type: "thinking_delta", text: "让我想想", raw: {} });
+    await handle.drain();
+
+    const panelCreate = calls.find(
+      (c) => c.name === "createElements" &&
+        JSON.stringify(c.args[1]).includes("collapsible_panel"),
+    );
+    expect(panelCreate).toBeDefined();
+    // Panel is expanded with a "思考中…" title, inserted above the answer/footer.
+    expect(JSON.stringify(panelCreate!.args[1])).toContain("思考中");
+    expect(JSON.stringify(panelCreate!.args[1])).toContain("cot_inner_md");
+    expect(panelCreate!.args[2]).toMatchObject({ type: "insert_before" });
+    // Reasoning streamed into the inner element.
+    const innerStream = calls.filter(
+      (c) => c.name === "streamElementContent" && c.args[1] === "cot_inner_md",
+    );
+    expect(innerStream.length).toBeGreaterThan(0);
+    expect(innerStream.at(-1)!.args[2]).toContain("让我想想");
+    // Resume hook fired with the panel id.
+    expect(panelElementId).toBe("cot_panel");
+  });
+
+  it("brief tier renders the tool NAME only — never the command args (bubble leak fix)", async () => {
+    const { calls, promise } = makeHandle("brief");
+    const handle = await promise;
+    handle.handle({ type: "thinking_delta", text: "先看看", raw: {} });
+    handle.handle({
+      type: "tool_use",
+      toolName: "Bash",
+      toolInput: { command: "cat /etc/secret.txt", token: "SUPERSECRET" },
+      raw: {},
+    });
+    await handle.drain();
+    const inner = calls
+      .filter((c) => c.name === "streamElementContent" && c.args[1] === "cot_inner_md")
+      .at(-1)!.args[2] as string;
+    expect(inner).toContain("Bash");
+    expect(inner).not.toContain("cat /etc/secret.txt");
+    expect(inner).not.toContain("SUPERSECRET");
+  });
+
+  it("detailed tier includes truncated args + result", async () => {
+    const { calls, promise } = makeHandle("detailed");
+    const handle = await promise;
+    handle.handle({ type: "thinking_delta", text: "读文件", raw: {} });
+    handle.handle({ type: "tool_use", toolName: "Read", toolInput: { file_path: "/x" }, raw: {} });
+    handle.handle({
+      type: "tool_result",
+      raw: { message: { content: [{ type: "tool_result", content: "文件内容 abc" }] } },
+    });
+    await handle.drain();
+    const inner = calls
+      .filter((c) => c.name === "streamElementContent" && c.args[1] === "cot_inner_md")
+      .at(-1)!.args[2] as string;
+    expect(inner).toContain("Read");
+    expect(inner).toContain("/x");
+    expect(inner).toContain("文件内容 abc");
+  });
+
+  it("caps the panel text at the char budget with an ellipsis marker", async () => {
+    const { calls, promise } = makeHandle("brief");
+    const handle = await promise;
+    for (let i = 0; i < 60; i++) {
+      handle.handle({ type: "thinking_delta", text: "x".repeat(100), raw: {} });
+    }
+    await handle.drain();
+    const inner = calls
+      .filter((c) => c.name === "streamElementContent" && c.args[1] === "cot_inner_md")
+      .at(-1)!.args[2] as string;
+    expect(inner.length).toBeLessThan(4200); // ~4000 cap + short marker
+    expect(inner).toContain("省略");
+  });
+
+  it("finalize embeds the COLLAPSED panel (title 思考过程) into the final card", async () => {
+    const { calls, promise } = makeHandle("brief");
+    const handle = await promise;
+    handle.handle({ type: "thinking_delta", text: "推理内容", raw: {} });
+    handle.handle({ type: "answer_snapshot", text: "答案", raw: {} });
+    await handle.finalize({ finalText: "答案" });
+
+    const finalCardCall = calls.filter((c) => c.name === "updateCardEntity").at(-1)!;
+    const cardJson = JSON.stringify(finalCardCall.args[1]);
+    expect(cardJson).toContain("collapsible_panel");
+    expect(cardJson).toContain("思考过程");
+    expect(cardJson).not.toContain("思考中"); // no longer the streaming title
+    expect(cardJson).toContain("推理内容"); // reasoning preserved
+    // collapsed
+    const card = finalCardCall.args[1] as { body: { elements: Array<Record<string, unknown>> } };
+    const panel = card.body.elements.find((e) => e["tag"] === "collapsible_panel")!;
+    expect(panel["expanded"]).toBe(false);
+    // panel sits ABOVE the answer element
+    const panelIdx = card.body.elements.findIndex((e) => e["tag"] === "collapsible_panel");
+    const answerIdx = card.body.elements.findIndex((e) => e["element_id"] === "final_md");
+    expect(panelIdx).toBeLessThan(answerIdx);
+  });
+
+  it("markCotError sets the errored panel title", async () => {
+    const { calls, promise } = makeHandle("brief");
+    const handle = await promise;
+    handle.handle({ type: "thinking_delta", text: "推理", raw: {} });
+    handle.markCotError();
+    await handle.finalize({ finalText: "出错了" });
+    const cardJson = JSON.stringify(calls.filter((c) => c.name === "updateCardEntity").at(-1)!.args[1]);
+    expect(cardJson).toContain("思考过程（本轮出错）");
+  });
+
+  it("a panel streaming failure never breaks the answer finalize (best-effort)", async () => {
+    const { client, calls } = fakeCardKitClient();
+    // Make ONLY the cot_inner stream throw; the answer path must still finalize.
+    const origStream = client.streamElementContent;
+    client.streamElementContent = async (cardId, elementId, content, opts) => {
+      if (elementId === "cot_inner_md") throw new Error("panel stream boom");
+      return origStream(cardId, elementId, content, opts);
+    };
+    const handle = await createCardKitProgressHandle({
+      cardKitClient: client,
+      replyToMessageId: "trigger_message",
+      replyInThread: true,
+      facts: { botId: "bot", threadId: "thread", triggerMessageId: "trigger_message" },
+      patchIntervalMs: 0,
+      cot: { detail: "brief" },
+    });
+    handle.handle({ type: "thinking_delta", text: "推理", raw: {} });
+    handle.handle({ type: "answer_snapshot", text: "答案", raw: {} });
+    await expect(handle.finalize({ finalText: "答案" })).resolves.toBeUndefined();
+    // Answer still streamed + final card written.
+    expect(calls.some((c) => c.name === "streamElementContent" && c.args[1] === "final_md")).toBe(true);
+    expect(calls.some((c) => c.name === "updateCardEntity")).toBe(true);
+  });
+});

--- a/src/bridge/cardkitProgress.ts
+++ b/src/bridge/cardkitProgress.ts
@@ -27,7 +27,12 @@ const DEFAULT_MAX_PROGRESS_UPDATES = 240;
 /** A6: patch-interval backoff ladder once the soft budget is exceeded, capped at the last entry. */
 const BACKOFF_LADDER_MS = [250, 1_000, 2_000, 5_000];
 
-/** COT-in-card (方案 B): hard cap on reasoning-panel text to keep the card small. */
+/**
+ * COT-in-card (方案 B): hard cap on reasoning-panel text to keep the card small.
+ * NOTE (accepted nit): the COT patch channel reuses patchIntervalMs but is NOT
+ * on the answer's A6 soft-budget/backoff ladder. That's fine here — this
+ * char budget bounds total panel writes far below where backoff would matter.
+ */
 const COT_PANEL_BUDGET_CHARS = 4_000;
 /** Detailed-tier tool arg / result caps inside the panel. */
 const COT_TOOL_ARGS_MAX = 200;
@@ -672,6 +677,13 @@ export async function createCardKitProgressHandle(
   });
 }
 
+/**
+ * Boot-reconcile finalize for a card orphaned by a bridge crash.
+ * NOTE (accepted nit): the streamed reasoning-panel content lives only in the
+ * in-process handle, so a crash-recovery finalize rebuilds the final card
+ * WITHOUT the COT panel (the reasoning is dropped). Acceptable degradation —
+ * the panel is cosmetic; the answer itself is reconciled from state.json.
+ */
 export async function finalizeExistingCardKitCard(opts: {
   cardKitClient: OutboundCardKitClient;
   cardId: string;

--- a/src/bridge/cardkitProgress.ts
+++ b/src/bridge/cardkitProgress.ts
@@ -8,8 +8,11 @@ import {
   buildCardKitFinalCard,
   buildCardKitFinalMarkdown,
   buildCardKitInitialCard,
+  buildCotPanelElement,
   CARDKIT_FOOTER_ELEMENT_ID,
   CARDKIT_FINAL_ELEMENT_ID,
+  CARDKIT_COT_PANEL_ELEMENT_ID,
+  CARDKIT_COT_INNER_ELEMENT_ID,
   type BuildCardKitFinalCardOpts,
 } from "../lark/cardkitSurface.js";
 
@@ -23,6 +26,12 @@ const DEFAULT_PATCH_INTERVAL_MS = 250;
 const DEFAULT_MAX_PROGRESS_UPDATES = 240;
 /** A6: patch-interval backoff ladder once the soft budget is exceeded, capped at the last entry. */
 const BACKOFF_LADDER_MS = [250, 1_000, 2_000, 5_000];
+
+/** COT-in-card (方案 B): hard cap on reasoning-panel text to keep the card small. */
+const COT_PANEL_BUDGET_CHARS = 4_000;
+/** Detailed-tier tool arg / result caps inside the panel. */
+const COT_TOOL_ARGS_MAX = 200;
+const COT_TOOL_RESULT_MAX = 1_200;
 
 export interface CardKitLiveMetrics {
   answerDeltaCount: number;
@@ -50,6 +59,8 @@ export interface CardKitProgressHandle {
   drain(): Promise<void>;
   finalize(opts: BuildCardKitFinalCardOpts): Promise<void>;
   close(): void;
+  /** COT-in-card: mark this turn errored so the panel's settled title reflects it. */
+  markCotError(): void;
 }
 
 export interface CreateCardKitProgressHandleOpts {
@@ -65,6 +76,16 @@ export interface CreateCardKitProgressHandleOpts {
   patchIntervalMs?: number;
   /** Soft budget before patch cadence backs off (A6) — no longer a hard stop. */
   maxProgressUpdates?: number;
+  /**
+   * COT-in-card (方案 B): when present (cotSurface="card" && cot!="off"), the
+   * handle lazily inserts a collapsible reasoning panel on the FIRST thinking/
+   * tool event and streams reasoning + tool activity into it. Absent = no
+   * panel (the bubble path or cot="off"). `detail` mirrors bot config: brief =
+   * tool name only, detailed = + truncated args + truncated result.
+   */
+  cot?: { detail: "brief" | "detailed" };
+  /** Fired once when the panel element is first created — persists the id for resume. */
+  onCotPanelCreated?: (elementId: string) => void;
   onSequenceCommitted?: (sequence: number) => Promise<void>;
   onLiveMetricsChanged?: (metrics: CardKitLiveMetrics & { sequence: number }) => void;
 }
@@ -118,6 +139,50 @@ function toolStatusText(toolUseCount: number): string {
     : "努力回答中...";
 }
 
+function clip(value: unknown, max: number): string {
+  const text = String(value ?? "");
+  return text.length > max ? `${text.slice(0, max)}…` : text;
+}
+
+/**
+ * Brief-tier tool title for the panel: the tool NAME only — never the command
+ * args. Fixes the bubble version's leak of full command parameters at the
+ * brief tier (方案 B spec item 3).
+ */
+function cotBriefToolTitle(name: string): string {
+  return String(name ?? "tool");
+}
+
+/**
+ * Best-effort text of a tool_result for the detailed tier — larkway's
+ * tool_result event carries only `raw` (a claude `user` message). Any miss
+ * returns "" and the caller renders no result line.
+ */
+function cotExtractToolResultText(raw: unknown): string {
+  if (typeof raw !== "object" || raw === null) return "";
+  const message = (raw as Record<string, unknown>)["message"];
+  if (typeof message !== "object" || message === null) return "";
+  const content = (message as Record<string, unknown>)["content"];
+  if (!Array.isArray(content)) return "";
+  const parts: string[] = [];
+  for (const item of content) {
+    if (typeof item !== "object" || item === null) continue;
+    const block = item as Record<string, unknown>;
+    if (block["type"] !== "tool_result") continue;
+    const inner = block["content"];
+    if (typeof inner === "string") parts.push(inner);
+    else if (Array.isArray(inner)) {
+      for (const piece of inner) {
+        if (typeof piece === "object" && piece !== null) {
+          const text = (piece as Record<string, unknown>)["text"];
+          if (typeof text === "string") parts.push(text);
+        }
+      }
+    }
+  }
+  return parts.join("\n").trim();
+}
+
 class LiveCardKitProgressHandle implements CardKitProgressHandle {
   readonly cardId: string;
   readonly messageId: string;
@@ -139,6 +204,18 @@ class LiveCardKitProgressHandle implements CardKitProgressHandle {
   private metrics: CardKitLiveMetrics = initialLiveMetrics();
   sequence = 0;
 
+  // COT-in-card (方案 B) state. All no-ops when cotDetail is undefined.
+  private readonly cotDetail?: "brief" | "detailed";
+  private readonly onCotPanelCreated?: (elementId: string) => void;
+  private cotBuffer = "";
+  private cotTruncated = false;
+  private cotPanelCreated = false;
+  private cotPendingPatch: ReturnType<typeof setTimeout> | null = null;
+  private cotSawThinkingDelta = false;
+  private cotToolIndex = 0;
+  private readonly cotPendingTools: string[] = [];
+  private cotErrored = false;
+
   constructor(opts: {
     cardKitClient: OutboundCardKitClient;
     cardId: string;
@@ -146,6 +223,8 @@ class LiveCardKitProgressHandle implements CardKitProgressHandle {
     idempotencyKey: string;
     patchIntervalMs: number;
     maxProgressUpdates: number;
+    cot?: { detail: "brief" | "detailed" };
+    onCotPanelCreated?: (elementId: string) => void;
     onSequenceCommitted?: (sequence: number) => Promise<void>;
     onLiveMetricsChanged?: (metrics: CardKitLiveMetrics & { sequence: number }) => void;
   }) {
@@ -155,6 +234,8 @@ class LiveCardKitProgressHandle implements CardKitProgressHandle {
     this.idempotencyKey = opts.idempotencyKey;
     this.patchIntervalMs = opts.patchIntervalMs;
     this.maxProgressUpdates = opts.maxProgressUpdates;
+    this.cotDetail = opts.cot?.detail;
+    this.onCotPanelCreated = opts.onCotPanelCreated;
     this.onSequenceCommitted = opts.onSequenceCommitted;
     this.onLiveMetricsChanged = opts.onLiveMetricsChanged;
   }
@@ -169,6 +250,10 @@ class LiveCardKitProgressHandle implements CardKitProgressHandle {
 
   handle(event: AgentStreamEvent): void {
     if (this.closed) return;
+    // COT-in-card panel (方案 B): reasoning + tool activity into the collapsible
+    // panel, in parallel with the status/answer handling below. No-op unless
+    // cotDetail is set. Best-effort — a panel error never touches the answer.
+    if (this.cotDetail) this.handleCot(event);
     if (event.type === "tool_use") {
       this.recordToolUse();
       this.patchStatus(toolStatusText(this.metrics.toolUseCount));
@@ -188,6 +273,11 @@ class LiveCardKitProgressHandle implements CardKitProgressHandle {
   }
 
   async drain(): Promise<void> {
+    if (this.cotPendingPatch) {
+      clearTimeout(this.cotPendingPatch);
+      this.cotPendingPatch = null;
+      await this.cotPatch();
+    }
     if (this.pendingPatch) {
       clearTimeout(this.pendingPatch);
       this.pendingPatch = null;
@@ -199,6 +289,9 @@ class LiveCardKitProgressHandle implements CardKitProgressHandle {
   async finalize(opts: BuildCardKitFinalCardOpts): Promise<void> {
     await this.drain();
     this.closed = true;
+    // Embed the collapsed reasoning panel INTO the final card (updateCardEntity
+    // rebuilds the whole card, so a separate PATCH would be clobbered).
+    const finalOpts: BuildCardKitFinalCardOpts = { ...opts, cotPanel: this.cotPanelForFinalCard() };
     const finalMarkdown = buildCardKitFinalMarkdown(opts);
     if (finalMarkdown !== this.answerBuffer) {
       await this.withAnswerElement(finalMarkdown);
@@ -216,7 +309,7 @@ class LiveCardKitProgressHandle implements CardKitProgressHandle {
       this.answerBuffer = finalMarkdown;
     }
     await this.next((sequence) =>
-      this.cardKitClient.updateCardEntity(this.cardId, buildCardKitFinalCard(opts), {
+      this.cardKitClient.updateCardEntity(this.cardId, buildCardKitFinalCard(finalOpts), {
         sequence,
         uuid: sequenceUuid(this.cardId, "final-card", sequence),
       }),
@@ -244,6 +337,142 @@ class LiveCardKitProgressHandle implements CardKitProgressHandle {
       clearTimeout(this.pendingPatch);
       this.pendingPatch = null;
     }
+    if (this.cotPendingPatch) {
+      clearTimeout(this.cotPendingPatch);
+      this.cotPendingPatch = null;
+    }
+  }
+
+  /** Mark the reasoning panel's turn as errored so its settled title reflects it. */
+  markCotError(): void {
+    this.cotErrored = true;
+  }
+
+  // ── COT-in-card (方案 B) ────────────────────────────────────────────────
+  //
+  // Reasoning + tool activity stream into a collapsible_panel that is created
+  // LAZILY on the first such event (a thinking-free short turn shows no panel),
+  // inserted above the answer, then collapsed + retitled inside the final card
+  // (buildCardKitFinalCard, not a separate PATCH — the full-card rebuild would
+  // clobber a PATCH). Every step is best-effort: a panel failure never touches
+  // the answer stream.
+
+  private handleCot(event: AgentStreamEvent): void {
+    switch (event.type) {
+      case "thinking_delta":
+        this.cotSawThinkingDelta = true;
+        this.cotAppendReasoning(event.text);
+        break;
+      case "thinking_snapshot":
+        // Catch-up only (same rule as the bubble): deltas are the source of
+        // truth when partial streaming is on; snapshot renders only if none.
+        if (this.cotSawThinkingDelta) break;
+        this.cotAppendReasoning(event.text);
+        break;
+      case "tool_use":
+        this.cotAppendToolUse(event.toolName, event.toolInput);
+        break;
+      case "tool_result":
+        this.cotAppendToolResult(event.raw);
+        break;
+      default:
+        break;
+    }
+  }
+
+  private cotAppendReasoning(text: string): void {
+    this.cotAppend(text);
+  }
+
+  private cotAppendToolUse(toolName: string, toolInput: unknown): void {
+    this.cotPendingTools.push(`tool-${++this.cotToolIndex}`);
+    let line = `\n\n🔧 ${cotBriefToolTitle(toolName)}`;
+    if (this.cotDetail === "detailed" && toolInput !== undefined && toolInput !== null) {
+      line += `\n\`\`\`\n${clip(JSON.stringify(toolInput), COT_TOOL_ARGS_MAX)}\n\`\`\``;
+    }
+    this.cotAppend(line);
+  }
+
+  private cotAppendToolResult(raw: unknown): void {
+    this.cotPendingTools.shift();
+    if (this.cotDetail !== "detailed") return;
+    const text = cotExtractToolResultText(raw);
+    if (!text) return;
+    this.cotAppend(`\n> ${clip(text, COT_TOOL_RESULT_MAX).replace(/\n/g, "\n> ")}`);
+  }
+
+  /** Append to the panel buffer under the hard char budget, then schedule a patch. */
+  private cotAppend(text: string): void {
+    if (this.closed || this.cotTruncated) return;
+    const remaining = COT_PANEL_BUDGET_CHARS - this.cotBuffer.length;
+    if (text.length >= remaining) {
+      // This append reaches the budget: keep what fits, add a truncation
+      // marker, and stop accepting further reasoning for the rest of the turn.
+      this.cotBuffer += text.slice(0, Math.max(0, remaining)) + "\n\n_…思考内容较长，后续省略_";
+      this.cotTruncated = true;
+    } else {
+      this.cotBuffer += text;
+    }
+    this.cotSchedulePatch();
+  }
+
+  private cotSchedulePatch(): void {
+    if (this.cotPendingPatch || this.closed) return;
+    this.cotPendingPatch = setTimeout(() => {
+      this.cotPendingPatch = null;
+      void this.cotPatch();
+    }, this.patchIntervalMs);
+    this.cotPendingPatch.unref?.();
+  }
+
+  private async cotPatch(): Promise<void> {
+    if (this.closed || !this.cotBuffer) return;
+    this.inFlight = this.inFlight
+      .then(() => this.cotEnsurePanel())
+      .then(() =>
+        this.next((sequence) =>
+          this.cardKitClient.streamElementContent(
+            this.cardId,
+            CARDKIT_COT_INNER_ELEMENT_ID,
+            this.cotBuffer,
+            { sequence, uuid: sequenceUuid(this.cardId, "cot-inner", sequence) },
+          ),
+        ),
+      )
+      .catch((err) => {
+        console.warn("[cardkit_progress] COT panel patch failed (continuing):", err);
+      });
+    await this.inFlight;
+  }
+
+  /** Lazily insert the expanded reasoning panel, once, above the answer/footer. */
+  private async cotEnsurePanel(): Promise<void> {
+    if (this.cotPanelCreated) return;
+    this.cotPanelCreated = true;
+    const target = this.answerElementCreated
+      ? CARDKIT_FINAL_ELEMENT_ID
+      : CARDKIT_FOOTER_ELEMENT_ID;
+    await this.next((sequence) =>
+      this.cardKitClient.createElements(
+        this.cardId,
+        [buildCotPanelElement({ expanded: true, title: "思考中…", content: this.cotBuffer || "…" })],
+        {
+          sequence,
+          uuid: sequenceUuid(this.cardId, "cot-panel", sequence),
+          type: "insert_before",
+          targetElementId: target,
+        },
+      ),
+    );
+    this.onCotPanelCreated?.(CARDKIT_COT_PANEL_ELEMENT_ID);
+  }
+
+  private cotPanelForFinalCard(): BuildCardKitFinalCardOpts["cotPanel"] {
+    if (!this.cotPanelCreated) return undefined;
+    return {
+      title: this.cotErrored ? "思考过程（本轮出错）" : "思考过程",
+      content: this.cotBuffer,
+    };
   }
 
   private recordAnswerEvent(type: "answer_delta" | "answer_snapshot"): void {
@@ -436,6 +665,8 @@ export async function createCardKitProgressHandle(
     idempotencyKey: key,
     patchIntervalMs: opts.patchIntervalMs ?? DEFAULT_PATCH_INTERVAL_MS,
     maxProgressUpdates: opts.maxProgressUpdates ?? DEFAULT_MAX_PROGRESS_UPDATES,
+    cot: opts.cot,
+    onCotPanelCreated: opts.onCotPanelCreated,
     onSequenceCommitted: opts.onSequenceCommitted,
     onLiveMetricsChanged: opts.onLiveMetricsChanged,
   });

--- a/src/bridge/handler.test.ts
+++ b/src/bridge/handler.test.ts
@@ -1141,6 +1141,9 @@ describe("handleOne — thin-channel finalize", () => {
       return {
         events: (async function* () {
           yield { type: "system_init", sessionId: "sess_idle", raw: {} };
+          // Emit one reasoning delta so a COT-in-card panel exists this turn —
+          // lets us assert the failure-path panel title below.
+          yield { type: "thinking_delta", text: "思考中断测试", raw: {} };
           while (!killed) await new Promise((r) => setTimeout(r, 5));
         })(),
         done,
@@ -1203,6 +1206,15 @@ describe("handleOne — thin-channel finalize", () => {
     expect(stream?.content).not.toContain("请再 @ 我一次");
     const settings = cardKitCalls.find((c) => c.kind === "settings");
     expect(JSON.stringify(settings?.payload)).toContain("本轮被中断");
+    // COT-in-card: the failed (idle-interrupted) turn settles the reasoning
+    // panel with the errored title — proves handler wires markCotError() on the
+    // failure path (was production-unreachable before).
+    const panelCreate = cardKitCalls.find(
+      (c) => c.kind === "createElements" && JSON.stringify(c.payload).includes("collapsible_panel"),
+    );
+    expect(panelCreate).toBeDefined();
+    const finalCard = cardKitCalls.filter((c) => c.kind === "updateCard").at(-1);
+    expect(JSON.stringify(finalCard?.payload)).toContain("思考过程（本轮出错）");
   });
 
   it("A3: does not kill an idle-stuck turn while a real tool call is in flight (tool_use with no matching tool_result yet)", async () => {

--- a/src/bridge/handler.ts
+++ b/src/bridge/handler.ts
@@ -634,6 +634,8 @@ export interface BridgeHandlerDeps {
      * 缺省视为 "brief"。仅在非 "off" 时 main.ts 才注入 cotClient。
      */
     cot?: "off" | "brief" | "detailed";
+    /** COT 展示形态(方案 B):"card"(默认,折叠进卡片)| "bubble"(实验,message_cot 气泡)。 */
+    cotSurface?: "card" | "bubble";
   };
   /**
    * Optional outbound post transport. main.ts only injects this when the bot's
@@ -1133,6 +1135,17 @@ export class BridgeHandler {
         });
       };
 
+      // COT (方案 B) surface resolution — shared by the CardKit panel (below)
+      // and the experimental bubble (further down). "card" (default) folds
+      // reasoning into the answer card's collapsible panel; "bubble" uses the
+      // message_cot side channel.
+      const cotDetail = this.deps.botConfig?.cot ?? "brief";
+      const cotSurface = this.deps.botConfig?.cotSurface ?? "card";
+      const cotCardOption =
+        cotDetail !== "off" && cotSurface === "card"
+          ? { detail: cotDetail as "brief" | "detailed" }
+          : undefined;
+
       // CardKit response surface: default main surface when the transport and
       // rollout gates are available. It streams bounded progress into a
       // thinking area during execution, then replaces the card entity with a
@@ -1153,6 +1166,21 @@ export class BridgeHandler {
                 triggerMessageId: messageId,
               },
               initialStatusText: "努力回答中...",
+              cot: cotCardOption,
+              onCotPanelCreated: (elementId) => {
+                // Persist the reasoning panel's element id (cardkitFile's
+                // reserved `thinking` slot) so a crash-recovery reconcile knows
+                // the panel exists. Best-effort; shallow-merge keeps footer/final.
+                void updateCardKitRecord({
+                  elements: {
+                    ...(cardKitRecord?.elements ?? {
+                      footer: { elementId: "footer_md" },
+                      final: { elementId: "final_md" },
+                    }),
+                    thinking: { elementId },
+                  },
+                }).catch(() => {});
+              },
               onSequenceCommitted: async (sequence) => {
                 await updateCardKitRecord({ status: "streaming", sequence });
               },
@@ -1573,8 +1601,12 @@ export class BridgeHandler {
       // silently. Only reasoning + tool activity flow here; the final answer
       // stays exclusively on the card. Topic groups anchor on the omt_ thread
       // id; other chats fall back to chat_id + the trigger message.
-      const cotDetail = this.deps.botConfig?.cot ?? "brief";
-      if (this.deps.cotClient && cotDetail !== "off") {
+      // 方案 B: the reasoning bubble is now the EXPERIMENTAL surface — only
+      // built when the bot opts into cotSurface="bubble". The default
+      // ("card") streams reasoning into the answer card's collapsible panel
+      // (wired into createCardKitProgressHandle above via `cot`), no bubble.
+      // `cotDetail`/`cotSurface` are resolved once above (shared with the panel).
+      if (this.deps.cotClient && cotDetail !== "off" && cotSurface === "bubble") {
         cotPublisher = await createCotProgressHandle({
           cotClient: this.deps.cotClient,
           detail: cotDetail,

--- a/src/bridge/handler.ts
+++ b/src/bridge/handler.ts
@@ -2200,6 +2200,10 @@ export class BridgeHandler {
               });
             }
             try {
+              // COT-in-card: a failed turn (bot-reported failure OR idle-timeout
+              // interrupt — both set success=false) settles the reasoning panel
+              // with the errored title. No-op when no panel was created.
+              if (!success) cardKitProgress.markCotError();
               await cardKitProgress.finalize({
                 title: baseCardPayload.titleOverride,
                 finalText: baseCardPayload.finalText,
@@ -2437,6 +2441,9 @@ export class BridgeHandler {
       };
       if (!card && cardKitProgress) {
         try {
+          // COT-in-card: this is the hard-crash path — settle the reasoning
+          // panel with the errored title. No-op when no panel was created.
+          cardKitProgress.markCotError();
           await cardKitProgress.finalize({
             finalText: hardFailureText,
           });

--- a/src/cli/botsStore.test.ts
+++ b/src/cli/botsStore.test.ts
@@ -30,6 +30,7 @@ const sampleBot = (): BotConfig =>
     runtime: "legacy",
     backend: "claude",
     cot: "brief",
+    cotSurface: "card",
   }) as BotConfig;
 
 beforeEach(async () => {

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -636,6 +636,7 @@ async function runCreateBot(
     runtime: "agent_workspace",
     backend: basics.backend,
     cot: "brief",
+    cotSurface: "card",
     memory_file: memoryFile,
     ...(basics.gitlabTokenEnv ? { gitlab_token_env: basics.gitlabTokenEnv } : {}),
     ...(basics.gitName && basics.gitEmail

--- a/src/cli/commands/memory.test.ts
+++ b/src/cli/commands/memory.test.ts
@@ -48,6 +48,7 @@ const sampleBot = (id = "test-bot"): BotConfig =>
     runtime: "legacy",
     backend: "claude",
     cot: "brief",
+    cotSurface: "card",
   }) as BotConfig;
 
 /** Collected output lines (stdout / stderr) across a run. */

--- a/src/config/botLoader.ts
+++ b/src/config/botLoader.ts
@@ -340,6 +340,17 @@ export const BotConfigSchema = z.object({
   cot: z.enum(["off", "brief", "detailed"]).default("brief"),
 
   /**
+   * COT 展示形态(方案 B)。`cot` 管密度(off/brief/detailed),这个管落点:
+   * - "card"(默认):思考过程折叠进答案卡片里的 collapsible_panel(懒创建、
+   *   答案上方、finalize 时折叠)。话题群里也能用,是默认形态。
+   * - "bubble":走飞书原生 message_cot 思维链气泡(src/bridge/cotProgress.ts)。
+   *   保留为实验选项 —— 已知限制:话题内锚定不可用(气泡落群顶层),且本租户
+   *   thread 通道判死、chat 通道 PUT 偶发 400。
+   * cot="off" 时本字段无意义(两种形态都不产出)。
+   */
+  cotSurface: z.enum(["card", "bubble"]).default("card"),
+
+  /**
    * 话题 ↔ 飞书任务句柄(docs/task-handle.md,v2)。省略此字段不代表关闭,但也
    * 不会触发任何自动建清单——main.ts 在 startup 时只做只读解析(yaml 里的
    * tasklistGuid,或共享注册文件里已有的 guid);清单本身只由

--- a/src/lark/cardkitSurface.test.ts
+++ b/src/lark/cardkitSurface.test.ts
@@ -2,8 +2,11 @@ import { describe, expect, it } from "vitest";
 import {
   buildCardKitFinalCard,
   buildCardKitInitialCard,
+  buildCotPanelElement,
   CARDKIT_FOOTER_ELEMENT_ID,
   CARDKIT_FINAL_ELEMENT_ID,
+  CARDKIT_COT_PANEL_ELEMENT_ID,
+  CARDKIT_COT_INNER_ELEMENT_ID,
 } from "./cardkitSurface.js";
 
 function elements(card: Record<string, unknown>): Record<string, unknown>[] {
@@ -97,4 +100,32 @@ describe("cardkitSurface", () => {
     const tags = elements(card).map((e) => e["tag"]);
     expect(tags).toEqual(["markdown"]);
   });
+
+  it("buildCotPanelElement wraps an inner markdown in a collapsible_panel", () => {
+    const panel = buildCotPanelElement({ expanded: true, title: "思考中…", content: "推理" }) as Record<string, unknown>;
+    expect(panel["tag"]).toBe("collapsible_panel");
+    expect(panel["element_id"]).toBe(CARDKIT_COT_PANEL_ELEMENT_ID);
+    expect(panel["expanded"]).toBe(true);
+    const inner = (panel["elements"] as Record<string, unknown>[])[0]!;
+    expect(inner["element_id"]).toBe(CARDKIT_COT_INNER_ELEMENT_ID);
+    expect(inner["content"]).toBe("推理");
+  });
+
+  it("buildCardKitFinalCard embeds the collapsed cotPanel ABOVE the answer", () => {
+    const card = buildCardKitFinalCard({ finalText: "答案", cotPanel: { title: "思考过程", content: "推理内容" } });
+    const els = elements(card);
+    const panelIdx = els.findIndex((e) => e["tag"] === "collapsible_panel");
+    const answerIdx = els.findIndex((e) => e["element_id"] === CARDKIT_FINAL_ELEMENT_ID);
+    expect(panelIdx).toBeGreaterThanOrEqual(0);
+    expect(panelIdx).toBeLessThan(answerIdx);
+    expect(els[panelIdx]!["expanded"]).toBe(false);
+    expect(JSON.stringify(els[panelIdx])).toContain("思考过程");
+    expect(JSON.stringify(els[panelIdx])).toContain("推理内容");
+  });
+
+  it("buildCardKitFinalCard omits the panel when no cotPanel is given", () => {
+    const card = buildCardKitFinalCard({ finalText: "答案" });
+    expect(elements(card).some((e) => e["tag"] === "collapsible_panel")).toBe(false);
+  });
+
 });

--- a/src/lark/cardkitSurface.ts
+++ b/src/lark/cardkitSurface.ts
@@ -3,6 +3,9 @@ import type { Choice, ContentBlock, ImageBlock } from "./card.js";
 export const CARDKIT_FINAL_ELEMENT_ID = "final_md";
 export const CARDKIT_FOOTER_ELEMENT_ID = "footer_md";
 export const CARDKIT_CHOICES_ELEMENT_ID = "choices_slot";
+/** COT-in-card (方案 B): the collapsible reasoning panel and its inner markdown. */
+export const CARDKIT_COT_PANEL_ELEMENT_ID = "cot_panel";
+export const CARDKIT_COT_INNER_ELEMENT_ID = "cot_inner_md";
 
 const MAX_CARD_BYTES = 30 * 1024;
 const FINAL_BUDGET_CHARS = 22_000;
@@ -27,6 +30,14 @@ export interface BuildCardKitFinalCardOpts {
   choicePrompt?: string;
   imageBlocks?: ImageBlock[];
   contentBlocks?: ContentBlock[];
+  /**
+   * COT-in-card (方案 B): when the reasoning panel was created this turn, its
+   * collapsed final form is embedded ABOVE the answer here. This is deliberate:
+   * finalize replaces the whole card via updateCardEntity, so a separate
+   * collapse-PATCH would be clobbered by that rebuild — the panel must live in
+   * the final card itself. Omitted when no reasoning streamed.
+   */
+  cotPanel?: { title: string; content: string };
 }
 
 function plainText(content: string): { tag: "plain_text"; content: string } {
@@ -41,6 +52,28 @@ function markdown(content: string, elementId?: string): Record<string, unknown> 
 
 export function buildCardKitAnswerElement(content = ""): Record<string, unknown> {
   return markdown(content, CARDKIT_FINAL_ELEMENT_ID);
+}
+
+/**
+ * COT-in-card (方案 B): a collapsible_panel wrapping a single markdown element
+ * that the reasoning stream flows into. Verified against Feishu CardKit 2.0
+ * (cot-write-probe.md): the nested markdown is accepted at create time and can
+ * be streamed via PUT elements/{inner}/content; expanded + header.title are
+ * settable. During the run the panel is expanded ("思考中…"); the final card
+ * embeds it collapsed with a settled title.
+ */
+export function buildCotPanelElement(opts: {
+  expanded: boolean;
+  title: string;
+  content: string;
+}): Record<string, unknown> {
+  return {
+    tag: "collapsible_panel",
+    element_id: CARDKIT_COT_PANEL_ELEMENT_ID,
+    expanded: opts.expanded,
+    header: { title: { tag: "markdown", content: opts.title } },
+    elements: [markdown(opts.content || "…", CARDKIT_COT_INNER_ELEMENT_ID)],
+  };
 }
 
 function safeAtMention(target: CardKitMentionTarget): string {
@@ -161,7 +194,19 @@ function finalMarkdown(opts: BuildCardKitFinalCardOpts): string {
 export function buildCardKitFinalCard(
   opts: BuildCardKitFinalCardOpts,
 ): Record<string, unknown> {
-  const elements: unknown[] = [buildCardKitAnswerElement(finalMarkdown(opts))];
+  const elements: unknown[] = [];
+  // Collapsed reasoning panel sits ABOVE the answer (matches its streaming
+  // position). Embedded here so the full-card rebuild keeps it (collapsed).
+  if (opts.cotPanel) {
+    elements.push(
+      buildCotPanelElement({
+        expanded: false,
+        title: opts.cotPanel.title,
+        content: opts.cotPanel.content,
+      }),
+    );
+  }
+  elements.push(buildCardKitAnswerElement(finalMarkdown(opts)));
   const images: ImageBlock[] = [];
   if (opts.contentBlocks?.length) {
     for (const block of opts.contentBlocks) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -429,10 +429,14 @@ async function runV2Mode({
     )
       ? client.outboundCardKitClient()
       : undefined;
-    // COT (思维链) bubble transport — provisioned only when the bot opts in
-    // (cot != "off"). Uses the SDK's generic rawClient.request(), so no new
-    // auth surface; the handler degrades silently on any failure.
-    const cotClient = bot.cot !== "off" ? client.outboundCotClient() : undefined;
+    // COT (思维链) bubble transport — 方案 B made the bubble the EXPERIMENTAL
+    // surface, so this is provisioned only when the bot opts into
+    // cotSurface="bubble" (and cot != "off"). The default "card" surface folds
+    // reasoning into the answer card and needs no message_cot client.
+    const cotClient =
+      bot.cot !== "off" && bot.cotSurface === "bubble"
+        ? client.outboundCotClient()
+        : undefined;
 
     // Task-handle (docs/task-handle.md v2: team-shared single tasklist).
     // No `enabled` flag gates this — the real gate is whether a LIVE guid
@@ -752,6 +756,7 @@ async function runV2Mode({
         model: bot.model,
         effort: bot.effort,
         cot: bot.cot,
+        cotSurface: bot.cotSurface,
       },
       cardKitClient,
       cotClient,

--- a/src/web/onboardSession.ts
+++ b/src/web/onboardSession.ts
@@ -458,6 +458,7 @@ export async function createBotFromCreds(
     runtime: "agent_workspace",
     backend: form.backend && form.backend.trim() ? form.backend.trim() : "codex",
     cot: "brief",
+    cotSurface: "card",
     // Persist the Feishu avatar URL so the Web 管理面 can show an avatar before
     // the bridge writes status.json (pre-bridge / central roster). Best-effort:
     // only set when resolveBotIdentity returned a valid url.


### PR DESCRIPTION
## What

Makes the **card-embedded collapsible panel** the default COT surface (方案 B). Reasoning + tool activity fold into a `collapsible_panel` inside the answer card, so it works in topic groups (unlike the message_cot bubble, which our tenant rejects for thread anchoring). The native bubble becomes an experimental opt-in.

New bot config `cotSurface: "card" | "bubble"` (default `"card"`); existing `cot: off|brief|detailed` still controls density.

## How (verified against the probe)

Technique confirmed in `cot-write-probe.md` (nested `collapsible_panel` accepted at create, `PUT elements/{inner}/content` streams, `expanded`+`header.title` settable).

- **cardkitSurface**: `buildCotPanelElement` + `buildCardKitFinalCard.cotPanel`. The collapsed panel is embedded **into the final card** rather than collapsed via a separate PATCH — `finalize` does a full-card `updateCardEntity` rebuild that would clobber any prior PATCH (a subtle ordering bug the naive approach would hit), so embedding is the correct mechanism.
- **cardkitProgress**: lazily inserts the expanded panel on the **first** thinking/tool event (thinking-free short turns show no panel), inserted above the answer; streams reasoning into `cot_inner_md` on the existing 250ms throttle; **brief = tool NAME only** (fixes the bubble's full-arg leak), **detailed** = + truncated args (≤200) + truncated result (≤1200); ~4000-char panel cap with an ellipsis marker; `finalize` embeds the collapsed panel (title `思考过程` / `思考过程（本轮出错）`). Every panel op is best-effort — a panel failure never touches the answer stream.
- **handler/main**: `cotSurface` routing — the message_cot client is provisioned only for `cotSurface="bubble"`; `onCotPanelCreated` persists cardkitFile's reserved `thinking` element slot for crash-recovery reconcile.
- The thinking event-parsing layer (both backends) is unchanged.

## Tests

Lazy-create (no panel without thinking), streaming map, brief-no-args, cap truncation, collapse-in-final-card, error title, panel-failure isolation, resume slot; plus surface-builder unit tests. `pnpm typecheck` / `pnpm test` (1371) / `pnpm build` all green.

## Note

CardKit has no GET readback (probe), so the *visual* collapse is API-confirmed (`code=0`) but a one-time human eyeball on a real card is the only remaining check — outside unit-test scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)