### PR TITLE
fix(cot): default cotSurface to bubble + fix two in-card panel formatting bugs

### DIFF
--- a/src/bridge/cardkitProgress.test.ts
+++ b/src/bridge/cardkitProgress.test.ts
@@ -428,6 +428,53 @@ describe("CardKitProgressHandle — COT-in-card panel (方案 B)", () => {
     expect(inner).not.toContain("SUPERSECRET");
   });
 
+  it("keeps a tool line and the following reasoning on separate lines", async () => {
+    const { calls, promise } = makeHandle("brief");
+    const handle = await promise;
+    handle.handle({ type: "thinking_delta", text: "开始", raw: {} });
+    handle.handle({ type: "tool_use", toolName: "shell", toolInput: {}, raw: {} });
+    handle.handle({ type: "thinking_delta", text: "继续想", raw: {} });
+    await handle.drain();
+    const inner = calls
+      .filter((c) => c.name === "streamElementContent" && c.args[1] === "cot_inner_md")
+      .at(-1)!.args[2] as string;
+    // Regression: was "🔧 shell继续想" — the tool name ran into the next reasoning.
+    expect(inner).not.toContain("shell继续想");
+    expect(inner).toMatch(/🔧 shell\n/);
+  });
+
+  it("collapses consecutive same-name tool calls into a ×N count (brief)", async () => {
+    const { calls, promise } = makeHandle("brief");
+    const handle = await promise;
+    handle.handle({ type: "thinking_delta", text: "跑一批", raw: {} });
+    for (let i = 0; i < 7; i++) {
+      handle.handle({ type: "tool_use", toolName: "shell", toolInput: { command: `c${i}` }, raw: {} });
+      handle.handle({ type: "tool_result", raw: {} });
+    }
+    await handle.drain();
+    const inner = calls
+      .filter((c) => c.name === "streamElementContent" && c.args[1] === "cot_inner_md")
+      .at(-1)!.args[2] as string;
+    expect(inner).toContain("🔧 shell ×7");
+    // Only ONE tool line, not seven stacked "🔧 shell" lines.
+    expect(inner.match(/🔧 shell/g)).toHaveLength(1);
+  });
+
+  it("a DIFFERENT tool name breaks the count run", async () => {
+    const { calls, promise } = makeHandle("brief");
+    const handle = await promise;
+    handle.handle({ type: "thinking_delta", text: "混合", raw: {} });
+    handle.handle({ type: "tool_use", toolName: "shell", toolInput: {}, raw: {} });
+    handle.handle({ type: "tool_use", toolName: "shell", toolInput: {}, raw: {} });
+    handle.handle({ type: "tool_use", toolName: "Read", toolInput: {}, raw: {} });
+    await handle.drain();
+    const inner = calls
+      .filter((c) => c.name === "streamElementContent" && c.args[1] === "cot_inner_md")
+      .at(-1)!.args[2] as string;
+    expect(inner).toContain("🔧 shell ×2");
+    expect(inner).toContain("🔧 Read");
+  });
+
   it("detailed tier includes truncated args + result", async () => {
     const { calls, promise } = makeHandle("detailed");
     const handle = await promise;

--- a/src/bridge/cardkitProgress.ts
+++ b/src/bridge/cardkitProgress.ts
@@ -220,6 +220,12 @@ class LiveCardKitProgressHandle implements CardKitProgressHandle {
   private cotToolIndex = 0;
   private readonly cotPendingTools: string[] = [];
   private cotErrored = false;
+  // Panel formatting state: keep a tool line and following reasoning on
+  // separate lines, and collapse consecutive same-name tool calls into a count.
+  private cotAfterTool = false;
+  private cotLastToolName: string | undefined;
+  private cotLastToolCount = 0;
+  private cotLastToolLineStart = -1;
 
   constructor(opts: {
     cardKitClient: OutboundCardKitClient;
@@ -386,24 +392,59 @@ class LiveCardKitProgressHandle implements CardKitProgressHandle {
   }
 
   private cotAppendReasoning(text: string): void {
+    // A tool line and the reasoning that follows it must not run together
+    // ("🔧 shell" + "Considering…" → "🔧 shellConsidering…"): start reasoning
+    // after a tool on its own line.
+    if (this.cotAfterTool) {
+      this.cotAppend("\n");
+      this.cotAfterTool = false;
+    }
+    // Reasoning breaks a consecutive same-tool run.
+    this.cotLastToolName = undefined;
     this.cotAppend(text);
   }
 
   private cotAppendToolUse(toolName: string, toolInput: unknown): void {
     this.cotPendingTools.push(`tool-${++this.cotToolIndex}`);
-    let line = `\n\n🔧 ${cotBriefToolTitle(toolName)}`;
+    const name = cotBriefToolTitle(toolName);
+    // Collapse consecutive same-name calls into "🔧 name ×N" (brief tier only —
+    // detailed keeps each call so its args stay visible). Rewrites the last
+    // tool line in place rather than stacking "🔧 shell" seven times.
+    if (
+      this.cotDetail === "brief" &&
+      name === this.cotLastToolName &&
+      this.cotLastToolLineStart >= 0 &&
+      !this.cotTruncated
+    ) {
+      this.cotLastToolCount += 1;
+      this.cotBuffer = this.cotBuffer.slice(0, this.cotLastToolLineStart);
+      this.cotAppend(`\n\n🔧 ${name} ×${this.cotLastToolCount}`);
+      this.cotAfterTool = true;
+      return;
+    }
+    this.cotLastToolLineStart = this.cotBuffer.length;
+    this.cotLastToolName = name;
+    this.cotLastToolCount = 1;
+    let line = `\n\n🔧 ${name}`;
     if (this.cotDetail === "detailed" && toolInput !== undefined && toolInput !== null) {
       line += `\n\`\`\`\n${clip(JSON.stringify(toolInput), COT_TOOL_ARGS_MAX)}\n\`\`\``;
     }
     this.cotAppend(line);
+    this.cotAfterTool = true;
   }
 
   private cotAppendToolResult(raw: unknown): void {
     this.cotPendingTools.shift();
+    // Brief tier renders no result line, so leave the consecutive-tool run
+    // intact (the next same-name tool_use still collapses into ×N).
     if (this.cotDetail !== "detailed") return;
     const text = cotExtractToolResultText(raw);
     if (!text) return;
     this.cotAppend(`\n> ${clip(text, COT_TOOL_RESULT_MAX).replace(/\n/g, "\n> ")}`);
+    // A rendered result closes the tool block: following reasoning starts fresh
+    // and a later same-name tool is a new line (no merge across a result).
+    this.cotAfterTool = true;
+    this.cotLastToolName = undefined;
   }
 
   /** Append to the panel buffer under the hard char budget, then schedule a patch. */

--- a/src/bridge/handler.test.ts
+++ b/src/bridge/handler.test.ts
@@ -3018,6 +3018,7 @@ describe("handleOne — COT bubble ordering (before the card)", () => {
     cotClient: OutboundCotClient;
     cotBubbleCreateBudgetMs?: number;
     onCardCreate?: () => void;
+    errorTurn?: boolean;
   }) {
     const threadId = "om_msg";
     const wt = await seedWorktree(threadId);
@@ -3033,14 +3034,18 @@ describe("handleOne — COT bubble ordering (before the card)", () => {
     runClaudeImpl = () => ({
       events: (async function* () {
         yield { type: "system_init", sessionId: "sess_order", raw: {} };
-        await writeFile(stateFileMod.stateFilePathOf(wt), JSON.stringify(READY_STATE, null, 2), "utf8");
+        if (!opts.errorTurn) {
+          await writeFile(stateFileMod.stateFilePathOf(wt), JSON.stringify(READY_STATE, null, 2), "utf8");
+        }
       })(),
-      done: Promise.resolve({ exitCode: 0, sessionId: "sess_order" }),
+      done: opts.errorTurn
+        ? Promise.reject(new Error("mock runner crash"))
+        : Promise.resolve({ exitCode: 0, sessionId: "sess_order" }),
       kill: () => {},
     });
     const { renderer } = makeCardRenderer();
     const { store } = makeSessionStore();
-    const { client, acked } = makeClient(makeEvent());
+    const { client, acked, unhandled } = makeClient(makeEvent());
     const handler = new BridgeHandler({
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       client: client as any,
@@ -3055,10 +3060,10 @@ describe("handleOne — COT bubble ordering (before the card)", () => {
       cotBubbleCreateBudgetMs: opts.cotBubbleCreateBudgetMs,
     });
     await handler.run();
-    for (let i = 0; i < 200 && acked.length === 0; i++) {
+    for (let i = 0; i < 200 && acked.length === 0 && unhandled.length === 0; i++) {
       await new Promise((r) => setTimeout(r, 10));
     }
-    return { acked, cardKitCalls };
+    return { acked, unhandled, cardKitCalls };
   }
 
   it("creates the COT bubble BEFORE sending the answer card", async () => {
@@ -3098,9 +3103,10 @@ describe("handleOne — COT bubble ordering (before the card)", () => {
   });
 
   it("sends the card without waiting when the COT bubble create is slow (budget)", async () => {
-    // create never resolves; the budget must let the card proceed anyway.
+    // create resolves LATE (past the budget) — the card must proceed anyway.
     const cotClient: OutboundCotClient = {
-      create: () => new Promise(() => {}),
+      create: () =>
+        new Promise((resolve) => setTimeout(() => resolve({ cotId: "cot_1", messageId: "om_cot_1" }), 60)),
       async resolveThreadId() {
         return undefined;
       },
@@ -3110,6 +3116,54 @@ describe("handleOne — COT bubble ordering (before the card)", () => {
     const { acked, cardKitCalls } = await runTurn({ cotClient, cotBubbleCreateBudgetMs: 20 });
     expect(acked).toEqual(["om_msg"]);
     expect(cardKitCalls.map((c) => c.kind)).toContain("createCard");
+  });
+
+  it("anti-orphan: a bubble adopted AFTER the turn ends is still finalized (done)", async () => {
+    // The reviewer's blocker: create slower than the budget resolves after a
+    // trivial turn has already finished — cotPublisher was undefined at every
+    // finalize site, so without the finally's late-adoption finalize the bubble
+    // is created (RUN_STARTED) but never completed = orphan. Model a create that
+    // EVENTUALLY resolves (a never-resolving promise would hide the bug).
+    let completeReason: string | undefined;
+    const cotClient: OutboundCotClient = {
+      create: () =>
+        new Promise((resolve) => setTimeout(() => resolve({ cotId: "cot_1", messageId: "om_cot_1" }), 60)),
+      async resolveThreadId() {
+        return undefined;
+      },
+      async update() {},
+      async complete(_ref, reason) {
+        completeReason = reason;
+      },
+    };
+    const { acked } = await runTurn({ cotClient, cotBubbleCreateBudgetMs: 20 });
+    expect(acked).toEqual(["om_msg"]);
+    // The turn is long done; wait for the late create + finally finalize.
+    for (let i = 0; i < 100 && completeReason === undefined; i++) {
+      await new Promise((r) => setTimeout(r, 10));
+    }
+    expect(completeReason).toBe("done");
+  });
+
+  it("anti-orphan: a late-adopted bubble is finalized as error on a failed turn", async () => {
+    let completeReason: string | undefined;
+    const cotClient: OutboundCotClient = {
+      create: () =>
+        new Promise((resolve) => setTimeout(() => resolve({ cotId: "cot_1", messageId: "om_cot_1" }), 60)),
+      async resolveThreadId() {
+        return undefined;
+      },
+      async update() {},
+      async complete(_ref, reason) {
+        completeReason = reason;
+      },
+    };
+    const { unhandled } = await runTurn({ cotClient, cotBubbleCreateBudgetMs: 20, errorTurn: true });
+    expect(unhandled).toEqual(["om_msg"]); // failed turn released as unhandled
+    for (let i = 0; i < 100 && completeReason === undefined; i++) {
+      await new Promise((r) => setTimeout(r, 10));
+    }
+    expect(completeReason).toBe("error");
   });
 });
 

--- a/src/bridge/handler.test.ts
+++ b/src/bridge/handler.test.ts
@@ -1171,6 +1171,10 @@ describe("handleOne — thin-channel finalize", () => {
         name: "Frontend",
         turn_taking_limit: 10,
         backend: "claude",
+        // Opt into the in-card panel (default is now "bubble") so this test
+        // still exercises the failure-path panel title.
+        cot: "brief",
+        cotSurface: "card",
         response_surface_prototype: {
           enabled: true,
           allowed_chats: [],

--- a/src/bridge/handler.test.ts
+++ b/src/bridge/handler.test.ts
@@ -17,6 +17,7 @@ import { derivePostIdempotencyKey, digestPostContent } from "../lark/idempotency
 import type { OutboundPostClient } from "../lark/outboundPostClient.js";
 import type { OutboundCardKitClient } from "../lark/channelCardKitClient.js";
 import { CardKitReplyConversionError } from "../lark/channelCardKitClient.js";
+import type { OutboundCotClient } from "../lark/channelCotClient.js";
 import type { PerfSample } from "./perfLog.js";
 
 // ---------------------------------------------------------------------------
@@ -2977,6 +2978,138 @@ describe("handleOne — thin-channel finalize", () => {
     expect(unhandled).toEqual(["om_msg"]);
     // And it must NOT be marked handled/seen (that would permanently bury it).
     expect(acked).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// COT bubble timeline ordering (bubble created before the answer card)
+// ---------------------------------------------------------------------------
+
+describe("handleOne — COT bubble ordering (before the card)", () => {
+  const READY_STATE = {
+    status: "ready",
+    last_message: "答案正文",
+    updated_at: "2026-07-05T10:00:00.000Z",
+  };
+
+  function bubbleBotConfig() {
+    return {
+      id: "frontend",
+      name: "Frontend",
+      turn_taking_limit: 10,
+      backend: "claude",
+      cot: "brief" as const,
+      cotSurface: "bubble" as const,
+      response_surface_prototype: {
+        enabled: true,
+        allowed_chats: [],
+        allowed_threads: ["om_msg"],
+        kill_switch: false,
+        post_outbound_enabled: false,
+        cardkit_streaming_enabled: true,
+        allow_agent_mentions: true,
+        denied_mention_open_ids: [],
+        allowed_mention_open_ids: [],
+      },
+    };
+  }
+
+  async function runTurn(opts: {
+    cotClient: OutboundCotClient;
+    cotBubbleCreateBudgetMs?: number;
+    onCardCreate?: () => void;
+  }) {
+    const threadId = "om_msg";
+    const wt = await seedWorktree(threadId);
+    await seedRepoCachePath();
+    const { client: cardKitClient, calls: cardKitCalls } = makeCardKitClient();
+    if (opts.onCardCreate) {
+      const orig = cardKitClient.createCardEntity.bind(cardKitClient);
+      cardKitClient.createCardEntity = async (card) => {
+        opts.onCardCreate!();
+        return orig(card);
+      };
+    }
+    runClaudeImpl = () => ({
+      events: (async function* () {
+        yield { type: "system_init", sessionId: "sess_order", raw: {} };
+        await writeFile(stateFileMod.stateFilePathOf(wt), JSON.stringify(READY_STATE, null, 2), "utf8");
+      })(),
+      done: Promise.resolve({ exitCode: 0, sessionId: "sess_order" }),
+      kill: () => {},
+    });
+    const { renderer } = makeCardRenderer();
+    const { store } = makeSessionStore();
+    const { client, acked } = makeClient(makeEvent());
+    const handler = new BridgeHandler({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      client: client as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      cardRenderer: renderer as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      sessionStore: store as any,
+      conventions: makeConventions(),
+      botConfig: bubbleBotConfig(),
+      cardKitClient,
+      cotClient: opts.cotClient,
+      cotBubbleCreateBudgetMs: opts.cotBubbleCreateBudgetMs,
+    });
+    await handler.run();
+    for (let i = 0; i < 200 && acked.length === 0; i++) {
+      await new Promise((r) => setTimeout(r, 10));
+    }
+    return { acked, cardKitCalls };
+  }
+
+  it("creates the COT bubble BEFORE sending the answer card", async () => {
+    const order: string[] = [];
+    const cotClient: OutboundCotClient = {
+      async create() {
+        order.push("cot_create");
+        return { cotId: "cot_1", messageId: "om_cot_1" };
+      },
+      async resolveThreadId() {
+        return undefined;
+      },
+      async update() {},
+      async complete() {},
+    };
+    const { acked } = await runTurn({ cotClient, onCardCreate: () => order.push("card_create") });
+    expect(acked).toEqual(["om_msg"]);
+    expect(order).toContain("cot_create");
+    expect(order).toContain("card_create");
+    expect(order.indexOf("cot_create")).toBeLessThan(order.indexOf("card_create"));
+  });
+
+  it("still sends the card when the COT bubble create throws (bypass rule)", async () => {
+    const cotClient: OutboundCotClient = {
+      async create() {
+        throw new Error("code=10002 bubble create rejected");
+      },
+      async resolveThreadId() {
+        return undefined;
+      },
+      async update() {},
+      async complete() {},
+    };
+    const { acked, cardKitCalls } = await runTurn({ cotClient });
+    expect(acked).toEqual(["om_msg"]);
+    expect(cardKitCalls.map((c) => c.kind)).toContain("createCard");
+  });
+
+  it("sends the card without waiting when the COT bubble create is slow (budget)", async () => {
+    // create never resolves; the budget must let the card proceed anyway.
+    const cotClient: OutboundCotClient = {
+      create: () => new Promise(() => {}),
+      async resolveThreadId() {
+        return undefined;
+      },
+      async update() {},
+      async complete() {},
+    };
+    const { acked, cardKitCalls } = await runTurn({ cotClient, cotBubbleCreateBudgetMs: 20 });
+    expect(acked).toEqual(["om_msg"]);
+    expect(cardKitCalls.map((c) => c.kind)).toContain("createCard");
   });
 });
 

--- a/src/bridge/handler.ts
+++ b/src/bridge/handler.ts
@@ -100,6 +100,14 @@ const DEFAULT_CARDKIT_RESPONSE_SURFACE_TIMEOUT_MS = 20 * 60 * 1000;
  */
 const DEFAULT_CARDKIT_IDLE_TIMEOUT_MS = 3 * 60 * 1000;
 
+/**
+ * Max time the COT bubble create may sit in front of the answer card's first
+ * frame. The bubble is created before the card (timeline ordering), but a slow
+ * create (hung GET / multi-tier create) must not delay the card — past this
+ * budget, the card is sent and the bubble handle is adopted in the background.
+ */
+const COT_BUBBLE_CREATE_BUDGET_MS = 3_000;
+
 function summarizeMentionPolicyRules(rules: string[]): string {
   const counts = new Map<string, number>();
   for (const rule of rules) {
@@ -577,6 +585,12 @@ export interface BridgeHandlerDeps {
    * duration. @default 3 * 60 * 1000 (3 min), overridable per bot.
    */
   responseSurfaceIdleTimeoutMs?: number;
+  /**
+   * Max ms the COT bubble create may precede the answer card (timeline
+   * ordering). Past this, the card is sent and the bubble handle is adopted in
+   * the background. @default COT_BUBBLE_CREATE_BUDGET_MS (3s). Test seam.
+   */
+  cotBubbleCreateBudgetMs?: number;
   /**
    * V2: fully-resolved peer bot list for this bot.
    * Pre-resolved by runV2Mode: each entry has the peer bot's open_id, name, description.
@@ -1146,6 +1160,57 @@ export class BridgeHandler {
           ? { detail: cotDetail as "brief" | "detailed" }
           : undefined;
 
+      // COT (思维链) bubble — created BEFORE the answer card so it lands FIRST
+      // in the timeline (competitor parity: reasoning bubble on top, answer
+      // below). Created ONCE per turn (before the retry loop, so a stale-session
+      // respawn never opens a second bubble). 方案 B: the bubble is the
+      // EXPERIMENTAL surface, only built for cotSurface="bubble" (the default
+      // "card" folds reasoning into the card panel via `cot` above).
+      //
+      // Bypass rule preserved: createCotProgressHandle never throws (a create
+      // failure returns a disabled no-op handle). To keep a SLOW bubble create
+      // off the card's critical path — worst case is a hung GET + two-tier
+      // create, each 8s-bounded — race it against a 3s budget: if it's slow,
+      // send the card now and adopt the bubble handle when it finally resolves.
+      // Events don't start until after spawn (well after the card), so a late
+      // handle still catches the run; a fast business reject (10002) is ms.
+      if (this.deps.cotClient && cotDetail !== "off" && cotSurface === "bubble") {
+        const bubbleCreate = createCotProgressHandle({
+          cotClient: this.deps.cotClient,
+          detail: cotDetail,
+          runId: messageId,
+          scope: threadId,
+          inputPreview: parsed.text,
+          target: {
+            chatId: parsed.chatId,
+            threadId:
+              typeof parsed.raw.thread_id === "string" && parsed.raw.thread_id
+                ? parsed.raw.thread_id
+                : undefined,
+            originMessageId: messageId,
+          },
+        });
+        const raced = await Promise.race([
+          bubbleCreate.then((handle) => ({ ready: true as const, handle })),
+          new Promise<{ ready: false }>((resolve) => {
+            const t = setTimeout(
+              () => resolve({ ready: false }),
+              this.deps.cotBubbleCreateBudgetMs ?? COT_BUBBLE_CREATE_BUDGET_MS,
+            );
+            t.unref?.();
+          }),
+        ]);
+        if (raced.ready) {
+          cotPublisher = raced.handle;
+        } else {
+          // Slow create — proceed to the card now; adopt the handle in the
+          // background once it resolves (never throws).
+          void bubbleCreate.then((handle) => {
+            cotPublisher = handle;
+          });
+        }
+      }
+
       // CardKit response surface: default main surface when the transport and
       // rollout gates are available. It streams bounded progress into a
       // thinking area during execution, then replaces the card entity with a
@@ -1591,37 +1656,6 @@ export class BridgeHandler {
         } catch (err) {
           console.warn("[bridge.handler] mtime fact computation failed (continuing):", err);
         }
-      }
-
-      // COT (思维链) bubble — a parallel side channel to the answer card,
-      // created ONCE per turn here (outside the retry loop, so a stale-session
-      // respawn never opens a second bubble). Best-effort in every respect:
-      // createCotProgressHandle never throws (a create failure returns a
-      // disabled no-op handle), and each handle()/finalize() below degrades
-      // silently. Only reasoning + tool activity flow here; the final answer
-      // stays exclusively on the card. Topic groups anchor on the omt_ thread
-      // id; other chats fall back to chat_id + the trigger message.
-      // 方案 B: the reasoning bubble is now the EXPERIMENTAL surface — only
-      // built when the bot opts into cotSurface="bubble". The default
-      // ("card") streams reasoning into the answer card's collapsible panel
-      // (wired into createCardKitProgressHandle above via `cot`), no bubble.
-      // `cotDetail`/`cotSurface` are resolved once above (shared with the panel).
-      if (this.deps.cotClient && cotDetail !== "off" && cotSurface === "bubble") {
-        cotPublisher = await createCotProgressHandle({
-          cotClient: this.deps.cotClient,
-          detail: cotDetail,
-          runId: messageId,
-          scope: threadId,
-          inputPreview: parsed.text,
-          target: {
-            chatId: parsed.chatId,
-            threadId:
-              typeof parsed.raw.thread_id === "string" && parsed.raw.thread_id
-                ? parsed.raw.thread_id
-                : undefined,
-            originMessageId: messageId,
-          },
-        });
       }
 
       // Step 4b–4f: spawn + stream + finalize, with one stale-session retry.

--- a/src/bridge/handler.ts
+++ b/src/bridge/handler.ts
@@ -952,6 +952,13 @@ export class BridgeHandler {
     // inside the try, fed every event, finalized on success/error. Always
     // best-effort; a disabled handle is a no-op (see src/bridge/cotProgress.ts).
     let cotPublisher: CotProgressHandle | undefined;
+    // The bubble-create promise itself (see the ordering block below). Held at
+    // function scope so the finally can guarantee a late-resolving handle —
+    // adopted in the BACKGROUND after the 3s budget — still gets finalized:
+    // without this a slow create + a trivial (fast) turn would leave the bubble
+    // orphaned (created + RUN_STARTED, but nobody ever completes it).
+    let bubbleCreate: Promise<CotProgressHandle> | undefined;
+    let cotTurnOutcome: "done" | "error" = "done";
     const settle = (ok: boolean): void => {
       if (settled) return;
       settled = true;
@@ -1175,7 +1182,7 @@ export class BridgeHandler {
       // Events don't start until after spawn (well after the card), so a late
       // handle still catches the run; a fast business reject (10002) is ms.
       if (this.deps.cotClient && cotDetail !== "off" && cotSurface === "bubble") {
-        const bubbleCreate = createCotProgressHandle({
+        bubbleCreate = createCotProgressHandle({
           cotClient: this.deps.cotClient,
           detail: cotDetail,
           runId: messageId,
@@ -1911,6 +1918,9 @@ export class BridgeHandler {
           // teardown delaying the card. finalize() is idempotent + never throws;
           // the finally's close() only cancels the throttle timer, so it stays
           // compatible with an in-flight finalize.
+          // Record the outcome for the finally's late-adoption finalize (a
+          // background-adopted bubble may not exist as cotPublisher yet here).
+          cotTurnOutcome = interruptedByIdle ? "error" : "done";
           if (cotPublisher) {
             void cotPublisher
               .finalize(
@@ -2425,6 +2435,7 @@ export class BridgeHandler {
       // markUnhandled self-heal — must not wait on a best-effort COT call.
       // finalize() is idempotent + never throws; the finally's close() only
       // cancels the throttle timer.
+      cotTurnOutcome = "error";
       if (cotPublisher) {
         void cotPublisher.finalize("error", { message: String(err) }).catch(() => {
           /* best-effort COT completion — never affects error teardown */
@@ -2533,6 +2544,16 @@ export class BridgeHandler {
       // turn escaped both (e.g. threw before finalize), close() at least stops
       // a dangling throttle timer. Never completes the bubble on its own.
       cotPublisher?.close();
+      // Anti-orphan for the background-adopted bubble: a create slower than the
+      // 3s budget resolves AFTER the turn ended, so cotPublisher was still
+      // undefined at both finalize sites (and above) — the bubble would be
+      // created (RUN_STARTED sent) but never completed. Attach an idempotent
+      // finalize to the create promise itself: an already-finalized (early-
+      // adopted) handle no-ops via its closed guard; a late one gets completed
+      // when it resolves. Never throws.
+      if (bubbleCreate) {
+        void bubbleCreate.then((handle) => handle.finalize(cotTurnOutcome).catch(() => {}));
+      }
       // Safety net for EVERY exit path of handleOne. The success site calls
       // settle(true) and the failure catch calls settle(false); both make
       // settled=true so this is a no-op for them. But if anything threw BEFORE

--- a/src/bridge/handler.ts
+++ b/src/bridge/handler.ts
@@ -1140,7 +1140,7 @@ export class BridgeHandler {
       // reasoning into the answer card's collapsible panel; "bubble" uses the
       // message_cot side channel.
       const cotDetail = this.deps.botConfig?.cot ?? "brief";
-      const cotSurface = this.deps.botConfig?.cotSurface ?? "card";
+      const cotSurface = this.deps.botConfig?.cotSurface ?? "bubble";
       const cotCardOption =
         cotDetail !== "off" && cotSurface === "card"
           ? { detail: cotDetail as "brief" | "detailed" }

--- a/src/cli/botsStore.test.ts
+++ b/src/cli/botsStore.test.ts
@@ -30,7 +30,7 @@ const sampleBot = (): BotConfig =>
     runtime: "legacy",
     backend: "claude",
     cot: "brief",
-    cotSurface: "card",
+    cotSurface: "bubble",
   }) as BotConfig;
 
 beforeEach(async () => {

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -636,7 +636,7 @@ async function runCreateBot(
     runtime: "agent_workspace",
     backend: basics.backend,
     cot: "brief",
-    cotSurface: "card",
+    cotSurface: "bubble",
     memory_file: memoryFile,
     ...(basics.gitlabTokenEnv ? { gitlab_token_env: basics.gitlabTokenEnv } : {}),
     ...(basics.gitName && basics.gitEmail

--- a/src/cli/commands/memory.test.ts
+++ b/src/cli/commands/memory.test.ts
@@ -48,7 +48,7 @@ const sampleBot = (id = "test-bot"): BotConfig =>
     runtime: "legacy",
     backend: "claude",
     cot: "brief",
-    cotSurface: "card",
+    cotSurface: "bubble",
   }) as BotConfig;
 
 /** Collected output lines (stdout / stderr) across a run. */

--- a/src/config/botLoader.test.ts
+++ b/src/config/botLoader.test.ts
@@ -662,6 +662,27 @@ runtime: agent_workspace
     expect(bots[0]?.runtime).toBe("agent_workspace");
   });
 
+  it("cot defaults to brief and cotSurface defaults to bubble (real-machine reversal 2026-07-05)", async () => {
+    await createBotsDir();
+    await writeYaml(
+      "cot-defaults.yaml",
+      `
+id: cot-defaults-bot
+name: COT Defaults Bot
+description: cot/cotSurface 未设时的默认值
+app_id: cli_cot_defaults
+app_secret_env: COT_DEFAULTS_SECRET
+bot_open_id: ou_cot_defaults
+`,
+    );
+
+    const bots = await loadBots(botsDir());
+    expect(bots).toHaveLength(1);
+    expect(bots[0]?.cot).toBe("brief");
+    // 方案 B 卡片形态真机体验差(collapsible_panel 客户端不渲染折叠) → 默认回退气泡。
+    expect(bots[0]?.cotSurface).toBe("bubble");
+  });
+
   // ---------------------------------------------------------------------------
   // Backward compat: git_token_env / gitlab_token_env field migration
   // ---------------------------------------------------------------------------

--- a/src/config/botLoader.ts
+++ b/src/config/botLoader.ts
@@ -340,15 +340,18 @@ export const BotConfigSchema = z.object({
   cot: z.enum(["off", "brief", "detailed"]).default("brief"),
 
   /**
-   * COT 展示形态(方案 B)。`cot` 管密度(off/brief/detailed),这个管落点:
-   * - "card"(默认):思考过程折叠进答案卡片里的 collapsible_panel(懒创建、
-   *   答案上方、finalize 时折叠)。话题群里也能用,是默认形态。
-   * - "bubble":走飞书原生 message_cot 思维链气泡(src/bridge/cotProgress.ts)。
-   *   保留为实验选项 —— 已知限制:话题内锚定不可用(气泡落群顶层),且本租户
-   *   thread 通道判死、chat 通道 PUT 偶发 400。
+   * COT 展示形态。`cot` 管密度(off/brief/detailed),这个管落点:
+   * - "bubble"(默认):走飞书原生 message_cot 思维链气泡(src/bridge/cotProgress.ts)——
+   *   客户端原生渲染(工具图标列表 + 可折叠头),真机体验最好。已知限制:话题内
+   *   锚定不可用(气泡落群顶层,本租户 thread 通道判死),收尾 bug 已在 main 修复。
+   * - "card":思考过程内嵌进答案卡片里的 collapsible_panel(懒创建、答案上方)。
+   *   ⚠️ 实验选项 —— 2026-07-05 真机实测:飞书客户端**不渲染 collapsible_panel 的
+   *   折叠交互**(API 全 code=0,但面板被拍平成普通文本、无折叠箭头、终态也不可折叠;
+   *   CardKit 无 GET 读回、只能真机人眼验)。故 card 形态目前仅作纯文本内嵌展示用,
+   *   体验不如气泡,不建议作默认。见 memory feishu-message-cot-api。
    * cot="off" 时本字段无意义(两种形态都不产出)。
    */
-  cotSurface: z.enum(["card", "bubble"]).default("card"),
+  cotSurface: z.enum(["card", "bubble"]).default("bubble"),
 
   /**
    * 话题 ↔ 飞书任务句柄(docs/task-handle.md,v2)。省略此字段不代表关闭,但也

--- a/src/web/onboardSession.ts
+++ b/src/web/onboardSession.ts
@@ -458,7 +458,7 @@ export async function createBotFromCreds(
     runtime: "agent_workspace",
     backend: form.backend && form.backend.trim() ? form.backend.trim() : "codex",
     cot: "brief",
-    cotSurface: "card",
+    cotSurface: "bubble",
     // Persist the Feishu avatar URL so the Web 管理面 can show an avatar before
     // the bridge writes status.json (pre-bridge / central roster). Best-effort:
     // only set when resolveBotIdentity returned a valid url.


### PR DESCRIPTION
## Why

Real-machine acceptance (2026-07-05) reversed the surface default. Feishu clients do **not** render `collapsible_panel`'s fold interaction inside a streaming CardKit card — the API returns `code=0` but the client flattens the panel to plain text (no fold arrow, not collapsible even when finalized). CardKit has no GET readback, so this could only surface on-device (exactly the gap flagged in PR #41). The native `message_cot` bubble renders better (tool-icon list + collapsible header), and its finalize bug is already fixed in `main`, so it returns as the default.

## Changes

1. **`cotSurface` default `card` → `bubble`.** `card` stays as an experimental, plain-text inline option; config doc + the handler's inline fallback updated, with the on-device observation recorded. New bot scaffolds (`init`, onboard) write `bubble`.
2. **Two card-mode presentation fixes** (for whoever opts into `card`):
   - A tool line and the following reasoning no longer run together (`🔧 shell` + `Considering…` → separate lines).
   - Consecutive same-name tool calls collapse into `🔧 shell ×N` (brief tier) instead of stacking N identical lines; a different tool name breaks the run.

## Tests

`cotSurface` default = bubble; tool/reasoning line separation; `×N` merge + different-tool-breaks-run. `pnpm typecheck` / `pnpm test` (1375) / `pnpm build` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)