### PR TITLE
fix(cot): first-turn ordering — card before bubble for a new topic

### DIFF
--- a/src/bridge/handler.test.ts
+++ b/src/bridge/handler.test.ts
@@ -3019,6 +3019,8 @@ describe("handleOne — COT bubble ordering (before the card)", () => {
     cotBubbleCreateBudgetMs?: number;
     onCardCreate?: () => void;
     errorTurn?: boolean;
+    /** true → the topic already exists (isNewThread=false → bubble before card). */
+    existingTopic?: boolean;
   }) {
     const threadId = "om_msg";
     const wt = await seedWorktree(threadId);
@@ -3045,6 +3047,11 @@ describe("handleOne — COT bubble ordering (before the card)", () => {
     });
     const { renderer } = makeCardRenderer();
     const { store } = makeSessionStore();
+    if (opts.existingTopic) {
+      // Non-empty get() → existing = truthy → isNewThread=false → bubble first.
+      store.get = (() =>
+        ({ threadId, sessionId: "prev", lastActiveTs: 0 })) as unknown as typeof store.get;
+    }
     const { client, acked, unhandled } = makeClient(makeEvent());
     const handler = new BridgeHandler({
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -3066,7 +3073,7 @@ describe("handleOne — COT bubble ordering (before the card)", () => {
     return { acked, unhandled, cardKitCalls };
   }
 
-  it("creates the COT bubble BEFORE sending the answer card", async () => {
+  it("existing topic: creates the COT bubble BEFORE the answer card (timeline order)", async () => {
     const order: string[] = [];
     const cotClient: OutboundCotClient = {
       async create() {
@@ -3079,11 +3086,41 @@ describe("handleOne — COT bubble ordering (before the card)", () => {
       async update() {},
       async complete() {},
     };
-    const { acked } = await runTurn({ cotClient, onCardCreate: () => order.push("card_create") });
+    const { acked } = await runTurn({
+      cotClient,
+      existingTopic: true,
+      onCardCreate: () => order.push("card_create"),
+    });
     expect(acked).toEqual(["om_msg"]);
     expect(order).toContain("cot_create");
     expect(order).toContain("card_create");
     expect(order.indexOf("cot_create")).toBeLessThan(order.indexOf("card_create"));
+  });
+
+  it("new topic (first turn): sends the card BEFORE creating the bubble (so it anchors in the topic)", async () => {
+    // The card's reply creates the topic; the bubble must be created AFTER that,
+    // or it lands outside the not-yet-existing topic (real-machine bug).
+    const order: string[] = [];
+    const cotClient: OutboundCotClient = {
+      async create() {
+        order.push("cot_create");
+        return { cotId: "cot_1", messageId: "om_cot_1" };
+      },
+      async resolveThreadId() {
+        return undefined;
+      },
+      async update() {},
+      async complete() {},
+    };
+    const { acked } = await runTurn({
+      cotClient,
+      existingTopic: false, // new thread
+      onCardCreate: () => order.push("card_create"),
+    });
+    expect(acked).toEqual(["om_msg"]);
+    expect(order).toContain("cot_create");
+    expect(order).toContain("card_create");
+    expect(order.indexOf("card_create")).toBeLessThan(order.indexOf("cot_create"));
   });
 
   it("still sends the card when the COT bubble create throws (bypass rule)", async () => {
@@ -3136,7 +3173,9 @@ describe("handleOne — COT bubble ordering (before the card)", () => {
         completeReason = reason;
       },
     };
-    const { acked } = await runTurn({ cotClient, cotBubbleCreateBudgetMs: 20 });
+    // existingTopic → the (slow) create runs BEFORE the card, exercising the
+    // pre-card ordering's anti-orphan path.
+    const { acked } = await runTurn({ cotClient, cotBubbleCreateBudgetMs: 20, existingTopic: true });
     expect(acked).toEqual(["om_msg"]);
     // The turn is long done; wait for the late create + finally finalize.
     for (let i = 0; i < 100 && completeReason === undefined; i++) {
@@ -3145,7 +3184,7 @@ describe("handleOne — COT bubble ordering (before the card)", () => {
     expect(completeReason).toBe("done");
   });
 
-  it("anti-orphan: a late-adopted bubble is finalized as error on a failed turn", async () => {
+  it("anti-orphan: a late-adopted bubble is finalized as error on a failed turn (new topic, post-card)", async () => {
     let completeReason: string | undefined;
     const cotClient: OutboundCotClient = {
       create: () =>

--- a/src/bridge/handler.ts
+++ b/src/bridge/handler.ts
@@ -1167,21 +1167,29 @@ export class BridgeHandler {
           ? { detail: cotDetail as "brief" | "detailed" }
           : undefined;
 
-      // COT (思维链) bubble — created BEFORE the answer card so it lands FIRST
-      // in the timeline (competitor parity: reasoning bubble on top, answer
-      // below). Created ONCE per turn (before the retry loop, so a stale-session
-      // respawn never opens a second bubble). 方案 B: the bubble is the
-      // EXPERIMENTAL surface, only built for cotSurface="bubble" (the default
-      // "card" folds reasoning into the card panel via `cot` above).
-      //
-      // Bypass rule preserved: createCotProgressHandle never throws (a create
-      // failure returns a disabled no-op handle). To keep a SLOW bubble create
-      // off the card's critical path — worst case is a hung GET + two-tier
-      // create, each 8s-bounded — race it against a 3s budget: if it's slow,
-      // send the card now and adopt the bubble handle when it finally resolves.
-      // Events don't start until after spawn (well after the card), so a late
-      // handle still catches the run; a fast business reject (10002) is ms.
-      if (this.deps.cotClient && cotDetail !== "off" && cotSurface === "bubble") {
+      // COT (思维链) bubble — 方案 B experimental surface (cotSurface="bubble";
+      // the default "card" folds reasoning into the panel via `cot` above).
+      // Extracted to a closure because its position relative to the answer card
+      // depends on whether this is the FIRST turn of a NEW topic:
+      //   - existing topic (later turns): create the bubble BEFORE the card so
+      //     the reasoning bubble lands first in the timeline (competitor parity).
+      //   - new topic (first @): the Feishu topic does not exist until the
+      //     card's reply CREATES it — a bubble made now would anchor to the bare
+      //     group message and land OUTSIDE the topic (real-machine bug). So for
+      //     a new topic we DEFER the bubble to after the card; by then the
+      //     trigger message is inside the topic and the bubble anchors like
+      //     every later turn. A first-turn bubble slightly below the card is the
+      //     correct trade here (users want "bubble inside the topic" over "on top").
+      // Created ONCE per turn (before the retry loop). Bypass rule preserved:
+      // createCotProgressHandle never throws. To keep a SLOW create off the
+      // card's critical path (worst case = hung GET + two-tier create, each
+      // 8s-bounded), race a 3s budget — past it, proceed and adopt the handle in
+      // the background (the finally's anti-orphan finalize completes a late
+      // handle). This holds for BOTH orderings (a first-turn, post-card create
+      // can be slow/fail too).
+      const createCotBubble = async (): Promise<void> => {
+        if (!(this.deps.cotClient && cotDetail !== "off" && cotSurface === "bubble")) return;
+        if (bubbleCreate) return; // once per turn
         bubbleCreate = createCotProgressHandle({
           cotClient: this.deps.cotClient,
           detail: cotDetail,
@@ -1210,13 +1218,17 @@ export class BridgeHandler {
         if (raced.ready) {
           cotPublisher = raced.handle;
         } else {
-          // Slow create — proceed to the card now; adopt the handle in the
-          // background once it resolves (never throws).
+          // Slow create — proceed now; adopt the handle in the background once
+          // it resolves (never throws; the finally guarantees it's finalized).
           void bubbleCreate.then((handle) => {
             cotPublisher = handle;
           });
         }
-      }
+      };
+
+      // Existing topic → bubble BEFORE the card (timeline order). New topic
+      // (first turn) is deferred to AFTER the card (see closure + call below).
+      if (!isNewThread) await createCotBubble();
 
       // CardKit response surface: default main surface when the transport and
       // rollout gates are available. It streams bounded progress into a
@@ -1664,6 +1676,13 @@ export class BridgeHandler {
           console.warn("[bridge.handler] mtime fact computation failed (continuing):", err);
         }
       }
+
+      // New topic (first turn): NOW create the bubble — the card's reply above
+      // has created the Feishu topic, so the trigger message is inside it and
+      // the bubble anchors into the topic (same as every later turn) instead of
+      // landing at the group top level. No-op for existing topics (already
+      // created before the card) and for cot="off"/cotSurface="card".
+      if (isNewThread) await createCotBubble();
 
       // Step 4b–4f: spawn + stream + finalize, with one stale-session retry.
       // `currentExisting` may be reset to undefined on retry (ghost session cleared).


### PR DESCRIPTION
## Why

Real-machine feedback (final surface deployed): on the **first @ that creates a new topic**, the COT bubble landed **outside** the topic (a plain group top-level reply); the topic was only created afterward by the card's reply. Later turns in an existing topic anchor fine.

Root cause: a Feishu topic is created only when the first reply lands in it. PR #42 moved the bubble create *before* the card for timeline ordering — but on a first turn the topic doesn't exist yet, so the bubble anchors to the bare group message and lands outside the (not-yet-created) topic.

## Fix

Order the bubble create by `is_new_thread`:
- **Existing topic** (later turns): bubble **before** the card — timeline order, unchanged.
- **New topic** (first turn): defer the bubble to **after** the card. The card's reply creates the topic, so by then the trigger message is inside it and the bubble anchors like every later turn. A first-turn bubble slightly below the card is the correct trade under this platform constraint (users want "bubble inside the topic" over "bubble on top").

The create + 3s-budget + background-adopt logic is extracted into a `createCotBubble()` closure called at one of the two points; the `finally`'s anti-orphan finalize (from #42) holds for both orderings.

## Tests

Existing topic → cot create before card; new topic → card before cot create; card still sends when the bubble create throws; anti-orphan covered under **both** orderings (pre-card done path, post-card error path). `pnpm typecheck` / `pnpm test` (1381) / `pnpm build` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)