### PR TITLE
fix(cot): anchor the first-turn bubble on the answer card message

### DIFF
--- a/src/bridge/cotProgress.ts
+++ b/src/bridge/cotProgress.ts
@@ -261,6 +261,9 @@ class LiveCotProgressHandle implements CotProgressHandle {
           `cotId=${ref.cotId}`,
           `channel=${attempt.threadId ? "thread" : "chat_id"}`,
           `messageId=${ref.messageId}`,
+          // origin decides in-topic vs group-top anchoring (see handler) — log it
+          // so a future anchoring failure is diagnosable from the create line.
+          `origin=${attempt.originMessageId ?? "none"}`,
         );
         return ref;
       } catch (err) {

--- a/src/bridge/handler.test.ts
+++ b/src/bridge/handler.test.ts
@@ -3021,11 +3021,15 @@ describe("handleOne — COT bubble ordering (before the card)", () => {
     errorTurn?: boolean;
     /** true → the topic already exists (isNewThread=false → bubble before card). */
     existingTopic?: boolean;
+    /** true → both card surfaces fail so no card message id exists (fallback path). */
+    noCard?: boolean;
   }) {
     const threadId = "om_msg";
     const wt = await seedWorktree(threadId);
     await seedRepoCachePath();
-    const { client: cardKitClient, calls: cardKitCalls } = makeCardKitClient();
+    const { client: cardKitClient, calls: cardKitCalls } = makeCardKitClient(
+      opts.noCard ? { failCreate: true } : {},
+    );
     if (opts.onCardCreate) {
       const orig = cardKitClient.createCardEntity.bind(cardKitClient);
       cardKitClient.createCardEntity = async (card) => {
@@ -3045,7 +3049,7 @@ describe("handleOne — COT bubble ordering (before the card)", () => {
         : Promise.resolve({ exitCode: 0, sessionId: "sess_order" }),
       kill: () => {},
     });
-    const { renderer } = makeCardRenderer();
+    const { renderer } = makeCardRenderer(opts.noCard ? { failStart: true } : {});
     const { store } = makeSessionStore();
     if (opts.existingTopic) {
       // Non-empty get() → existing = truthy → isNewThread=false → bubble first.
@@ -3121,6 +3125,66 @@ describe("handleOne — COT bubble ordering (before the card)", () => {
     expect(order).toContain("cot_create");
     expect(order).toContain("card_create");
     expect(order.indexOf("card_create")).toBeLessThan(order.indexOf("cot_create"));
+  });
+
+  it("new topic: anchors the bubble on the answer CARD message (so it lands in the topic)", async () => {
+    // The trigger @ is the topic root (pos=-1) → anchoring on it lands the
+    // bubble at the group top level. The card (reply_in_thread, pos=0) is the
+    // correct in-topic anchor, so origin must be the card message id.
+    let createdOrigin: string | undefined;
+    const cotClient: OutboundCotClient = {
+      async create(target) {
+        createdOrigin = target.originMessageId;
+        return { cotId: "cot_1", messageId: "om_cot_1" };
+      },
+      async resolveThreadId() {
+        return undefined;
+      },
+      async update() {},
+      async complete() {},
+    };
+    const { acked } = await runTurn({ cotClient, existingTopic: false });
+    expect(acked).toEqual(["om_msg"]);
+    // Fake replyCardEntity returns "om_cardkit"; the trigger message is "om_msg".
+    expect(createdOrigin).toBe("om_cardkit");
+    expect(createdOrigin).not.toBe("om_msg");
+  });
+
+  it("new topic: falls back to the trigger message when no card id is available", async () => {
+    let createdOrigin: string | undefined;
+    const cotClient: OutboundCotClient = {
+      async create(target) {
+        createdOrigin = target.originMessageId;
+        return { cotId: "cot_1", messageId: "om_cot_1" };
+      },
+      async resolveThreadId() {
+        return undefined;
+      },
+      async update() {},
+      async complete() {},
+    };
+    // noCard → both cardkit create and legacy card start fail → no card message id.
+    // The bubble create still runs (post-card) and falls back to the trigger id.
+    await runTurn({ cotClient, existingTopic: false, noCard: true });
+    expect(createdOrigin).toBe("om_msg");
+  });
+
+  it("existing topic: anchors the bubble on the trigger message (unchanged)", async () => {
+    let createdOrigin: string | undefined;
+    const cotClient: OutboundCotClient = {
+      async create(target) {
+        createdOrigin = target.originMessageId;
+        return { cotId: "cot_1", messageId: "om_cot_1" };
+      },
+      async resolveThreadId() {
+        return undefined;
+      },
+      async update() {},
+      async complete() {},
+    };
+    const { acked } = await runTurn({ cotClient, existingTopic: true });
+    expect(acked).toEqual(["om_msg"]);
+    expect(createdOrigin).toBe("om_msg"); // the in-topic follow-up, not the card
   });
 
   it("still sends the card when the COT bubble create throws (bypass rule)", async () => {

--- a/src/bridge/handler.ts
+++ b/src/bridge/handler.ts
@@ -1187,7 +1187,13 @@ export class BridgeHandler {
       // the background (the finally's anti-orphan finalize completes a late
       // handle). This holds for BOTH orderings (a first-turn, post-card create
       // can be slow/fail too).
-      const createCotBubble = async (): Promise<void> => {
+      // `originMessageId` is the message_cot anchor. Its POSITION in the topic
+      // decides where the bubble lands (control-var experiment, cot-write-probe
+      // §F/F2): origin = the topic ROOT (首楼, pos=-1) → the bubble quote-replies
+      // at the GROUP top level (thread_id=None); origin = an IN-topic message
+      // (pos≥0) → the bubble inherits its thread and lands INSIDE the topic. So
+      // callers pass an in-topic message id whenever they have one.
+      const createCotBubble = async (originMessageId: string): Promise<void> => {
         if (!(this.deps.cotClient && cotDetail !== "off" && cotSurface === "bubble")) return;
         if (bubbleCreate) return; // once per turn
         bubbleCreate = createCotProgressHandle({
@@ -1202,7 +1208,7 @@ export class BridgeHandler {
               typeof parsed.raw.thread_id === "string" && parsed.raw.thread_id
                 ? parsed.raw.thread_id
                 : undefined,
-            originMessageId: messageId,
+            originMessageId,
           },
         });
         const raced = await Promise.race([
@@ -1226,9 +1232,10 @@ export class BridgeHandler {
         }
       };
 
-      // Existing topic → bubble BEFORE the card (timeline order). New topic
-      // (first turn) is deferred to AFTER the card (see closure + call below).
-      if (!isNewThread) await createCotBubble();
+      // Existing topic → bubble BEFORE the card, anchored on the TRIGGER message
+      // — a user follow-up inside an existing topic is itself an in-topic
+      // message (pos≥0), so the bubble lands in the topic (verified in prod).
+      if (!isNewThread) await createCotBubble(messageId);
 
       // CardKit response surface: default main surface when the transport and
       // rollout gates are available. It streams bounded progress into a
@@ -1677,12 +1684,18 @@ export class BridgeHandler {
         }
       }
 
-      // New topic (first turn): NOW create the bubble — the card's reply above
-      // has created the Feishu topic, so the trigger message is inside it and
-      // the bubble anchors into the topic (same as every later turn) instead of
-      // landing at the group top level. No-op for existing topics (already
-      // created before the card) and for cot="off"/cotSurface="card".
-      if (isNewThread) await createCotBubble();
+      // New topic (first turn): NOW create the bubble, anchored on the ANSWER
+      // CARD's message. The trigger @ is the topic root (pos=-1) — anchoring on
+      // it quote-replies at the group top level (cot-write-probe §F). The card
+      // we just sent replied reply_in_thread, so it is an in-topic message
+      // (pos=0) whose thread the bubble inherits → the bubble lands INSIDE the
+      // topic (probe §F2). Fall back to the trigger message if no card id is
+      // available (both surfaces failed) — origin=首楼 lands at the top level
+      // but is still usable; never block the turn.
+      if (isNewThread) {
+        const anchorMessageId = cardKitProgress?.messageId ?? card?.messageId ?? messageId;
+        await createCotBubble(anchorMessageId);
+      }
 
       // Step 4b–4f: spawn + stream + finalize, with one stale-session retry.
       // `currentExisting` may be reset to undefined on retry (ghost session cleared).


### PR DESCRIPTION
## Why

Control-variable experiment (`cot-write-probe.md` §F/F2) pinned the message_cot anchoring mechanism: a `chat_id` + `origin_message_id` bubble lands **inside the topic iff `origin` points at an in-topic message** (`pos ≥ 0`). Pointing at the topic **root** (首楼, `pos = -1`) makes it a quote-reply at the **group top level** (`thread_id = None`).

The first-turn trigger @ *is* the topic root, so #43's re-ordering (card before bubble) alone still anchored the first-turn bubble outside the topic — the bubble's `origin` was still the trigger message.

## Fix

On the new-topic (post-card) path, pass the **just-sent answer card's message id** as `origin`. The card replied `reply_in_thread`, so it is an in-topic `pos = 0` message; the bubble inherits its thread and lands inside the topic (probe §F2).

- Fall back to the trigger message id when no card id is available (both surfaces failed) — group top level but usable; never blocks the turn.
- Existing-topic path unchanged (the trigger follow-up is itself in-topic, verified in prod).
- Bonus: `origin` is now logged on create success (this round's debugging was hampered by its absence).

## Tests

New topic → `origin` = card message id (not the trigger); fallback to trigger when no card id; existing topic → `origin` unchanged. `pnpm typecheck` / `pnpm test` (1384) / `pnpm build` all green.

## Acceptance (post-deploy)

`GET /im/v1/messages/{first-turn bubble id}` → `thread_id == omt_*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)