### PR TITLE
docs(cot): document cot + cotSurface bot config

### DIFF
--- a/bots-examples/dev-bot.yaml
+++ b/bots-examples/dev-bot.yaml
@@ -54,6 +54,25 @@ runtime: agent_workspace
 # Switch to "claude" to use local Claude Code instead.
 backend: codex
 
+# Chain-of-thought (COT) display — surface the agent's thinking + tool activity
+# while it works, so the user isn't left staring at a bare "working…" card.
+#   off       no thinking shown, no extra message (pick this if you find the
+#             extra message noisy).
+#   brief     (default) thinking text + tool names.
+#   detailed  also shows tool arguments + truncated tool results.
+cot: brief
+
+# Where the thinking is shown:
+#   bubble    (default) Feishu's native, collapsible chain-of-thought bubble.
+#   card      experimental — folded into the answer card. NOTE: Feishu clients
+#             currently render the card panel as plain text (no collapse), so
+#             "bubble" is recommended.
+# Behavior: the answer always lands on its own card/message (never only in the
+# bubble). On the FIRST turn of a NEW topic the bubble appears just AFTER the
+# card (a platform anchoring constraint); in every other case the thinking
+# shows first. Any COT failure degrades silently and never affects the answer.
+cotSurface: bubble
+
 # L2 Agent Memory (relative to the bots/ directory at runtime).
 memory_file: dev-bot.memory.md
 

--- a/bots-examples/knowledge-bot.yaml
+++ b/bots-examples/knowledge-bot.yaml
@@ -63,6 +63,25 @@ runtime: agent_workspace
 # "claude" = local Claude Code (reads ~/.claude/.credentials.json).
 backend: claude
 
+# Chain-of-thought (COT) display — surface the agent's thinking + tool activity
+# while it works, so the user isn't left staring at a bare "working…" card.
+#   off       no thinking shown, no extra message (pick this if you find the
+#             extra message noisy).
+#   brief     (default) thinking text + tool names.
+#   detailed  also shows tool arguments + truncated tool results.
+cot: brief
+
+# Where the thinking is shown:
+#   bubble    (default) Feishu's native, collapsible chain-of-thought bubble.
+#   card      experimental — folded into the answer card. NOTE: Feishu clients
+#             currently render the card panel as plain text (no collapse), so
+#             "bubble" is recommended.
+# Behavior: the answer always lands on its own card/message (never only in the
+# bubble). On the FIRST turn of a NEW topic the bubble appears just AFTER the
+# card (a platform anchoring constraint); in every other case the thinking
+# shows first. Any COT failure degrades silently and never affects the answer.
+cotSurface: bubble
+
 # L2 Agent Memory file (relative to the bots/ directory at runtime).
 # Loaded at startup and injected as <agent-memory> role preamble.
 # Keep it thin: WHO the bot is + what it must NOT do.


### PR DESCRIPTION
## What

Adds the two COT-display bot-config fields to the adopter-facing example configs (`bots-examples/dev-bot.yaml`, `bots-examples/knowledge-bot.yaml` — the templates the README points to under "Bot config + memory templates"):

- **`cot: off | brief | detailed`** (default `brief`) — thinking-display density. `off` fully disables it (no bubble, no extra message) for users who find the extra message noisy.
- **`cotSurface: bubble | card`** (default `bubble`) — `bubble` uses Feishu's native collapsible chain-of-thought bubble; `card` is experimental (noted: Feishu clients currently render the card panel as plain text, no collapse).

Each field is documented inline in the existing yaml comment style, plus a one-line behavior note: the answer always lands on its own card/message; on the first turn of a new topic the bubble appears just after the card (platform anchoring constraint), otherwise thinking shows first; any COT failure degrades silently and never affects the answer.

Docs-only. `pnpm test` (1384) / `pnpm build` / `pnpm check:links` all green; example yamls parse and validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)