### PR TITLE
fix(tasklist-init): make adopt reachable + unify 404 + accurate wording (BL-32)

### DIFF
--- a/src/cli/commands/tasklistInit.test.ts
+++ b/src/cli/commands/tasklistInit.test.ts
@@ -47,6 +47,8 @@ let mockedAutoResolvedOwner: string | undefined;
 let currentMembers: FakeMember[];
 /** When true, the fake GET .../tasklists/:guid handler throws instead of responding. */
 let mockGetTasklistThrows: boolean;
+let mockAddMembersThrows404: boolean;
+let mockAddMembersThrowsScope: boolean;
 
 // v3.4 --adopt mode: controllable results for the mocked userTasklistOps.js functions.
 let mockedListUserTasklists: UserOpResult<UserTasklistSummary[]>;
@@ -97,6 +99,8 @@ beforeEach(async () => {
   capturedRequests = [];
   currentMembers = [];
   mockGetTasklistThrows = false;
+  mockAddMembersThrows404 = false;
+  mockAddMembersThrowsScope = false;
   mockedAutoResolvedOwner = undefined; // default: auto-detect finds nothing, same as no lark-cli user login
   // v3.4 --adopt mode defaults — individual tests override to exercise each branch.
   mockedListUserTasklists = { ok: true, data: [] };
@@ -114,6 +118,8 @@ beforeEach(async () => {
           return { data: { tasklist: { guid: "tl-created-1", members: currentMembers } } };
         }
         if (config.url.includes("/members") && config.method === "POST") {
+          if (mockAddMembersThrows404) throw new Error("404 page not found");
+          if (mockAddMembersThrowsScope) throw new Error("permission denied: missing task:tasklist:write");
           const data = config.data as { members?: FakeMember[] };
           for (const m of data.members ?? []) {
             if (!currentMembers.some((existing) => existing.id === m.id)) currentMembers.push(m);
@@ -133,7 +139,7 @@ beforeEach(async () => {
     resolveOwnerOpenId: () => mockedAutoResolvedOwner,
   }));
   vi.doMock("../userTasklistOps.js", () => ({
-    listUserTasklists: () => mockedListUserTasklists,
+    searchUserTasklists: () => mockedListUserTasklists,
     addTasklistMembersAsUser: (profile: string, tasklistGuid: string, members: unknown[]) => {
       capturedAddMembersAsUserCall = { profile, tasklistGuid, members };
       return mockedAddTasklistMembersAsUser;
@@ -328,6 +334,35 @@ describe("tasklist-init --team", () => {
 
       // Registry still points at the same pre-existing guid — untouched.
       await expect(readTeamTasklistGuid(resolveTaskTeamRegistryPath())).resolves.toBe("tl-pre-existing");
+    });
+
+    it("BL-32 #2: a 404 from add_members on the reuse path warns + continues (exit 0), not fatal", async () => {
+      await makeBot("bot-a", "cli_a", "BOT_A_SECRET");
+      const { claimTeamTasklistGuid, readTeamTasklistGuid } = await import("../../tasklist/teamRegistry.js");
+      const { resolveTaskTeamRegistryPath } = await import("../../config/paths.js");
+      await claimTeamTasklistGuid(resolveTaskTeamRegistryPath(), "tl-pre-existing");
+      mockAddMembersThrows404 = true; // app-type members endpoint 404s (bot already a member)
+
+      const { run } = await import("./tasklistInit.js");
+      const code = await run(makeCtx(), ["--team", "bot-a", "--owner", "ou_owner"]);
+      // Same best-effort posture as the bridge self-join — the reused list is fine.
+      expect(code).toBe(0);
+      expect(ui.warning).toHaveBeenCalled();
+      // Did NOT create a duplicate board on the way.
+      expect(capturedRequests.find((r) => r.url.endsWith("/tasklists") && r.method === "POST")).toBeUndefined();
+      await expect(readTeamTasklistGuid(resolveTaskTeamRegistryPath())).resolves.toBe("tl-pre-existing");
+    });
+
+    it("BL-32 #2: a NON-404 add_members failure on the reuse path still fails hard (exit 1)", async () => {
+      await makeBot("bot-a", "cli_a", "BOT_A_SECRET");
+      const { claimTeamTasklistGuid } = await import("../../tasklist/teamRegistry.js");
+      const { resolveTaskTeamRegistryPath } = await import("../../config/paths.js");
+      await claimTeamTasklistGuid(resolveTaskTeamRegistryPath(), "tl-pre-existing");
+      mockAddMembersThrowsScope = true; // a real scope failure (not a 404) must still surface
+
+      const { run } = await import("./tasklistInit.js");
+      const code = await run(makeCtx(), ["--team", "bot-a", "--owner", "ou_owner"]);
+      expect(code).toBe(1);
     });
 
     it("reports reused:true in JSON mode when reusing", async () => {
@@ -640,6 +675,36 @@ describe("tasklist-init auto-select adopt-vs-create (v3.4 north star, no explici
     const code = await run(makeCtx({ json: true }), ["--team", "bot-a"]);
     expect(code).toBe(0); // no hard failure — silent fallback, not the "list-failed" error
     expect(ui.emitJson).toHaveBeenCalledWith(expect.objectContaining({ ok: true, tasklistGuid: "tl-created-1" }));
+  });
+
+  it("BL-32 #4: LOUD warns (not a silent dim note) when the auto-select query FAILS before falling back", async () => {
+    // A failed adopt query that silently creates can accrete a duplicate board;
+    // the operator must be told (non-JSON mode).
+    await makeBot("bot-a", "cli_a", "BOT_A_SECRET");
+    mockedListUserTasklists = { ok: false, error: "need_user_authorization" };
+    mockedAutoResolvedOwner = "ou_owner1234567890";
+    const { run } = await import("./tasklistInit.js");
+    const code = await run(makeCtx(), ["--team", "bot-a"]); // non-JSON
+    expect(code).toBe(0);
+    expect(ui.warning).toHaveBeenCalled();
+    const warnedText = (ui.warning as unknown as { mock: { calls: unknown[][] } }).mock.calls
+      .map((c) => String(c[0]))
+      .join("\n");
+    expect(warnedText).toContain("重复");
+  });
+
+  it("does NOT loud-warn on the not-found path (a genuinely new team is expected)", async () => {
+    await makeBot("bot-a", "cli_a", "BOT_A_SECRET");
+    mockedListUserTasklists = { ok: true, data: [{ guid: "tl-other", name: "Some Other List" }] };
+    mockedAutoResolvedOwner = "ou_owner1234567890";
+    const { run } = await import("./tasklistInit.js");
+    const code = await run(makeCtx(), ["--team", "bot-a"]); // non-JSON
+    expect(code).toBe(0);
+    // not-found is expected for a new team → no scary duplicate warning.
+    const warnedText = (ui.warning as unknown as { mock: { calls: unknown[][] } }).mock.calls
+      .map((c) => String(c[0]))
+      .join("\n");
+    expect(warnedText).not.toContain("重复");
   });
 
   it("silently falls back to the create path when no same-named tasklist is visible", async () => {

--- a/src/cli/commands/tasklistInit.test.ts
+++ b/src/cli/commands/tasklistInit.test.ts
@@ -120,9 +120,26 @@ beforeEach(async () => {
           return { data: { tasklist: { guid: "tl-created-1", members: currentMembers } } };
         }
         if (config.url.includes("/members") && config.method === "POST") {
-          if (mockAddMembersThrows404) throw new Error("404 page not found");
-          if (mockAddMembersThrowsScope) throw new Error("permission denied: missing task:tasklist:write");
-          if (mockAddMembersThrowsDeleted) throw new Error("resource_not_exist: tasklist not found (1470404)");
+          // Throw axios-shaped errors so the REAL TaskListClient.wrapErr path
+          // constructs a realistic TaskApiError (status/code) — mirroring the
+          // real machine, where the members-endpoint gateway 404 body is plain
+          // text (no parseable code) and the message is axios's generic one.
+          if (mockAddMembersThrows404) {
+            const e = new Error("Request failed with status code 404");
+            (e as { response?: unknown }).response = { status: 404, data: "404 page not found" };
+            throw e;
+          }
+          if (mockAddMembersThrowsScope) {
+            const e = new Error("Request failed with status code 403");
+            (e as { response?: unknown }).response = { status: 403, data: { code: 1470403, msg: "no permission" } };
+            throw e;
+          }
+          if (mockAddMembersThrowsDeleted) {
+            // TOCTOU: reused guid deleted → business resource-not-exist WITH a code.
+            const e = new Error("Request failed with status code 404");
+            (e as { response?: unknown }).response = { status: 404, data: { code: 1470404, msg: "resource not exist" } };
+            throw e;
+          }
           const data = config.data as { members?: FakeMember[] };
           for (const m of data.members ?? []) {
             if (!currentMembers.some((existing) => existing.id === m.id)) currentMembers.push(m);

--- a/src/cli/commands/tasklistInit.test.ts
+++ b/src/cli/commands/tasklistInit.test.ts
@@ -49,6 +49,7 @@ let currentMembers: FakeMember[];
 let mockGetTasklistThrows: boolean;
 let mockAddMembersThrows404: boolean;
 let mockAddMembersThrowsScope: boolean;
+let mockAddMembersThrowsDeleted: boolean;
 
 // v3.4 --adopt mode: controllable results for the mocked userTasklistOps.js functions.
 let mockedListUserTasklists: UserOpResult<UserTasklistSummary[]>;
@@ -101,6 +102,7 @@ beforeEach(async () => {
   mockGetTasklistThrows = false;
   mockAddMembersThrows404 = false;
   mockAddMembersThrowsScope = false;
+  mockAddMembersThrowsDeleted = false;
   mockedAutoResolvedOwner = undefined; // default: auto-detect finds nothing, same as no lark-cli user login
   // v3.4 --adopt mode defaults — individual tests override to exercise each branch.
   mockedListUserTasklists = { ok: true, data: [] };
@@ -120,6 +122,7 @@ beforeEach(async () => {
         if (config.url.includes("/members") && config.method === "POST") {
           if (mockAddMembersThrows404) throw new Error("404 page not found");
           if (mockAddMembersThrowsScope) throw new Error("permission denied: missing task:tasklist:write");
+          if (mockAddMembersThrowsDeleted) throw new Error("resource_not_exist: tasklist not found (1470404)");
           const data = config.data as { members?: FakeMember[] };
           for (const m of data.members ?? []) {
             if (!currentMembers.some((existing) => existing.id === m.id)) currentMembers.push(m);
@@ -359,6 +362,21 @@ describe("tasklist-init --team", () => {
       const { resolveTaskTeamRegistryPath } = await import("../../config/paths.js");
       await claimTeamTasklistGuid(resolveTaskTeamRegistryPath(), "tl-pre-existing");
       mockAddMembersThrowsScope = true; // a real scope failure (not a 404) must still surface
+
+      const { run } = await import("./tasklistInit.js");
+      const code = await run(makeCtx(), ["--team", "bot-a", "--owner", "ou_owner"]);
+      expect(code).toBe(1);
+    });
+
+    it("BL-32 #2 (narrowed): a DELETED-tasklist 'not found' (TOCTOU, not the app-member 404) still fails hard", async () => {
+      // The narrowed isMembersEndpoint404 must NOT swallow a resource_not_exist /
+      // "tasklist not found" — that means the reused guid was deleted, a real
+      // error the operator needs to see, not the benign app-member endpoint 404.
+      await makeBot("bot-a", "cli_a", "BOT_A_SECRET");
+      const { claimTeamTasklistGuid } = await import("../../tasklist/teamRegistry.js");
+      const { resolveTaskTeamRegistryPath } = await import("../../config/paths.js");
+      await claimTeamTasklistGuid(resolveTaskTeamRegistryPath(), "tl-pre-existing");
+      mockAddMembersThrowsDeleted = true;
 
       const { run } = await import("./tasklistInit.js");
       const code = await run(makeCtx(), ["--team", "bot-a", "--owner", "ou_owner"]);

--- a/src/cli/commands/tasklistInit.test.ts
+++ b/src/cli/commands/tasklistInit.test.ts
@@ -653,72 +653,26 @@ describe("tasklist-init --adopt (v3.4, docs/task-handle.md §7)", () => {
   });
 });
 
-describe("tasklist-init auto-select adopt-vs-create (v3.4 north star, no explicit --adopt/--adopt-guid)", () => {
-  it("auto-adopts when the operator's own identity finds a same-named tasklist — no --owner needed", async () => {
+describe("tasklist-init zero-arg = CREATE by design (adopt is explicit-only, 2026-07 ownership decision)", () => {
+  it("CREATES a bot-app-owned board and does NOT auto-adopt, even when a same-named list is visible", async () => {
     await makeBot("bot-a", "cli_a", "BOT_A_SECRET");
-    mockedListUserTasklists = { ok: true, data: [{ guid: "tl-auto-adopted", name: "Agent Team" }] };
-    mockedGetUserTasklistMembers = { ok: true, data: [{ id: "cli_a", type: "app", role: "editor" }] };
-    const { run } = await import("./tasklistInit.js");
-    const code = await run(makeCtx({ json: true }), ["--team", "bot-a"]);
-    expect(code).toBe(0);
-    expect(capturedAddMembersAsUserCall?.tasklistGuid).toBe("tl-auto-adopted");
-    expect(ui.emitJson).toHaveBeenCalledWith(expect.objectContaining({ ok: true, mode: "adopt", tasklistGuid: "tl-auto-adopted" }));
-    // Never touched the SDK-based create/reuse path.
-    expect(capturedRequests.find((r) => r.url.endsWith("/tasklists"))).toBeUndefined();
-  });
-
-  it("silently falls back to the create path when the user-identity lookup fails (not logged in / missing scope)", async () => {
-    await makeBot("bot-a", "cli_a", "BOT_A_SECRET");
-    mockedListUserTasklists = { ok: false, error: "need_user_authorization" };
+    // A same-named board the operator could see — pre-decision this would have
+    // been auto-adopted. Now zero-arg must ignore it and CREATE (owner=bot app).
+    mockedListUserTasklists = { ok: true, data: [{ guid: "tl-visible", name: "Agent Team" }] };
     mockedAutoResolvedOwner = "ou_owner1234567890";
     const { run } = await import("./tasklistInit.js");
     const code = await run(makeCtx({ json: true }), ["--team", "bot-a"]);
-    expect(code).toBe(0); // no hard failure — silent fallback, not the "list-failed" error
+    expect(code).toBe(0);
+    // Went through the SDK create path, NOT the user-identity adopt path.
+    expect(capturedRequests.find((r) => r.url.endsWith("/tasklists") && r.method === "POST")).toBeDefined();
+    expect(capturedAddMembersAsUserCall).toBeUndefined(); // adopt's user-identity add never ran
     expect(ui.emitJson).toHaveBeenCalledWith(expect.objectContaining({ ok: true, tasklistGuid: "tl-created-1" }));
   });
 
-  it("BL-32 #4: LOUD warns (not a silent dim note) when the auto-select query FAILS before falling back", async () => {
-    // A failed adopt query that silently creates can accrete a duplicate board;
-    // the operator must be told (non-JSON mode).
+  it("CREATES even when MULTIPLE same-named lists are visible — no ambiguity failure (never queries)", async () => {
     await makeBot("bot-a", "cli_a", "BOT_A_SECRET");
-    mockedListUserTasklists = { ok: false, error: "need_user_authorization" };
-    mockedAutoResolvedOwner = "ou_owner1234567890";
-    const { run } = await import("./tasklistInit.js");
-    const code = await run(makeCtx(), ["--team", "bot-a"]); // non-JSON
-    expect(code).toBe(0);
-    expect(ui.warning).toHaveBeenCalled();
-    const warnedText = (ui.warning as unknown as { mock: { calls: unknown[][] } }).mock.calls
-      .map((c) => String(c[0]))
-      .join("\n");
-    expect(warnedText).toContain("重复");
-  });
-
-  it("does NOT loud-warn on the not-found path (a genuinely new team is expected)", async () => {
-    await makeBot("bot-a", "cli_a", "BOT_A_SECRET");
-    mockedListUserTasklists = { ok: true, data: [{ guid: "tl-other", name: "Some Other List" }] };
-    mockedAutoResolvedOwner = "ou_owner1234567890";
-    const { run } = await import("./tasklistInit.js");
-    const code = await run(makeCtx(), ["--team", "bot-a"]); // non-JSON
-    expect(code).toBe(0);
-    // not-found is expected for a new team → no scary duplicate warning.
-    const warnedText = (ui.warning as unknown as { mock: { calls: unknown[][] } }).mock.calls
-      .map((c) => String(c[0]))
-      .join("\n");
-    expect(warnedText).not.toContain("重复");
-  });
-
-  it("silently falls back to the create path when no same-named tasklist is visible", async () => {
-    await makeBot("bot-a", "cli_a", "BOT_A_SECRET");
-    mockedListUserTasklists = { ok: true, data: [{ guid: "tl-other", name: "Some Other List" }] };
-    mockedAutoResolvedOwner = "ou_owner1234567890";
-    const { run } = await import("./tasklistInit.js");
-    const code = await run(makeCtx({ json: true }), ["--team", "bot-a"]);
-    expect(code).toBe(0);
-    expect(ui.emitJson).toHaveBeenCalledWith(expect.objectContaining({ ok: true, tasklistGuid: "tl-created-1" }));
-  });
-
-  it("still hard-fails on a genuinely ambiguous same-named match, even with no explicit --adopt (never guesses)", async () => {
-    await makeBot("bot-a", "cli_a", "BOT_A_SECRET");
+    // Pre-decision this hard-failed as ambiguous; now zero-arg never queries, so
+    // it just creates.
     mockedListUserTasklists = {
       ok: true,
       data: [
@@ -726,11 +680,23 @@ describe("tasklist-init auto-select adopt-vs-create (v3.4 north star, no explici
         { guid: "tl-dup-2", name: "Agent Team" },
       ],
     };
+    mockedAutoResolvedOwner = "ou_owner1234567890";
     const { run } = await import("./tasklistInit.js");
-    const code = await run(makeCtx(), ["--team", "bot-a"]);
-    expect(code).toBe(1);
-    expect(ui.failure).toHaveBeenCalledWith(expect.stringContaining("--adopt-guid"));
-    // Never fell through to create — no POST to /tasklists.
-    expect(capturedRequests.find((r) => r.url.endsWith("/tasklists"))).toBeUndefined();
+    const code = await run(makeCtx({ json: true }), ["--team", "bot-a"]);
+    expect(code).toBe(0);
+    expect(ui.emitJson).toHaveBeenCalledWith(expect.objectContaining({ ok: true, tasklistGuid: "tl-created-1" }));
+  });
+
+  it("CREATES with no loud duplicate-warning (zero-arg has no adopt query to fail)", async () => {
+    await makeBot("bot-a", "cli_a", "BOT_A_SECRET");
+    mockedListUserTasklists = { ok: false, error: "should never be consulted in zero-arg" };
+    mockedAutoResolvedOwner = "ou_owner1234567890";
+    const { run } = await import("./tasklistInit.js");
+    const code = await run(makeCtx(), ["--team", "bot-a"]); // non-JSON
+    expect(code).toBe(0);
+    const warnedText = (ui.warning as unknown as { mock: { calls: unknown[][] } }).mock.calls
+      .map((c) => String(c[0]))
+      .join("\n");
+    expect(warnedText).not.toContain("重复"); // no duplicate scare — zero-arg doesn't query
   });
 });

--- a/src/cli/commands/tasklistInit.ts
+++ b/src/cli/commands/tasklistInit.ts
@@ -73,7 +73,12 @@
 
 import { Client as LarkSdkClient } from "@larksuiteoapi/node-sdk";
 import type { CliContext } from "../types.js";
-import { TaskListClient, type LarkTaskRequester, type TaskMember } from "../../tasklist/client.js";
+import {
+  TaskListClient,
+  TaskApiError,
+  type LarkTaskRequester,
+  type TaskMember,
+} from "../../tasklist/client.js";
 import { resolveTaskTeamRegistryPath } from "../../config/paths.js";
 import {
   claimTeamTasklistGuid,
@@ -389,7 +394,7 @@ export async function run(ctx: CliContext, args: string[]): Promise<number> {
       await taskClient.addTasklistMembers(tasklistGuid, members);
     } catch (err) {
       const errMsg = err instanceof Error ? err.message : String(err);
-      if (isMembersEndpoint404(errMsg)) {
+      if (isMembersEndpoint404(err)) {
         // Same 404 the bridge's self-join treats as best-effort continuing
         // (main.ts) — the app-type members endpoint 404s (app self-add isn't
         // supported there), but the bots are already members, so the reused
@@ -516,18 +521,26 @@ export async function run(ctx: CliContext, args: string[]): Promise<number> {
 }
 
 /**
- * True ONLY for the app-type members-endpoint's raw HTTP 404 — `POST
- * /tasklists/{guid}/members` responds "404 page not found" for an app self-add
- * (the bot is already a member). Deliberately narrow: a bare "not found" /
- * 不存在 / resource_not_exist is a DIFFERENT, API-level failure — e.g. the
- * reused tasklist guid was deleted out from under us (TOCTOU) — which must NOT
- * be swallowed as benign. So we key on the endpoint-not-found body string only,
- * not on any generic not-found marker. Message-based because TaskListClient
- * wraps the raw error before it reaches here; the call site guarantees this is
- * an addTasklistMembers failure.
+ * True ONLY for the app-type members-endpoint's raw gateway 404 — `POST
+ * /tasklists/{guid}/members` responds with a plain-text "404 page not found"
+ * body for an app self-add (the bot is already a member).
+ *
+ * STRUCTURAL, not message-based: on the real machine the gateway's body is a
+ * plain string, so TaskListClient.wrapErr can't parse a `bodyMsg` out of it and
+ * the wrapped message falls back to axios's generic "Request failed with status
+ * code 404" — a substring like "page not found" is NOT present there. So we key
+ * on the structured fields wrapErr DID capture: an HTTP 404 (`status===404`)
+ * with NO business error code (`code===undefined`, because the plain-text body
+ * has no `code`). A DELETED tasklist (TOCTOU on a reused guid) instead returns a
+ * business resource-not-exist error WITH a code (e.g. 1470404) — that keeps a
+ * code and so stays fatal, never swallowed. The message check is only a
+ * belt-and-braces fallback for a non-TaskApiError shape.
  */
-function isMembersEndpoint404(errMsg: string): boolean {
-  return /page not found/i.test(errMsg);
+function isMembersEndpoint404(err: unknown): boolean {
+  if (err instanceof TaskApiError) {
+    return err.status === 404 && err.code === undefined;
+  }
+  return /page not found/i.test(err instanceof Error ? err.message : String(err));
 }
 
 /** Discriminated result of resolveAdoptTarget — see its doc comment. */

--- a/src/cli/commands/tasklistInit.ts
+++ b/src/cli/commands/tasklistInit.ts
@@ -516,13 +516,18 @@ export async function run(ctx: CliContext, args: string[]): Promise<number> {
 }
 
 /**
- * True for the app-type members-endpoint 404 (`POST /tasklists/{guid}/members`
- * returns "404 page not found" for an app self-add — the bot is already a
- * member). Message-based because TaskListClient wraps the raw error before it
- * reaches here. Matches the bridge's best-effort treatment of the same failure.
+ * True ONLY for the app-type members-endpoint's raw HTTP 404 — `POST
+ * /tasklists/{guid}/members` responds "404 page not found" for an app self-add
+ * (the bot is already a member). Deliberately narrow: a bare "not found" /
+ * 不存在 / resource_not_exist is a DIFFERENT, API-level failure — e.g. the
+ * reused tasklist guid was deleted out from under us (TOCTOU) — which must NOT
+ * be swallowed as benign. So we key on the endpoint-not-found body string only,
+ * not on any generic not-found marker. Message-based because TaskListClient
+ * wraps the raw error before it reaches here; the call site guarantees this is
+ * an addTasklistMembers failure.
  */
 function isMembersEndpoint404(errMsg: string): boolean {
-  return /\b404\b|page not found|not.?found|不存在|resource_not_exist/i.test(errMsg);
+  return /page not found/i.test(errMsg);
 }
 
 /** Discriminated result of resolveAdoptTarget — see its doc comment. */

--- a/src/cli/commands/tasklistInit.ts
+++ b/src/cli/commands/tasklistInit.ts
@@ -17,16 +17,14 @@
  *   - `--team` defaults to EVERY bot under `bots/` (ctx.botsStore.listBots())
  *     — no manual enumeration required. Only a truly bot-less machine fails.
  *   - `--name` defaults to "Agent Team".
- *   - The choice between **adopt** (operator already made a same-named
- *     tasklist via the Task Center UI — ownership is correct by
- *     construction) and **create** (fall back to a bot's app credentials) is
- *     itself automatic: try a by-name lookup under the operator's own
- *     lark-cli user identity first; a match → adopt it; no match or the
- *     lookup itself fails (not logged in, missing scope) → silently fall
- *     through to the existing create/reuse-registry path below. Multiple
- *     same-named matches is the ONE case that hard-fails even in
- *     auto-select mode — see resolveAdoptTarget's "ambiguous" branch —
- *     because guessing which board to adopt is unsafe to automate.
+ *   - Zero-arg CREATES a bot-app-owned board by default (ownership decision,
+ *     2026-07). **adopt** — taking over a tasklist the operator built
+ *     themselves in the Task Center, so THEY own it — is opt-in only, via
+ *     `--adopt "<name>"` / `--adopt-guid <guid>`. Auto-adopting by name was
+ *     removed: a company running multiple Larkway fleets would have the
+ *     second fleet silently adopt the first's same-named board. Explicit
+ *     adopt hard-fails loudly on any lookup problem (not logged in, missing
+ *     scope, no match, ambiguous) — never a silent create.
  *   - `--adopt "<name>"` / `--adopt-guid <guid>` / `--team` / `--owner` /
  *     `--force` all remain valid EXPLICIT overrides of the above.
  *
@@ -98,7 +96,7 @@ interface ParsedFlags {
   force: boolean;
   /** v3.4 --adopt "<清单名>": adopt a tasklist the operator already created themselves via the Task Center UI, instead of creating one via a bot's app credentials. Explicit — forces adopt mode even if lookup fails (no silent fallback to create). */
   adopt?: string;
-  /** v3.4: disambiguates the by-name lookup when multiple visible tasklists share the same name (in either explicit --adopt mode or the zero-arg auto-select path) — also usable alone to force adopt mode with a known guid, skipping the lookup entirely. */
+  /** --adopt-guid: disambiguates the by-name lookup when multiple visible tasklists share the same name in --adopt mode — also usable alone to enter (explicit) adopt mode with a known guid, skipping the lookup entirely. */
   adoptGuid?: string;
 }
 
@@ -146,33 +144,41 @@ const USAGE = `larkway tasklist-init [--team <bot1,bot2,…>] [--name <清单名
 帮助的 agent,第一步必然会跑 \`larkway tasklist-init --help\`(就是你正在看的这段),
 从这里就能学会怎么把本机所有已配置的 bot 都配成清单成员,不需要你再手动传任何参数。
 
-零参数三步 Quickstart:
-  1. (可选)先在飞书任务中心手动建一个清单,名字随便取,比如 "Agent Team"。
-  2. 跑:larkway tasklist-init
+零参数 Quickstart:
+  1. 跑:larkway tasklist-init
      —— 会自动:--team = 本机 bots/ 目录下全部已配置 bot;--name = "Agent Team";
-     用你的 lark-cli 用户身份按名字查一遍能看到的清单 —— 查到同名的就 adopt(把这些
-     bot 加为 editor);查不到(或没登录/缺 scope)就静默回退到旧的创建路径(用第一个
-     bot 的 app 身份新建一个清单,并自动把你加为 owner)。
-  3. 去飞书任务中心确认这个清单在你的列表里可见,之后右键话题消息选"转任务"即可。
+     用第一个 bot 的 app 身份**新建**一个清单(清单 owner = 该 bot app),并把你
+     加为 editor 成员(方便在任务中心看到并编辑)。零参数**不会**自动去认领同名清单。
+  2. 去飞书任务中心确认这个清单在你的列表里可见,之后右键话题消息选"转任务"即可。
+
+想让清单归**你自己**所有(而不是 bot app)?先在任务中心自己建一个,再用
+\`--adopt "<清单名>"\` 认领(见下)。多套 Larkway 部署时,给每套用 --name 改个不同
+名字做隔离,避免混用。
 
 以上全部是缺省行为,以下 flag 仅用于覆盖:
 
   --team <bot1,bot2,…>   显式指定要加入清单的 bot(默认 = 全部已配置 bot)
-  --name <清单名>          显式指定清单名(默认 "Agent Team"),仅在自动/显式 create
-                          路径里生效;--adopt/--adopt-guid 会忽略它,按名字/guid 查
-  --adopt "<清单名>"       强制走 adopt 模式并用这个名字查找——查不到/查出多个都会
-                          直接报错退出,不会静默回退到创建路径(你已经明确要 adopt了)
-  --adopt-guid <guid>     跳过按名字查找,直接 adopt 这个 guid 的清单(单独使用也
-                          等价于强制 adopt 模式);多个同名清单时用它消歧
+  --name <清单名>          显式指定要创建/复用的清单名(默认 "Agent Team");多团队
+                          部署用它隔离。--adopt/--adopt-guid 会忽略它,按名字/guid 查
+  --adopt "<清单名>"       认领你自己在任务中心建好的同名清单(把这些 bot 加为 editor)——
+                          查不到/查出多个都直接报错退出,绝不静默回退到创建路径
+  --adopt-guid <guid>     跳过按名字查找,直接认领这个 guid 的清单;多个同名清单时消歧
   --owner <open_id>       显式指定人类 owner(仅创建路径用到,adopt 模式下你本来就是
                           owner,不需要这个)
   --force                 覆盖共享注册文件里已有的 guid(默认不覆盖,避免误操作把
                           整个团队切到一个新板)
 
-── adopt 模式内部步骤(自动选中,或显式 --adopt/--adopt-guid 触发)──
+── 删除/清理(暂无自动子命令)──
+  零参数创建的清单 owner 是 bot app,你的用户身份删不掉它。要删除本机注册的清单:
+  用创建它的 bot 的 app 凭证(bridge 自己用的那套,tenant_access_token)调
+  \`DELETE /open-apis/task/v2/tasklists/{guid}\`(guid 见 <LARKWAY_HOME>/task-team.json),
+  再删掉本机状态文件:task-team.json、candidate-alerts-<guid>.json、各 bot 的
+  task-handles.json 里对应记录。(自动 --delete 子命令按需再加。)
+
+── adopt 模式内部步骤(仅显式 --adopt/--adopt-guid 触发)──
   1. 以你(操作者)的用户身份按名字精确匹配你能看到的清单(重名 → 报错列出全部
-     guid,让你加 --adopt-guid <guid> 消歧重跑;一个都找不到 → 自动模式下静默回退
-     创建路径,显式 --adopt 下报错提示先去任务中心建一个)
+     guid,让你加 --adopt-guid <guid> 消歧重跑;一个都找不到 → 报错提示先去任务
+     中心建一个,绝不静默创建)
   2. 把每个 bot 的 app 加为清单成员(role=editor,幂等,已是成员的跳过/无害重复)
   3. 写入共享注册文件 <LARKWAY_HOME>/task-team.json(与创建路径同一套
      first-writer-wins / --force 覆盖语义)
@@ -271,19 +277,15 @@ export async function run(ctx: CliContext, args: string[]): Promise<number> {
   const creatorProfile = deriveLarkCliProfile(creator.lark_cli_profile, creator.app_id);
   const loginHint = `lark-cli auth login --profile ${creatorProfile} --domain task`;
 
-  // v3.4 mode selection — three ways in:
-  //   1. Explicit --adopt/--adopt-guid: the operator asked for adopt mode by
-  //      name, so ANY lookup problem (not logged in, missing scope, no
-  //      match, ambiguous match) is a hard failure — never silently fall
-  //      back to creating a DIFFERENT tasklist than the one they named.
-  //   2. Implicit (neither flag passed): try the exact same by-name lookup
-  //      quietly first — a match adopts it (ownership is correct by
-  //      construction, no --owner needed); "ambiguous" still hard-fails
-  //      (guessing which board is unsafe to automate — see
-  //      resolveAdoptTarget's doc comment); but "list-failed" (not logged
-  //      in / missing scope) or "not-found" (no same-named tasklist visible)
-  //      silently fall through into the create/reuse-registry path below,
-  //      unchanged since before v3.4.
+  // Mode selection — two ways in (user-owned ownership decision, 2026-07):
+  //   1. Explicit --adopt/--adopt-guid: adopt the tasklist the operator already
+  //      created themselves (they become its true owner). ANY lookup problem
+  //      (not logged in, missing scope, no match, ambiguous match) is a HARD
+  //      failure — they asked to adopt, so we never silently create a
+  //      different/duplicate board instead.
+  //   2. Neither flag (zero-arg): CREATE a bot-app-owned board. Auto-adopting
+  //      by name is deliberately NOT done — see the create fall-through below
+  //      for why (multi-fleet cross-team mixing).
   if (adopt !== undefined || explicitAdoptGuid !== undefined) {
     const adoptName = adopt ?? name;
     if (adoptName.trim().length === 0) {
@@ -314,45 +316,22 @@ export async function run(ctx: CliContext, args: string[]): Promise<number> {
     });
   }
 
-  const autoTarget = resolveAdoptTarget(creatorProfile, name, undefined, loginHint);
-  if (autoTarget.ok) {
-    return runAdoptWithGuid(ctx, {
-      guid: autoTarget.guid,
-      matchedName: autoTarget.matchedName,
-      bots,
-      force,
-      creatorProfile,
-      loginHint,
-    });
-  }
-  if (autoTarget.reason === "ambiguous") {
-    // Even in auto-select mode this must hard-fail — silently picking one of
-    // several same-named boards would non-deterministically wire the team
-    // into whichever guid happened to sort first.
-    if (ctx.flags.json) ctx.ui.emitJson({ ok: false, error: autoTarget.message });
-    else ctx.ui.failure(autoTarget.message);
-    return 1;
-  }
-  // "list-failed" or "not-found" → fall through to the create/reuse path below.
-  // Never emitted in --json mode (not part of that machine-readable contract).
-  //   - list-failed: a LOUD warn — the adopt query failed despite the user
-  //     possibly having the scope, so falling back to create can silently
-  //     accrete a DUPLICATE "Agent Team" board (the BL-32 root cause). Point at
-  //     the fix so the operator can re-auth and re-run instead of piling up dups.
-  //   - not-found: expected on a genuinely new team — a quiet note is enough.
+  // Zero-arg (no --adopt/--adopt-guid): CREATE a bot-app-owned board by design
+  // (user-owned ownership decision, 2026-07). Auto-adopting by name is
+  // deliberately GONE: a company running MULTIPLE Larkway fleets would have the
+  // second fleet silently adopt the first's same-named board (cross-team
+  // mixing). Adoption is now opt-in only, via --adopt/--adopt-guid above (which
+  // hard-fails loudly on any lookup error — the operator asked to adopt, so a
+  // failed lookup must never quietly create). So fall straight through to the
+  // create/reuse-registry path below; the tasklist's owner is the creating bot
+  // app (the human is added as an editor for visibility — see the output).
   if (!ctx.flags.json) {
-    if (autoTarget.reason === "list-failed") {
-      ctx.ui.warning(
-        `无法以你的用户身份查询同名清单,已回退到用 bot app 身份创建/复用 —— ` +
-          `如果你其实已经有一个名为 "${name}" 的清单,这次很可能会新建一个重复的板。\n` +
-          `建议先确认用户身份已登录且有 task:tasklist 权限,再重跑:\n  ${loginHint}\n` +
-          `或用 \`--adopt "${name}"\` / \`--adopt-guid <guid>\` 强制走 adopt。`,
-      );
-    } else {
-      ctx.ui.print(
-        ctx.ui.dim(`(没找到同名清单 "${name}",回退到用 bot app 身份创建——如需强制 adopt 见 --adopt)`),
-      );
-    }
+    ctx.ui.print(
+      ctx.ui.dim(
+        `(用 bot app 身份创建/复用清单 "${name}"。想认领你自己在任务中心建的清单请用 ` +
+          `--adopt "<清单名>" / --adopt-guid <guid>;多团队部署建议用 --name 改名隔离。)`,
+      ),
+    );
   }
 
   // F2: resolve the human owner's open_id BEFORE touching any tasklist — a
@@ -554,15 +533,12 @@ type AdoptTargetResult =
   | { ok: false; reason: "ambiguous"; message: string; matches: UserTasklistSummary[] };
 
 /**
- * v3.4 (docs/task-handle.md §7): resolve WHICH existing tasklist an adopt
- * should target, without doing any writes. Used from two call sites in
- * `run()` with different failure-handling policy attached to the SAME three
- * failure reasons:
- *   - explicit `--adopt`/`--adopt-guid`: every failure reason is fatal (the
- *     operator asked for adopt mode by name — no silent fallback).
- *   - implicit auto-select: only "ambiguous" is fatal; "list-failed" and
- *     "not-found" are meant to be swallowed by the caller and treated as
- *     "try the create path instead" (see run()'s auto-select branch).
+ * docs/task-handle.md §7: resolve WHICH existing tasklist an EXPLICIT adopt
+ * (`--adopt`/`--adopt-guid`) should target, without doing any writes. The
+ * operator asked to adopt by name/guid, so EVERY failure reason is fatal
+ * (list-failed / not-found / ambiguous) — we never silently create a
+ * different or duplicate board instead. (Zero-arg no longer calls this: it
+ * creates a bot-app-owned board by design, see run().)
  *
  * `explicitGuid`, when given, skips the by-name lookup entirely — the
  * operator (or a previous ambiguous-match error's suggested rerun) already

--- a/src/cli/commands/tasklistInit.ts
+++ b/src/cli/commands/tasklistInit.ts
@@ -85,7 +85,7 @@ import {
 import { resolveOwnerOpenId } from "../ownerIdentity.js";
 import { deriveLarkCliProfile } from "../../lark/profileBootstrap.js";
 import {
-  listUserTasklists,
+  searchUserTasklists,
   addTasklistMembersAsUser,
   getUserTasklistMembers,
   type UserTasklistSummary,
@@ -333,13 +333,26 @@ export async function run(ctx: CliContext, args: string[]): Promise<number> {
     else ctx.ui.failure(autoTarget.message);
     return 1;
   }
-  // "list-failed" or "not-found" → silently fall through to the create/reuse
-  // path below. A short non-JSON note explains why, for anyone watching (a
-  // human at a terminal, or an agent relaying progress) — never emitted in
-  // --json mode since it isn't part of that machine-readable contract.
+  // "list-failed" or "not-found" → fall through to the create/reuse path below.
+  // Never emitted in --json mode (not part of that machine-readable contract).
+  //   - list-failed: a LOUD warn — the adopt query failed despite the user
+  //     possibly having the scope, so falling back to create can silently
+  //     accrete a DUPLICATE "Agent Team" board (the BL-32 root cause). Point at
+  //     the fix so the operator can re-auth and re-run instead of piling up dups.
+  //   - not-found: expected on a genuinely new team — a quiet note is enough.
   if (!ctx.flags.json) {
-    const why = autoTarget.reason === "list-failed" ? "无法以你的用户身份查询清单" : `没找到同名清单 "${name}"`;
-    ctx.ui.print(ctx.ui.dim(`(${why},回退到用 bot app 身份创建/复用清单——如需强制 adopt 见 --adopt)`));
+    if (autoTarget.reason === "list-failed") {
+      ctx.ui.warning(
+        `无法以你的用户身份查询同名清单,已回退到用 bot app 身份创建/复用 —— ` +
+          `如果你其实已经有一个名为 "${name}" 的清单,这次很可能会新建一个重复的板。\n` +
+          `建议先确认用户身份已登录且有 task:tasklist 权限,再重跑:\n  ${loginHint}\n` +
+          `或用 \`--adopt "${name}"\` / \`--adopt-guid <guid>\` 强制走 adopt。`,
+      );
+    } else {
+      ctx.ui.print(
+        ctx.ui.dim(`(没找到同名清单 "${name}",回退到用 bot app 身份创建——如需强制 adopt 见 --adopt)`),
+      );
+    }
   }
 
   // F2: resolve the human owner's open_id BEFORE touching any tasklist — a
@@ -396,13 +409,28 @@ export async function run(ctx: CliContext, args: string[]): Promise<number> {
     try {
       await taskClient.addTasklistMembers(tasklistGuid, members);
     } catch (err) {
-      const msg = `复用已有清单 ${tasklistGuid} 时补充成员失败: ${err instanceof Error ? err.message : String(err)}`;
-      if (ctx.flags.json) ctx.ui.emitJson({ ok: false, error: msg });
-      else {
-        ctx.ui.failure(msg);
-        ctx.ui.print("常见原因:app 未在开放平台后台勾选 task:tasklist:write / task:task:write scope(见 docs/task-handle.md §7)。");
+      const errMsg = err instanceof Error ? err.message : String(err);
+      if (isMembersEndpoint404(errMsg)) {
+        // Same 404 the bridge's self-join treats as best-effort continuing
+        // (main.ts) — the app-type members endpoint 404s (app self-add isn't
+        // supported there), but the bots are already members, so the reused
+        // list is fully usable. Degrade to a warn instead of a fatal exit;
+        // don't blame a scope the app already has.
+        if (!ctx.flags.json) {
+          ctx.ui.warning(
+            `复用清单 ${tasklistGuid} 时 add_members 返回 404(app 类型成员端点不支持自助加入,` +
+              "bot 通常已经是成员)——已忽略,不影响使用(与 bridge 启动的自助加入同款降级)。",
+          );
+        }
+      } else {
+        const msg = `复用已有清单 ${tasklistGuid} 时补充成员失败: ${errMsg}`;
+        if (ctx.flags.json) ctx.ui.emitJson({ ok: false, error: msg });
+        else {
+          ctx.ui.failure(msg);
+          ctx.ui.print("常见原因:app 未在开放平台后台勾选 task:tasklist:write / task:task:write scope(见 docs/task-handle.md §7)。");
+        }
+        return 1;
       }
-      return 1;
     }
   } else {
     reused = false;
@@ -477,8 +505,16 @@ export async function run(ctx: CliContext, args: string[]): Promise<number> {
   } else {
     ctx.ui.success(`清单 "${name}" 已创建: ${tasklistGuid}`);
   }
-  ctx.ui.print(`owner 成员: ${ownerOpenId}${explicitOwner ? "" : "(从 lark-cli 当前登录用户自动解析)"}`);
-  ctx.ui.print(`已加入成员(editor): ${bots.map((b) => b.id).join(", ")}`);
+  // This is the bot-app CREATE/REUSE path: the tasklist's real owner is the
+  // bot app that created it (app-only credentials), NOT the human. The human is
+  // added as an EDITOR member so they can see + edit it in their Task Center.
+  // (True user ownership only happens on the --adopt path, where the operator
+  // created the board themselves in the UI.)
+  ctx.ui.print(
+    `你(${ownerOpenId})已作为 editor 加入${explicitOwner ? "" : "(open_id 从 lark-cli 当前登录用户自动解析)"} —— ` +
+      "清单 owner 是创建它的 bot app;你是 editor 成员(可在任务中心看到并编辑)。",
+  );
+  ctx.ui.print(`已加入(editor)的 bot: ${bots.map((b) => b.id).join(", ")}`);
   ctx.ui.print("");
   if (!reused) {
     ctx.ui.print(
@@ -498,6 +534,16 @@ export async function run(ctx: CliContext, args: string[]): Promise<number> {
     ctx.ui.bold("⚠️ 请手动确认:") + " 去飞书任务中心确认这个清单确实可见(见 docs/task-handle.md §7)。",
   );
   return 0;
+}
+
+/**
+ * True for the app-type members-endpoint 404 (`POST /tasklists/{guid}/members`
+ * returns "404 page not found" for an app self-add — the bot is already a
+ * member). Message-based because TaskListClient wraps the raw error before it
+ * reaches here. Matches the bridge's best-effort treatment of the same failure.
+ */
+function isMembersEndpoint404(errMsg: string): boolean {
+  return /\b404\b|page not found|not.?found|不存在|resource_not_exist/i.test(errMsg);
 }
 
 /** Discriminated result of resolveAdoptTarget — see its doc comment. */
@@ -532,18 +578,20 @@ function resolveAdoptTarget(
     return { ok: true, guid: explicitGuid, matchedName: name };
   }
 
-  const listResult = listUserTasklists(creatorProfile);
+  const listResult = searchUserTasklists(creatorProfile, name);
   if (!listResult.ok) {
     return {
       ok: false,
       reason: "list-failed",
       message:
-        `无法以你的用户身份列出清单:${listResult.error}\n\n` +
+        `无法以你的用户身份查询清单:${listResult.error}\n\n` +
         `请先确认已用这个 profile 登录过用户身份、且申请了 task 域权限:\n  ${loginHint}\n` +
         `(可用 \`lark-cli auth status --profile ${creatorProfile} --json\` 检查当前状态)`,
     };
   }
 
+  // The search filters by keyword server-side; still require an EXACT name
+  // match so a fuzzy/substring hit never adopts the wrong board.
   const matches = listResult.data.filter((t) => t.name === name);
   if (matches.length === 0) {
     return {

--- a/src/cli/userTasklistOps.test.ts
+++ b/src/cli/userTasklistOps.test.ts
@@ -8,7 +8,7 @@
 
 import { describe, it, expect } from "vitest";
 import {
-  listUserTasklists,
+  searchUserTasklists,
   addTasklistMembersAsUser,
   getUserTasklistMembers,
   type SpawnSyncFn,
@@ -28,19 +28,45 @@ function makeSpawn(result: { status: number | null; stdout?: string; stderr?: st
   });
 }
 
-describe("listUserTasklists", () => {
-  it("parses guid + name out of a successful list response", () => {
+describe("searchUserTasklists", () => {
+  it("calls the +tasklist-search skill (not the raw list) with --as user + --query (BL-32)", () => {
+    let capturedArgs: string[] = [];
+    const spawn: SpawnSyncFn = (_cmd, args) => {
+      capturedArgs = args;
+      return { status: 0, stdout: JSON.stringify({ items: [] }), stderr: "", pid: 0, signal: null, output: [], error: undefined };
+    };
+    searchUserTasklists(PROFILE, "Agent Team", spawn);
+    // The raw `tasklists list` command false-negatives its own scope precheck;
+    // the working call is the skill + a name query.
+    expect(capturedArgs).toContain("+tasklist-search");
+    expect(capturedArgs).not.toContain("list");
+    expect(capturedArgs).toEqual(expect.arrayContaining(["--as", "user", "--query", "Agent Team", "--profile", PROFILE]));
+  });
+
+  it("parses guid + name out of a successful search response (items shape)", () => {
     const spawn = makeSpawn({
       status: 0,
       stdout: JSON.stringify({ items: [{ guid: "tl-1", name: "Agent Team" }, { guid: "tl-2", name: "个人清单" }] }),
     });
-    const result = listUserTasklists(PROFILE, spawn);
+    const result = searchUserTasklists(PROFILE, "Agent Team", spawn);
     expect(result).toEqual({ ok: true, data: [{ guid: "tl-1", name: "Agent Team" }, { guid: "tl-2", name: "个人清单" }] });
+  });
+
+  it("also parses a `tasklists`-keyed or top-level-array envelope (shape-robust)", () => {
+    const keyed = makeSpawn({ status: 0, stdout: JSON.stringify({ tasklists: [{ guid: "tl-1", name: "Agent Team" }] }) });
+    expect(searchUserTasklists(PROFILE, "Agent Team", keyed)).toEqual({ ok: true, data: [{ guid: "tl-1", name: "Agent Team" }] });
+    const topArray = makeSpawn({ status: 0, stdout: JSON.stringify([{ guid: "tl-9", name: "Agent Team" }]) });
+    expect(searchUserTasklists(PROFILE, "Agent Team", topArray)).toEqual({ ok: true, data: [{ guid: "tl-9", name: "Agent Team" }] });
+  });
+
+  it("treats an empty result array as a valid no-match (not an error)", () => {
+    const spawn = makeSpawn({ status: 0, stdout: JSON.stringify({ items: [] }) });
+    expect(searchUserTasklists(PROFILE, "Agent Team", spawn)).toEqual({ ok: true, data: [] });
   });
 
   it("falls back to a placeholder name when an item has no name", () => {
     const spawn = makeSpawn({ status: 0, stdout: JSON.stringify({ items: [{ guid: "tl-1" }] }) });
-    const result = listUserTasklists(PROFILE, spawn);
+    const result = searchUserTasklists(PROFILE, "Agent Team", spawn);
     expect(result).toEqual({ ok: true, data: [{ guid: "tl-1", name: "(无标题)" }] });
   });
 
@@ -49,7 +75,7 @@ describe("listUserTasklists", () => {
       status: 0,
       stdout: JSON.stringify({ items: [{ name: "no guid here" }, { guid: "tl-2", name: "ok" }] }),
     });
-    const result = listUserTasklists(PROFILE, spawn);
+    const result = searchUserTasklists(PROFILE, "Agent Team", spawn);
     expect(result).toEqual({ ok: true, data: [{ guid: "tl-2", name: "ok" }] });
   });
 
@@ -64,7 +90,7 @@ describe("listUserTasklists", () => {
         },
       }),
     });
-    const result = listUserTasklists(PROFILE, spawn);
+    const result = searchUserTasklists(PROFILE, "Agent Team", spawn);
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.error).toContain("need_user_authorization");
@@ -72,21 +98,22 @@ describe("listUserTasklists", () => {
     }
   });
 
-  it("fails clearly when items is missing/malformed rather than silently returning an empty list", () => {
-    const spawn = makeSpawn({ status: 0, stdout: JSON.stringify({ notItems: [] }) });
-    const result = listUserTasklists(PROFILE, spawn);
+  it("fails clearly on an unrecognized shape (no array anywhere) rather than silently returning empty", () => {
+    // Silent-empty here would fall through to CREATE and accrete a duplicate.
+    const spawn = makeSpawn({ status: 0, stdout: JSON.stringify({ notItems: "nope" }) });
+    const result = searchUserTasklists(PROFILE, "Agent Team", spawn);
     expect(result.ok).toBe(false);
   });
 
   it("fails clearly on malformed JSON stdout", () => {
     const spawn = makeSpawn({ status: 0, stdout: "not json" });
-    const result = listUserTasklists(PROFILE, spawn);
+    const result = searchUserTasklists(PROFILE, "Agent Team", spawn);
     expect(result.ok).toBe(false);
   });
 
   it("fails clearly on empty stdout", () => {
     const spawn = makeSpawn({ status: 1, stdout: "" });
-    const result = listUserTasklists(PROFILE, spawn);
+    const result = searchUserTasklists(PROFILE, "Agent Team", spawn);
     expect(result.ok).toBe(false);
   });
 
@@ -94,8 +121,8 @@ describe("listUserTasklists", () => {
     const throwingSpawn: SpawnSyncFn = () => {
       throw new Error("spawnSync ENOENT");
     };
-    expect(() => listUserTasklists(PROFILE, throwingSpawn)).not.toThrow();
-    const result = listUserTasklists(PROFILE, throwingSpawn);
+    expect(() => searchUserTasklists(PROFILE, "Agent Team", throwingSpawn)).not.toThrow();
+    const result = searchUserTasklists(PROFILE, "Agent Team", throwingSpawn);
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.error).toContain("lark-cli");
   });
@@ -125,7 +152,7 @@ describe("addTasklistMembersAsUser", () => {
     expect(JSON.parse(dataArg)).toEqual({ members: [{ id: "cli_app1", type: "app", role: "editor" }] });
   });
 
-  it("surfaces a scope-missing error the same way listUserTasklists does", () => {
+  it("surfaces a scope-missing error the same way searchUserTasklists does", () => {
     const spawn = makeSpawn({
       status: 3,
       stdout: JSON.stringify({

--- a/src/cli/userTasklistOps.ts
+++ b/src/cli/userTasklistOps.ts
@@ -22,19 +22,18 @@
  * the operator hasn't run `lark-cli auth login --domain task` for this
  * profile yet) surfaced to the CLI's error output, not silently swallowed.
  *
- * Verified against a real `lark-cli` install (2026-07, read-only — see
- * docs/task-handle.md §9 platform facts for the full investigation):
- *   - `lark-cli task tasklists list --as user` supports the user identity
- *     (fails cleanly with a scope-missing hint when the profile's user token
- *     lacks `task:tasklist:read`, confirming the mechanism exists and names
- *     the exact scope needed).
- *   - `lark-cli schema task.tasklists.list`'s output shape confirms each item
- *     carries both `guid` AND `name` — name-based lookup is genuinely
- *     supported by the API, not something this module has to fake.
- *   - `lark-cli task tasklists add_members --as user --dry-run` prints the
- *     exact same request shape (`{members:[{id,type,role}]}`) the existing
- *     bot-identity path already uses — no shape difference between
- *     identities, only the `--as` flag and which OAuth token authenticates.
+ * Command choice (2026-07, real-machine BL-32):
+ *   - The QUERY uses the `+tasklist-search` SKILL, NOT the raw
+ *     `task tasklists list`. On a machine whose user token DOES carry
+ *     `task:tasklist:read`, `tasklists list --as user` still rejects with its
+ *     own client-side scope precheck ("user authorization does not cover the
+ *     required scope(s)") while `+tasklist-search --as user` succeeds — the two
+ *     lark-cli code paths disagree, and adopt must use the one that reaches the
+ *     API. See searchUserTasklists's own comment.
+ *   - The WRITE (add_members) stays on the raw `task tasklists add_members`
+ *     command: it accepts the `{members:[{id,type:"app",role:"editor"}]}` shape
+ *     the bot-identity path uses, which the `+tasklist-members` skill (open_ids
+ *     only, no app/role) cannot express.
  */
 
 import { spawnSync, type SpawnSyncOptions, type SpawnSyncReturns } from "node:child_process";
@@ -98,36 +97,81 @@ function runLarkCliJson(args: string[], spawnSyncFn: SpawnSyncFn): UserOpResult<
 }
 
 /**
- * List every tasklist visible to the human user logged into `profile`
- * (`lark-cli task tasklists list --as user --page-all --json`). The most
- * common failure — no user identity, or one missing the `task:tasklist:read`
- * scope — surfaces lark-cli's own actionable hint (points at `auth login`).
+ * Search the tasklists visible to the human user logged into `profile`, by
+ * name keyword — `lark-cli task +tasklist-search --as user --query <q>`.
+ *
+ * Why the `+tasklist-search` SKILL and not the raw `task tasklists list`
+ * command (real-machine BL-32, 2026-07-05): with a freshly re-authorized user
+ * token that DOES carry `task:tasklist:read`, `tasklists list --as user` still
+ * rejects with a CLIENT-SIDE precheck ("user authorization does not cover the
+ * required scope(s): task:tasklist:read") — its scope table lags a fresh grant
+ * — while `+tasklist-search --as user` with the same profile/token succeeds.
+ * lark-cli's own behavior is inconsistent between the two; adopt must use the
+ * one that actually reaches the API. `--query` is also a better fit for adopt-
+ * by-name (server-side filter) than listing everything; the caller still does
+ * an exact-name match on top.
  */
-export function listUserTasklists(
+export function searchUserTasklists(
   profile: string,
+  query: string,
   spawnSyncFn: SpawnSyncFn = spawnSync,
 ): UserOpResult<UserTasklistSummary[]> {
   const result = runLarkCliJson(
-    ["task", "tasklists", "list", "--as", "user", "--profile", profile, "--page-all", "--json"],
+    ["task", "+tasklist-search", "--as", "user", "--profile", profile, "--query", query, "--page-all", "--json"],
     spawnSyncFn,
   );
   if (!result.ok) return result;
-  const data = result.data;
-  const items =
-    typeof data === "object" && data !== null ? (data as Record<string, unknown>)["items"] : undefined;
-  if (!Array.isArray(items)) {
-    return { ok: false, error: `lark-cli 返回的清单列表形状不对(缺少 items 数组):${JSON.stringify(data).slice(0, 300)}` };
+  return extractTasklistSummaries(result.data);
+}
+
+/**
+ * Pull {guid, name} pairs out of a `+tasklist-search` JSON envelope. The
+ * skill's exact wrapper key could not be verified locally (every local profile
+ * is scope-gated), so this checks the likely array locations in order — a
+ * top-level array, or `items`/`tasklists`/`results` at the root or under
+ * `data` — and uses the FIRST array it finds (even if empty: an empty search
+ * result is a valid "no match", distinct from an unrecognized shape). If NONE
+ * of those locations holds an array, the shape is unrecognized → return an
+ * error rather than a silent empty list, so the caller does not fall through to
+ * CREATE and accrete a duplicate board on a shape we failed to parse (BL-32).
+ */
+function extractTasklistSummaries(data: unknown): UserOpResult<UserTasklistSummary[]> {
+  const rec = typeof data === "object" && data !== null ? (data as Record<string, unknown>) : {};
+  const nested =
+    typeof rec["data"] === "object" && rec["data"] !== null ? (rec["data"] as Record<string, unknown>) : {};
+  let arr: unknown[] | undefined;
+  for (const candidate of [
+    data,
+    rec["items"],
+    rec["tasklists"],
+    rec["results"],
+    nested["items"],
+    nested["tasklists"],
+    nested["results"],
+  ]) {
+    if (Array.isArray(candidate)) {
+      arr = candidate;
+      break;
+    }
   }
-  const tasklists: UserTasklistSummary[] = [];
-  for (const raw of items) {
+  if (!arr) {
+    return {
+      ok: false,
+      error: `lark-cli +tasklist-search 返回的形状无法识别(找不到清单数组):${JSON.stringify(data).slice(0, 300)}`,
+    };
+  }
+  const out: UserTasklistSummary[] = [];
+  const seen = new Set<string>();
+  for (const raw of arr) {
     if (typeof raw !== "object" || raw === null) continue;
     const guid = (raw as Record<string, unknown>)["guid"];
     const name = (raw as Record<string, unknown>)["name"];
-    if (typeof guid === "string" && guid.length > 0) {
-      tasklists.push({ guid, name: typeof name === "string" ? name : "(无标题)" });
+    if (typeof guid === "string" && guid.length > 0 && !seen.has(guid)) {
+      seen.add(guid);
+      out.push({ guid, name: typeof name === "string" ? name : "(无标题)" });
     }
   }
-  return { ok: true, data: tasklists };
+  return { ok: true, data: out };
 }
 
 /**


### PR DESCRIPTION
## Why (real-machine BL-32 + ownership decision)

Zero-arg `larkway tasklist-init` was auto-adopting a same-named board — which (a) was broken (the query path false-negatived, silently minting duplicate bot-owned boards) and (b) is unsafe for multi-fleet deployments (a second Larkway fleet would silently adopt the first's same-named "Agent Team" board). The user decided: **zero-arg CREATEs; adoption is explicit-only.**

Two commits: `af21d90` fixes the adopt machinery; `81cee0e` makes adoption opt-in.

## Behavior (final)

- **Zero-arg → CREATE** a bot-app-owned board (the human is added as an *editor* for visibility). No by-name query, no auto-adopt, no ambiguity failure. `--name` (default `Agent Team`) selects the board name; output + `--help` suggest renaming per fleet for isolation.
- **`--adopt "<name>"` / `--adopt-guid <guid>` → adopt** the board the operator built themselves (they own it), via the fixed user-identity query. **Hard-fails loudly on any lookup error** (not logged in / missing scope / no match / ambiguous) — the operator asked to adopt, so it never silently creates.

## The adopt-machinery fixes (retained from af21d90)

1. **Query reachable.** Switched the user-identity lookup from raw `task tasklists list --as user` — whose client-side scope precheck false-negatives even when the token carries `task:tasklist:read` — to the `+tasklist-search --as user --query <name>` skill, which reaches the API (both confirmed on the real machine). Shape-robust extraction; an unrecognized shape errors rather than silently returning empty. The member-**add** write stays on the raw command (the `+tasklist-members` skill can't express app-editor members).
2. **Unify the app-members-endpoint 404** on the reuse path: was fatal (exit 1), now warn + continue like the bridge self-join (the bot is already a member). Non-404 failures still fail hard.
3. **Accurate wording**: the create/reuse path called the human an "owner member" — they're an editor (owner is the bot app); the 404 no longer blames a scope the app already has.

## `--delete` (not automated)

Deleting a bot-owned board is destructive and spans the registry + `candidate-alerts` + per-bot `task-handles`, and `TaskListClient` has no delete method. `--help` documents the manual removal (owning bot app token → `DELETE /task/v2/tasklists/{guid}` → clean the state files); an automated subcommand can follow in a focused PR.

## Verification

`pnpm typecheck` / `pnpm test` (1388) / `pnpm build` all green. Tests: search command form + robust/empty/unrecognized-shape parsing; reuse-path 404 warn+continue vs non-404 hard-fail; zero-arg CREATEs even with same-named (or multiple) lists visible + never queries; explicit `--adopt` fatal-on-lookup-failure.

**Note:** `+tasklist-search`'s exact JSON envelope key couldn't be verified locally (every local profile is scope-gated); extraction is shape-robust and errors on an unrecognized shape. The user's planned mini re-test of the `--adopt` flow is the end-to-end confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)