### PR TITLE
chore(v0.3.36): correct COT ordering note + quiet tasklist-init raw error dump

### DIFF
--- a/bots-examples/dev-bot.yaml
+++ b/bots-examples/dev-bot.yaml
@@ -68,9 +68,9 @@ cot: brief
 #             currently render the card panel as plain text (no collapse), so
 #             "bubble" is recommended.
 # Behavior: the answer always lands on its own card/message (never only in the
-# bubble). On the FIRST turn of a NEW topic the bubble appears just AFTER the
-# card (a platform anchoring constraint); in every other case the thinking
-# shows first. Any COT failure degrades silently and never affects the answer.
+# bubble). Inside a topic every turn shows the card first, then the thinking
+# bubble (Feishu orders the topic view); only a non-topic group reply shows the
+# thinking first. Any COT failure degrades silently and never affects the answer.
 cotSurface: bubble
 
 # L2 Agent Memory (relative to the bots/ directory at runtime).

--- a/bots-examples/knowledge-bot.yaml
+++ b/bots-examples/knowledge-bot.yaml
@@ -77,9 +77,9 @@ cot: brief
 #             currently render the card panel as plain text (no collapse), so
 #             "bubble" is recommended.
 # Behavior: the answer always lands on its own card/message (never only in the
-# bubble). On the FIRST turn of a NEW topic the bubble appears just AFTER the
-# card (a platform anchoring constraint); in every other case the thinking
-# shows first. Any COT failure degrades silently and never affects the answer.
+# bubble). Inside a topic every turn shows the card first, then the thinking
+# bubble (Feishu orders the topic view); only a non-topic group reply shows the
+# thinking first. Any COT failure degrades silently and never affects the answer.
 cotSurface: bubble
 
 # L2 Agent Memory file (relative to the bots/ directory at runtime).

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -556,9 +556,11 @@ async function probeTaskScope(
   tasklistGuid: string,
 ): Promise<{ ok: boolean; message?: string }> {
   try {
-    const { Client: LarkSdkClient } = await import("@larksuiteoapi/node-sdk");
+    const { Client: LarkSdkClient, LoggerLevel } = await import("@larksuiteoapi/node-sdk");
     const { TaskListClient } = await import("../../tasklist/client.js");
-    const sdkClient = new LarkSdkClient({ appId, appSecret });
+    // loggerLevel: fatal — silence the node-sdk Client's raw AxiosError dump to
+    // stdout on request failure; doctor reports its own clean pass/fail line.
+    const sdkClient = new LarkSdkClient({ appId, appSecret, loggerLevel: LoggerLevel.fatal });
     const taskClient = new TaskListClient({
       request: (config) => sdkClient.request(config as Parameters<typeof sdkClient.request>[0]),
     });

--- a/src/cli/commands/tasklistInit.test.ts
+++ b/src/cli/commands/tasklistInit.test.ts
@@ -111,6 +111,7 @@ beforeEach(async () => {
   capturedAddMembersAsUserCall = undefined;
   vi.resetModules();
   vi.doMock("@larksuiteoapi/node-sdk", () => ({
+    LoggerLevel: { fatal: 0, error: 1, warn: 2, info: 3, debug: 4, trace: 5 },
     Client: class {
       async request(config: { method: string; url: string; data?: unknown }) {
         capturedRequests.push(config);
@@ -453,6 +454,7 @@ describe("tasklist-init --team", () => {
       // module is evaluated its already-resolved imports can't be swapped out
       // by a later doMock call (no re-import happens inside run()).
       vi.doMock("@larksuiteoapi/node-sdk", () => ({
+        LoggerLevel: { fatal: 0, error: 1, warn: 2, info: 3, debug: 4, trace: 5 },
         Client: class {
           async request(config: { method: string; url: string; data?: unknown }) {
             capturedRequests.push(config);
@@ -476,6 +478,7 @@ describe("tasklist-init --team", () => {
     it("reports ownerConfirmedMember:false in JSON mode when the owner is missing from the readback", async () => {
       await makeBot("bot-a", "cli_a", "BOT_A_SECRET");
       vi.doMock("@larksuiteoapi/node-sdk", () => ({
+        LoggerLevel: { fatal: 0, error: 1, warn: 2, info: 3, debug: 4, trace: 5 },
         Client: class {
           async request(config: { method: string; url: string; data?: unknown }) {
             capturedRequests.push(config);

--- a/src/cli/commands/tasklistInit.ts
+++ b/src/cli/commands/tasklistInit.ts
@@ -71,7 +71,7 @@
  * as `larkway bot add` / `larkway perms`.
  */
 
-import { Client as LarkSdkClient } from "@larksuiteoapi/node-sdk";
+import { Client as LarkSdkClient, LoggerLevel } from "@larksuiteoapi/node-sdk";
 import type { CliContext } from "../types.js";
 import {
   TaskListClient,
@@ -358,7 +358,16 @@ export async function run(ctx: CliContext, args: string[]): Promise<number> {
     return 1;
   }
 
-  const sdkClient = new LarkSdkClient({ appId: creator.app_id, appSecret: creator.appSecret });
+  // loggerLevel: fatal — the node-sdk Client otherwise logs the FULL raw
+  // AxiosError to stdout (its default `error` level) before our own catch runs,
+  // dumping a long, alarming object (and corrupting --json). We surface every
+  // failure ourselves with a clean message (and the benign app-member 404 is
+  // handled structurally), so the SDK's raw error logging is pure noise here.
+  const sdkClient = new LarkSdkClient({
+    appId: creator.app_id,
+    appSecret: creator.appSecret,
+    loggerLevel: LoggerLevel.fatal,
+  });
   const requester: LarkTaskRequester = {
     request: (config) => sdkClient.request(config as Parameters<typeof sdkClient.request>[0]),
   };

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
 import { mkdirSync } from "node:fs";
 import path from "node:path";
 import { resolveLarkwayVersion } from "./version.js";
-import { Client as LarkSdkClient } from "@larksuiteoapi/node-sdk";
+import { Client as LarkSdkClient, LoggerLevel } from "@larksuiteoapi/node-sdk";
 import { loadConfig, loadConfigJson } from "./config.js";
 import type { Config, ConfigJsonType } from "./config.js";
 import { ChannelClient, resolveOpenChatDiscoveryMs } from "./lark/channelClient.js";
@@ -466,7 +466,15 @@ async function runV2Mode({
     {
       const guid = bot.taskHandle?.tasklistGuid ?? (await readTeamTasklistGuid(resolveTaskTeamRegistryPath()));
       if (guid) {
-        const taskSdkClient = new LarkSdkClient({ appId: bot.app_id, appSecret });
+        // loggerLevel: fatal — the node-sdk Client otherwise dumps the full raw
+        // AxiosError (default `error` level) to stdout/the bridge log on every
+        // request failure, before our own .catch. The self-join 404 below is
+        // best-effort and warned cleanly, so that raw dump is pure log noise.
+        const taskSdkClient = new LarkSdkClient({
+          appId: bot.app_id,
+          appSecret,
+          loggerLevel: LoggerLevel.fatal,
+        });
         const taskRequester: LarkTaskRequester = {
           request: (config) => taskSdkClient.request(config as Parameters<typeof taskSdkClient.request>[0]),
         };


### PR DESCRIPTION
Two pre-release polish items.

1. **bots-examples COT comment.** The old note ("first turn of a new topic → bubble after the card; else thinking first") was inaccurate. Real behavior: inside a topic **every** turn is card-first then bubble (Feishu unifies the topic view order); only a non-topic group reply shows the thinking first.
2. **tasklist-init raw error dump.** The node-sdk `Client` logs the full raw AxiosError to stdout (its default `error` level) before our own catch runs — a long, alarming object that also corrupted `--json`. Pass `loggerLevel: fatal` to the client; we already surface every failure with a clean message, and the benign app-member 404 is handled structurally. Detection logic untouched.

`pnpm typecheck` / `pnpm test` (1389) / `pnpm build` / `check:links` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)