### PR TITLE
fix: actually silence node-sdk raw AxiosError dump (loggerLevel: fatal is a no-op)

### DIFF
--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -556,11 +556,13 @@ async function probeTaskScope(
   tasklistGuid: string,
 ): Promise<{ ok: boolean; message?: string }> {
   try {
-    const { Client: LarkSdkClient, LoggerLevel } = await import("@larksuiteoapi/node-sdk");
+    const { Client: LarkSdkClient } = await import("@larksuiteoapi/node-sdk");
     const { TaskListClient } = await import("../../tasklist/client.js");
-    // loggerLevel: fatal — silence the node-sdk Client's raw AxiosError dump to
+    const { silentSdkLogger } = await import("../../lark/sdkLogger.js");
+    // silentSdkLogger — silence the node-sdk Client's raw AxiosError dump to
     // stdout on request failure; doctor reports its own clean pass/fail line.
-    const sdkClient = new LarkSdkClient({ appId, appSecret, loggerLevel: LoggerLevel.fatal });
+    // (`loggerLevel: fatal` does NOT work — see lark/sdkLogger.ts.)
+    const sdkClient = new LarkSdkClient({ appId, appSecret, logger: silentSdkLogger });
     const taskClient = new TaskListClient({
       request: (config) => sdkClient.request(config as Parameters<typeof sdkClient.request>[0]),
     });

--- a/src/cli/commands/tasklistInit.test.ts
+++ b/src/cli/commands/tasklistInit.test.ts
@@ -111,7 +111,6 @@ beforeEach(async () => {
   capturedAddMembersAsUserCall = undefined;
   vi.resetModules();
   vi.doMock("@larksuiteoapi/node-sdk", () => ({
-    LoggerLevel: { fatal: 0, error: 1, warn: 2, info: 3, debug: 4, trace: 5 },
     Client: class {
       async request(config: { method: string; url: string; data?: unknown }) {
         capturedRequests.push(config);
@@ -454,7 +453,6 @@ describe("tasklist-init --team", () => {
       // module is evaluated its already-resolved imports can't be swapped out
       // by a later doMock call (no re-import happens inside run()).
       vi.doMock("@larksuiteoapi/node-sdk", () => ({
-        LoggerLevel: { fatal: 0, error: 1, warn: 2, info: 3, debug: 4, trace: 5 },
         Client: class {
           async request(config: { method: string; url: string; data?: unknown }) {
             capturedRequests.push(config);
@@ -478,7 +476,6 @@ describe("tasklist-init --team", () => {
     it("reports ownerConfirmedMember:false in JSON mode when the owner is missing from the readback", async () => {
       await makeBot("bot-a", "cli_a", "BOT_A_SECRET");
       vi.doMock("@larksuiteoapi/node-sdk", () => ({
-        LoggerLevel: { fatal: 0, error: 1, warn: 2, info: 3, debug: 4, trace: 5 },
         Client: class {
           async request(config: { method: string; url: string; data?: unknown }) {
             capturedRequests.push(config);

--- a/src/cli/commands/tasklistInit.ts
+++ b/src/cli/commands/tasklistInit.ts
@@ -71,7 +71,8 @@
  * as `larkway bot add` / `larkway perms`.
  */
 
-import { Client as LarkSdkClient, LoggerLevel } from "@larksuiteoapi/node-sdk";
+import { Client as LarkSdkClient } from "@larksuiteoapi/node-sdk";
+import { silentSdkLogger } from "../../lark/sdkLogger.js";
 import type { CliContext } from "../types.js";
 import {
   TaskListClient,
@@ -358,15 +359,16 @@ export async function run(ctx: CliContext, args: string[]): Promise<number> {
     return 1;
   }
 
-  // loggerLevel: fatal — the node-sdk Client otherwise logs the FULL raw
-  // AxiosError to stdout (its default `error` level) before our own catch runs,
-  // dumping a long, alarming object (and corrupting --json). We surface every
-  // failure ourselves with a clean message (and the benign app-member 404 is
-  // handled structurally), so the SDK's raw error logging is pure noise here.
+  // silentSdkLogger — the node-sdk Client otherwise logs the FULL raw
+  // AxiosError to stdout before our own catch runs, dumping a long, alarming
+  // object (and corrupting --json). We surface every failure ourselves with a
+  // clean message (and the benign app-member 404 is handled structurally), so
+  // the SDK's raw error logging is pure noise here. `loggerLevel: fatal` does
+  // NOT work (falsy-zero bug in the vendored SDK — see lark/sdkLogger.ts).
   const sdkClient = new LarkSdkClient({
     appId: creator.app_id,
     appSecret: creator.appSecret,
-    loggerLevel: LoggerLevel.fatal,
+    logger: silentSdkLogger,
   });
   const requester: LarkTaskRequester = {
     request: (config) => sdkClient.request(config as Parameters<typeof sdkClient.request>[0]),

--- a/src/lark/sdkLogger.test.ts
+++ b/src/lark/sdkLogger.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { Client, LoggerLevel } from "@larksuiteoapi/node-sdk";
+import { silentSdkLogger, compactErrorText } from "./sdkLogger.js";
+
+// These tests run against the REAL vendored @larksuiteoapi/node-sdk (no mock,
+// no network) so they pin the actual logging seam the bridge self-join hits.
+// The SDK's default logger routes each level to a distinct console method
+// (error→console.log, warn→console.warn, info→console.info, …), so we spy on
+// all of them and assert nothing is emitted.
+const CONSOLE_METHODS = ["log", "warn", "info", "debug", "trace", "error"] as const;
+
+function spyConsole() {
+  return CONSOLE_METHODS.map((m) => vi.spyOn(console, m).mockImplementation(() => {}));
+}
+function totalConsoleCalls(spies: ReturnType<typeof vi.spyOn>[]) {
+  return spies.reduce((n, s) => n + s.mock.calls.length, 0);
+}
+
+// A realistic stand-in for the multi-KB AxiosError the SDK would otherwise dump.
+function bigError(): Error {
+  const e = new Error("Request failed with status code 404");
+  (e as { config?: unknown }).config = { url: "/open-apis/task/v2/tasklists/x/members", method: "post", data: "{...}" };
+  (e as { response?: unknown }).response = { status: 404, statusText: "Not Found", data: "404 page not found" };
+  return e;
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("silentSdkLogger", () => {
+  it("emits nothing when its methods are called directly", () => {
+    const spies = spyConsole();
+    silentSdkLogger.error(bigError());
+    silentSdkLogger.warn("w");
+    silentSdkLogger.info("i");
+    silentSdkLogger.debug("d");
+    silentSdkLogger.trace("t");
+    expect(totalConsoleCalls(spies)).toBe(0);
+  });
+
+  it("silences a REAL node-sdk Client's error dump (the actual self-join seam)", () => {
+    // Construct with a no-op logger, then drive the SDK's internal logging seam
+    // exactly as a failed request would: client.logger.error(rawAxiosError).
+    const client = new Client({ appId: "cli_fake00000000000", appSecret: "fake-secret", logger: silentSdkLogger });
+    const spies = spyConsole();
+    // `.logger` is the internal LoggerProxy; cast to reach it in the test.
+    (client as unknown as { logger: { error: (e: unknown) => void } }).logger.error(bigError());
+    expect(totalConsoleCalls(spies)).toBe(0);
+  });
+});
+
+describe("loggerLevel: fatal is NOT a valid silence (regression guard)", () => {
+  // Documents WHY we pass a no-op logger instead of loggerLevel. The vendored
+  // SDK builds `new LoggerProxy(params.loggerLevel || LoggerLevel.info, ...)`,
+  // and since LoggerLevel.fatal === 0 is falsy, it collapses to `info`. If a
+  // future SDK bump fixes this, these assertions flip and prompt a re-review.
+  it("coerces fatal (0) back to info, so error-level logs still fire", () => {
+    const client = new Client({ appId: "cli_fake00000000000", appSecret: "fake-secret", loggerLevel: LoggerLevel.fatal });
+    const level = (client as unknown as { logger: { level: number } }).logger.level;
+    expect(level).toBe(LoggerLevel.info); // NOT LoggerLevel.fatal
+    expect(level).toBeGreaterThanOrEqual(LoggerLevel.error); // => error logs fire
+
+    const spies = spyConsole();
+    (client as unknown as { logger: { error: (e: unknown) => void } }).logger.error(bigError());
+    // The dump the real machine still saw with `loggerLevel: fatal`.
+    expect(totalConsoleCalls(spies)).toBeGreaterThan(0);
+  });
+});
+
+describe("compactErrorText", () => {
+  it("returns only the message, never the axios cause chain", () => {
+    // Mirror wrapErr: a TaskApiError-shaped Error whose .cause is the raw axios
+    // error. console.warn(msg, err) would expand this into the same KB dump.
+    class TaskApiErrorLike extends Error {
+      cause: unknown;
+      constructor(message: string, cause: unknown) {
+        super(message);
+        this.name = "TaskApiError";
+        this.cause = cause;
+      }
+    }
+    const err = new TaskApiErrorLike("addTasklistMembers(guid): Request failed with status code 404", bigError());
+    const text = compactErrorText(err);
+    expect(text).toBe("addTasklistMembers(guid): Request failed with status code 404");
+    expect(text).not.toMatch(/config|response|AxiosError|\[cause\]/i);
+  });
+
+  it("stringifies non-Error values", () => {
+    expect(compactErrorText("boom")).toBe("boom");
+    expect(compactErrorText(404)).toBe("404");
+  });
+});

--- a/src/lark/sdkLogger.ts
+++ b/src/lark/sdkLogger.ts
@@ -1,0 +1,45 @@
+/**
+ * lark/sdkLogger.ts
+ *
+ * Suppressing the vendored `@larksuiteoapi/node-sdk` (1.67.0) Client's noisy
+ * internal error logging for our one-off, best-effort task-v2 REST calls
+ * (bridge self-join, `doctor` scope probe, `tasklist-init` reuse). Those calls
+ * handle failure ourselves with a clean message, so the SDK's raw dump is pure
+ * noise — on a members-endpoint 404 it prints the ENTIRE AxiosError instance
+ * (config + ClientRequest + response, thousands of characters) to stdout.
+ *
+ * ⚠️ `loggerLevel: LoggerLevel.fatal` does NOT silence it. The SDK's public
+ * `Client` builds its logger as
+ *     new LoggerProxy(params.loggerLevel || LoggerLevel.info, ...)
+ * and because `LoggerLevel.fatal === 0` is falsy, `0 || info` collapses back to
+ * `info`, so `error`-level logs always fire. (Verified against node-sdk 1.67.0
+ * and reproduced on the real machine — the dump survived three rounds of
+ * `loggerLevel: fatal`.) The reliable silence is to pass a `logger` whose
+ * methods are no-ops: `LoggerProxy.error` unconditionally calls
+ * `this.logger.error(...)` once the (mis-computed) level gate passes, so a
+ * no-op logger produces no output regardless of the level bug.
+ *
+ * Only pass this to the throwaway task REST clients — never to the live WS
+ * channel client, whose SDK diagnostics we want.
+ */
+
+/** No-op logger matching the SDK's `Logger` interface (error/warn/info/debug/trace). */
+export const silentSdkLogger = {
+  error(..._msg: unknown[]) {},
+  warn(..._msg: unknown[]) {},
+  info(..._msg: unknown[]) {},
+  debug(..._msg: unknown[]) {},
+  trace(..._msg: unknown[]) {},
+};
+
+/**
+ * A one-line, log-safe rendering of an error for our OWN `console.warn`/`error`
+ * calls. Passing the raw error object to `console.*` is a second, independent
+ * source of AxiosError noise: a `TaskApiError` carries the original axios error
+ * on `.cause`, and Node's `util.inspect` expands that cause chain into the same
+ * multi-kilobyte dump. Logging just the message keeps the failure visible
+ * without the object graph.
+ */
+export function compactErrorText(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,11 +1,12 @@
 import { mkdirSync } from "node:fs";
 import path from "node:path";
 import { resolveLarkwayVersion } from "./version.js";
-import { Client as LarkSdkClient, LoggerLevel } from "@larksuiteoapi/node-sdk";
+import { Client as LarkSdkClient } from "@larksuiteoapi/node-sdk";
 import { loadConfig, loadConfigJson } from "./config.js";
 import type { Config, ConfigJsonType } from "./config.js";
 import { ChannelClient, resolveOpenChatDiscoveryMs } from "./lark/channelClient.js";
 import { CardRenderer } from "./lark/card.js";
+import { silentSdkLogger, compactErrorText } from "./lark/sdkLogger.js";
 import { SessionStore } from "./claude/sessionStore.js";
 import { BridgeHandler } from "./bridge/handler.js";
 import { upsertRuntimeEvent } from "./bridge/eventLog.js";
@@ -95,7 +96,10 @@ function printExternalCliProbe(bots: BotConfig[]): void {
  */
 async function fetchBotAvatar(appId: string, appSecret: string): Promise<string | undefined> {
   try {
-    const client = new LarkSdkClient({ appId, appSecret });
+    // logger: silentSdkLogger — this fetch is fire-and-forget with a silent
+    // catch below; without it the SDK dumps the raw AxiosError to stdout (per
+    // bot) on any failure before we swallow it. See lark/sdkLogger.ts.
+    const client = new LarkSdkClient({ appId, appSecret, logger: silentSdkLogger });
     const resp = (await client.request({
       method: "GET",
       url: "/open-apis/bot/v3/info",
@@ -466,14 +470,16 @@ async function runV2Mode({
     {
       const guid = bot.taskHandle?.tasklistGuid ?? (await readTeamTasklistGuid(resolveTaskTeamRegistryPath()));
       if (guid) {
-        // loggerLevel: fatal — the node-sdk Client otherwise dumps the full raw
-        // AxiosError (default `error` level) to stdout/the bridge log on every
-        // request failure, before our own .catch. The self-join 404 below is
-        // best-effort and warned cleanly, so that raw dump is pure log noise.
+        // silentSdkLogger — the node-sdk Client otherwise dumps the full raw
+        // AxiosError (config + ClientRequest + response) to stdout/the bridge
+        // log on every request failure, before our own .catch. The self-join
+        // 404 below is best-effort and warned cleanly, so that raw dump is pure
+        // log noise. `loggerLevel: fatal` does NOT work here (falsy-zero bug in
+        // the vendored SDK — see lark/sdkLogger.ts); a no-op logger does.
         const taskSdkClient = new LarkSdkClient({
           appId: bot.app_id,
           appSecret,
-          loggerLevel: LoggerLevel.fatal,
+          logger: silentSdkLogger,
         });
         const taskRequester: LarkTaskRequester = {
           request: (config) => taskSdkClient.request(config as Parameters<typeof taskSdkClient.request>[0]),
@@ -488,9 +494,11 @@ async function runV2Mode({
         await taskListClient
           .addTasklistMembers(guid, [{ id: bot.app_id, type: "app", role: "editor" }])
           .catch((err) => {
+            // compactErrorText, not the raw err: a TaskApiError carries the
+            // axios error on .cause, and console.warn(msg, err) would expand
+            // that cause chain into the same multi-KB AxiosError dump.
             console.warn(
-              `[larkway] bot "${bot.id}": self-join tasklist ${guid} as editor failed (continuing, best-effort):`,
-              err,
+              `[larkway] bot "${bot.id}": self-join tasklist ${guid} as editor failed (continuing, best-effort): ${compactErrorText(err)}`,
             );
           });
         effectiveTaskHandleTasklistGuid = guid;


### PR DESCRIPTION
## Problem

Real-machine打脸 (v0.3.36): the bridge startup **self-join 404 still dumps the full raw AxiosError object** (config + ClientRequest + response, thousands of chars) to the bridge log — identical to v0.3.35. The `loggerLevel: fatal` added in v0.3.36 (self-join, tasklist-init reuse, doctor) **never worked**.

## Root cause (verified against node-sdk 1.67.0, reproduced on real machine)

The vendored SDK's public `Client` builds its logger as:

```js
new LoggerProxy(params.loggerLevel || LoggerLevel.info, ...)
```

`LoggerLevel.fatal === 0` is **falsy**, so `0 || info` collapses back to `info`. Empirically `client.logger.level === 3` (info), and `LoggerProxy.error` fires whenever `level >= error (1)`. Every `loggerLevel: fatal` we shipped was dead.

There are also **two independent dump sources** per self-join:
1. the SDK's internal `logger.error(rawAxiosError)` **during** the request; and
2. our own `console.warn(msg, err)` in the `.catch` — `TaskApiError` carries the axios error on `.cause`, so `util.inspect` expands the same KB-scale dump a **second** time (measured 5425 chars).

## Fix (`src/lark/sdkLogger.ts`)

- **`silentSdkLogger`** — a no-op `Logger`. `LoggerProxy.error` unconditionally calls `this.logger.error()` once the (mis-computed) gate passes, so a no-op logger is silent *regardless* of the level bug. Applied to every throwaway task REST client: bridge self-join, `fetchBotAvatar`, `tasklist-init` reuse, `doctor` probe.
- **`compactErrorText`** — our own `console.warn`/catch now logs `err.message` only, never the raw object, so the `.cause` chain can't be expanded.

## Verification (hard, per request — not "changed, should be fine")

- `src/lark/sdkLogger.test.ts` drives the **real** node-sdk `LoggerProxy` seam (no mock, no network): asserts a `Client` built with `silentSdkLogger` emits nothing on `.error`, plus a **regression guard** asserting `loggerLevel: fatal` is coerced to `info` and still dumps (so nobody reverts to it).
- End-to-end: a real 404 driven through the **built** self-join shape emits only the one-line warn — `AxiosError` dumps = 0, raw-object markers (ClientRequest/_header/xsrf) = 0.
- `pnpm typecheck` / `pnpm test` (1394) / `pnpm build` all green.

For v0.3.37.

🤖 Generated with [Claude Code](https://claude.com/claude-code)