### PR TITLE
feat: surface web update version action

### DIFF
--- a/src/web/api.test.ts
+++ b/src/web/api.test.ts
@@ -21,6 +21,7 @@ import yaml from "js-yaml";
 
 import {
   _setEventNameResolverExecForTest,
+  _setUpdateVersionExecForTest,
   createManagementContext,
   matchRoute,
   ROUTES,
@@ -84,6 +85,8 @@ async function makeTmpDir(): Promise<string> {
 }
 
 afterEach(async () => {
+  _setEventNameResolverExecForTest();
+  _setUpdateVersionExecForTest();
   await Promise.all(tmpDirs.map((d) => rm(d, { recursive: true, force: true })));
   tmpDirs = [];
 });
@@ -253,6 +256,51 @@ describe("GET /api/context", () => {
     expect(res.status).toBe(200);
     expect((res.json as Record<string, unknown>).mode).toBe("local");
     expect((res.json as Record<string, unknown>).centralAvailable).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// /api/update_version
+// ---------------------------------------------------------------------------
+
+describe("GET /api/update_version", () => {
+  it("reports when global larkway is behind npm latest", async () => {
+    _setUpdateVersionExecForTest(async (file, args) => {
+      if (file === "larkway" && args.join(" ") === "--version") {
+        return { stdout: "0.3.30\n", stderr: "" };
+      }
+      if (file === "npm" && args.join(" ") === "view larkway version") {
+        return { stdout: "0.3.37\n", stderr: "" };
+      }
+      throw new Error(`unexpected command: ${file} ${args.join(" ")}`);
+    });
+
+    const dir = await makeLocalBotsDir();
+    const ctx = makeCtx(dir);
+    const res = await call(ctx, "GET /api/update_version");
+    expect(res.status).toBe(200);
+    expect(res.json).toMatchObject({
+      currentVersion: "0.3.30",
+      latestVersion: "0.3.37",
+      updateAvailable: true,
+    });
+  });
+});
+
+describe("POST /api/update_version", () => {
+  it("delegates to the existing larkway updater", async () => {
+    const calls: string[] = [];
+    _setUpdateVersionExecForTest(async (file, args) => {
+      calls.push(`${file} ${args.join(" ")}`);
+      return { stdout: '{"ok":true,"status":"complete"}\n', stderr: "" };
+    });
+
+    const dir = await makeLocalBotsDir();
+    const ctx = makeCtx(dir);
+    const res = await call(ctx, "POST /api/update_version");
+    expect(res.status).toBe(200);
+    expect(res.json).toMatchObject({ ok: true });
+    expect(calls).toEqual(["larkway update --latest --json"]);
   });
 });
 

--- a/src/web/api.ts
+++ b/src/web/api.ts
@@ -65,9 +65,20 @@ type EventExecFile = (
 ) => Promise<{ stdout: string; stderr: string }>;
 let eventExecFile: EventExecFile = execFileAsync as EventExecFile;
 
+type UpdateExecFile = (
+  file: string,
+  args: string[],
+  opts: { timeout: number; maxBuffer?: number },
+) => Promise<{ stdout: string; stderr: string }>;
+let updateExecFile: UpdateExecFile = execFileAsync as UpdateExecFile;
+
 export function _setEventNameResolverExecForTest(fn?: EventExecFile): void {
   chatNameCache.clear();
   eventExecFile = fn ?? (execFileAsync as EventExecFile);
+}
+
+export function _setUpdateVersionExecForTest(fn?: UpdateExecFile): void {
+  updateExecFile = fn ?? (execFileAsync as UpdateExecFile);
 }
 
 /**
@@ -75,6 +86,9 @@ export function _setEventNameResolverExecForTest(fn?: EventExecFile): void {
  * 避免版本号漂移)。模块加载时读一次;失败回退 "0.0.0"。
  */
 const LARKWAY_VERSION: string = resolveLarkwayVersion(import.meta.url, "0.0.0");
+const UPDATE_CHECK_TIMEOUT_MS = 5000;
+const UPDATE_RUN_TIMEOUT_MS = 5 * 60 * 1000;
+const UPDATE_MAX_BUFFER = 2 * 1024 * 1024;
 
 // ---------------------------------------------------------------------------
 // ManagementContext — the local / central abstraction
@@ -267,6 +281,43 @@ function badBotId(id: string): ApiResponse | null {
   return BOT_ID_RE.test(id) ? null : { status: 400, json: { error: `非法的助手 id "${id}"` } };
 }
 
+function firstVersion(text: string): string | null {
+  return text.match(/\b\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?\b/)?.[0] ?? null;
+}
+
+function compareVersion(a: string, b: string): number {
+  const aa = a.split(/[+-]/)[0].split(".").map((n) => Number.parseInt(n, 10) || 0);
+  const bb = b.split(/[+-]/)[0].split(".").map((n) => Number.parseInt(n, 10) || 0);
+  for (let i = 0; i < 3; i++) {
+    if ((aa[i] ?? 0) !== (bb[i] ?? 0)) return (aa[i] ?? 0) - (bb[i] ?? 0);
+  }
+  return 0;
+}
+
+async function readGlobalLarkwayVersion(): Promise<string> {
+  try {
+    const { stdout, stderr } = await updateExecFile("larkway", ["--version"], {
+      timeout: UPDATE_CHECK_TIMEOUT_MS,
+      maxBuffer: UPDATE_MAX_BUFFER,
+    });
+    return firstVersion(`${stdout}\n${stderr}`) ?? LARKWAY_VERSION;
+  } catch {
+    return LARKWAY_VERSION;
+  }
+}
+
+async function readLatestLarkwayVersion(): Promise<string | null> {
+  try {
+    const { stdout, stderr } = await updateExecFile("npm", ["view", "larkway", "version"], {
+      timeout: UPDATE_CHECK_TIMEOUT_MS,
+      maxBuffer: UPDATE_MAX_BUFFER,
+    });
+    return firstVersion(`${stdout}\n${stderr}`);
+  } catch {
+    return null;
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Route handlers
 // ---------------------------------------------------------------------------
@@ -280,6 +331,56 @@ const getContext: ApiHandler = async (req) => {
     status: 200,
     json: { mode: ctx.mode, centralAvailable: false, version: LARKWAY_VERSION },
   };
+};
+
+/**
+ * GET /api/update_version — compare the globally installed larkway with npm latest.
+ */
+const getUpdateVersion: ApiHandler = async () => {
+  const [currentVersion, latestVersion] = await Promise.all([
+    readGlobalLarkwayVersion(),
+    readLatestLarkwayVersion(),
+  ]);
+  return {
+    status: 200,
+    json: {
+      currentVersion,
+      latestVersion,
+      updateAvailable: latestVersion ? compareVersion(latestVersion, currentVersion) > 0 : false,
+    },
+  };
+};
+
+/**
+ * POST /api/update_version — run the existing updater: npm latest + bridge restart.
+ */
+const postUpdateVersion: ApiHandler = async () => {
+  try {
+    const { stdout, stderr } = await updateExecFile("larkway", ["update", "--latest", "--json"], {
+      timeout: UPDATE_RUN_TIMEOUT_MS,
+      maxBuffer: UPDATE_MAX_BUFFER,
+    });
+    return {
+      status: 200,
+      json: {
+        ok: true,
+        message: "larkway 已更新，bridge 已重启。刷新管理页后会使用新版 UI。",
+        stdout: stdout.trim(),
+        stderr: stderr.trim(),
+      },
+    };
+  } catch (e) {
+    const err = e as NodeJS.ErrnoException & { stdout?: string; stderr?: string };
+    return {
+      status: 500,
+      json: {
+        ok: false,
+        error: err.message ?? String(e),
+        stdout: typeof err.stdout === "string" ? err.stdout.trim() : "",
+        stderr: typeof err.stderr === "string" ? err.stderr.trim() : "",
+      },
+    };
+  }
 };
 
 /**
@@ -1328,6 +1429,8 @@ const getBackends: ApiHandler = async (_req) => {
  */
 export const ROUTES: Record<string, ApiHandler> = {
   "GET /api/context": getContext,
+  "GET /api/update_version": getUpdateVersion,
+  "POST /api/update_version": postUpdateVersion,
   "GET /api/bots": getBots,
   "GET /api/bot/:id": getBot,
   "GET /api/bot/:id/events": getBotEvents,

--- a/src/web/public/app.js
+++ b/src/web/public/app.js
@@ -405,6 +405,12 @@ const state = {
   eventFilters: {},
   /** 最近事件面板是否展开全部,按 bot id 索引。 */
   eventShowAll: {},
+  /** 当前 UI 版本(/api/context)。 */
+  runningVersion: null,
+  /** 全局 larkway 版本检查结果(/api/update_version)。 */
+  updateVersion: null,
+  /** 更新按钮是否正在执行。 */
+  updateVersionBusy: false,
   /** 当前详情表单是否有未保存改动(基础+高级 yaml 表单)。 */
   formDirty: false,
   /** 当前详情 memory 是否有未保存改动。 */
@@ -4559,6 +4565,74 @@ function renderOnboardError(msg) {
   modal.querySelector("#ob2-err-retry")?.addEventListener("click", () => openOnboardModal());
 }
 
+function renderBrandVersion() {
+  const btn = document.getElementById("brand-ver");
+  if (!btn) return;
+
+  const info = state.updateVersion;
+  const current = state.runningVersion ?? info?.currentVersion;
+  const latest = info?.latestVersion;
+  const updateAvailable = Boolean(info?.updateAvailable && latest);
+
+  btn.classList.toggle("is-update-available", updateAvailable);
+  btn.classList.toggle("is-busy", state.updateVersionBusy);
+  btn.disabled = !updateAvailable || state.updateVersionBusy;
+
+  if (state.updateVersionBusy) {
+    btn.textContent = "更新中…";
+    btn.title = "正在更新 Larkway";
+    return;
+  }
+
+  if (updateAvailable) {
+    btn.textContent = `v${latest}·可更新`;
+    btn.title = current ? `当前 v${current}，点击更新到 v${latest}` : `点击更新到 v${latest}`;
+    return;
+  }
+
+  btn.textContent = current ? `v${current}` : "";
+  btn.title = "Larkway 版本";
+}
+
+async function refreshUpdateVersion() {
+  const res = await api("GET", "/api/update_version");
+  if (!res.ok) return;
+  state.updateVersion = res.json;
+  renderBrandVersion();
+}
+
+async function doUpdateVersion() {
+  const info = state.updateVersion;
+  if (!info?.updateAvailable || state.updateVersionBusy) return;
+
+  const confirmed = await confirmDialog({
+    title: "更新 Larkway？",
+    body:
+      `将执行 npm i -g larkway@latest，并重启 bridge。\n\n` +
+      `当前全局版本：v${info.currentVersion ?? "unknown"}\n` +
+      `最新版本：v${info.latestVersion ?? "latest"}`,
+    confirmText: "确认更新",
+  });
+  if (!confirmed) return;
+
+  state.updateVersionBusy = true;
+  renderBrandVersion();
+  const res = await api("POST", "/api/update_version");
+  state.updateVersionBusy = false;
+
+  if (!res.ok) {
+    toast(`更新失败：${res.json?.error ?? res.status}`, "error");
+    renderBrandVersion();
+    return;
+  }
+
+  toast(res.json?.message ?? "已更新全局 larkway，刷新管理页后使用新版 UI。", "ok");
+  await refreshUpdateVersion();
+  await refreshRuntimeRequirements();
+  await refreshBridgeStatus();
+  await pollStatus();
+}
+
 // ---------------------------------------------------------------------------
 // 接线 + 启动
 // ---------------------------------------------------------------------------
@@ -4570,6 +4644,9 @@ function wireEvents() {
   // 添加新助手:页面内扫码开通(POST /api/onboard/start → 轮询 → 落盘)
   document.getElementById("btn-add")?.addEventListener("click", () => {
     openOnboardModal();
+  });
+  document.getElementById("brand-ver")?.addEventListener("click", () => {
+    void doUpdateVersion();
   });
 
   // 同步预览 modal 背景点击关闭
@@ -4616,8 +4693,8 @@ async function boot() {
   if (ctxRes.ok) {
     state.mode = "local";
     const ver = ctxRes.json?.version;
-    const verEl = document.getElementById("brand-ver");
-    if (verEl && ver) verEl.textContent = "v" + ver;
+    if (ver) state.runningVersion = ver;
+    renderBrandVersion();
     // 填充本机 hostname badge(浏览器侧地址,本机即 127.0.0.1)
     const hostEl = document.getElementById("ctx-host");
     const host = location.hostname || "";
@@ -4625,6 +4702,7 @@ async function boot() {
   }
 
   renderContextSwitch();
+  void refreshUpdateVersion();
 
   // 拉 backend 注册表(驱动底座选择就绪态;失败静默)
   void loadBackends();

--- a/src/web/public/index.html
+++ b/src/web/public/index.html
@@ -27,7 +27,7 @@
         </span>
         <span class="brand-word">Larkway</span>
         <span class="brand-sub">看板</span>
-        <span class="brand-ver" id="brand-ver" title="Larkway 版本"></span>
+        <button class="brand-ver" id="brand-ver" type="button" title="Larkway 版本"></button>
         <span class="ctx-static" id="ctx-static-badge">
           <span class="ctx-dot"></span>本机<span class="ctx-host" id="ctx-host"></span>
         </span>

--- a/src/web/public/style.css
+++ b/src/web/public/style.css
@@ -231,6 +231,7 @@ body {
   margin-left: 1px;
 }
 .brand-ver {
+  appearance: none;
   font-size: 11px;
   font-weight: 500;
   font-family: ui-monospace, "Cascadia Code", "Fira Code", monospace;
@@ -242,9 +243,28 @@ body {
   background: var(--bg);
   line-height: 1.5;
   white-space: nowrap;
+  cursor: default;
 }
 .brand-ver:empty {
   display: none;
+}
+.brand-ver:disabled {
+  opacity: 1;
+}
+.brand-ver.is-update-available {
+  color: #fff;
+  background: var(--br);
+  border-color: var(--br);
+  cursor: pointer;
+  box-shadow: 0 6px 16px rgba(79, 70, 229, 0.18);
+}
+.brand-ver.is-update-available:hover:not(:disabled) {
+  background: #4338ca;
+  border-color: #4338ca;
+}
+.brand-ver.is-update-available:focus-visible {
+  outline: none;
+  box-shadow: var(--ring);
 }
 
 /* 中间绝对居中分段控件(轨道 #f6f7f9 圆角9,active 白底+阴影 圆角7) */


### PR DESCRIPTION
## 变更说明

- 新增 `GET /api/update_version`，用于比较当前全局安装的 Larkway 版本和 npm 最新版本
- 新增 `POST /api/update_version`，复用现有 `larkway update --latest --json` 更新流程
- 当存在新版本时，将左上角版本号胶囊变成更新入口
- 没有新版本时，版本号仍保持原来的灰色样式

## 交互效果

当当前全局版本是 `v0.3.30`，npm 最新版本是 `v0.3.37` 时，版本号会从：

`v0.3.30`

变成：

`v0.3.37·可更新`

点击后会弹窗确认，确认后执行全局 `larkway` 更新，并重启 bridge 服务。

## 设计取舍

这版没有在左下角新增独立更新按钮，更新入口只放在左上角版本号上，避免侧边栏底部多一个维护类按钮。

这版也不做 Web UI 进程自重启。更新完成后会提示用户刷新或重新打开管理页，以使用新版 UI。

## 验证

- `./node_modules/.bin/vitest run src/web/api.test.ts`
- `./node_modules/.bin/tsc --noEmit`
- 手动验证：
  - `/api/context` 返回 `version: 0.3.30`
  - `/api/update_version` 返回 `currentVersion: 0.3.30`、`latestVersion: 0.3.37`、`updateAvailable: true`