### PR TITLE
feat: add bot permission authorization link

### DIFF
--- a/src/web/api.test.ts
+++ b/src/web/api.test.ts
@@ -21,6 +21,7 @@ import yaml from "js-yaml";
 
 import {
   _setEventNameResolverExecForTest,
+  _setPermissionAuthExecForTest,
   createManagementContext,
   matchRoute,
   ROUTES,
@@ -310,6 +311,79 @@ describe("GET /api/bot/:id", () => {
     const ctx = makeCtx(dir);
     const res = await call(ctx, "GET /api/bot/:id", { params: { id: "nonexistent" } });
     expect(res.status).toBe(404);
+  });
+});
+
+describe("POST /api/bot/:id/permission-auth", () => {
+  afterEach(() => {
+    _setPermissionAuthExecForTest();
+  });
+
+  it("generates the authorization URL with the selected bot's own profile and full scope list", async () => {
+    const dir = await makeLocalBotsDir();
+    await writeFile(
+      path.join(dir, "second-bot.yaml"),
+      `id: second-bot
+name: Second Bot
+description: Another bot used in tests
+app_id: cli_second123
+app_secret_env: SECOND_APP_SECRET_ENV
+bot_open_id: ou_second123
+lark_cli_profile: second-profile
+chats: []
+`,
+      "utf-8",
+    );
+    const ctx = makeCtx(dir);
+    ctx.stores.hostConfig = { ...ctx.stores.hostConfig, readSecret: async () => null };
+    const calls: Array<{ file: string; args: string[] }> = [];
+    _setPermissionAuthExecForTest(async (file, args) => {
+      calls.push({ file, args });
+      return {
+        stdout: JSON.stringify({
+          verification_url:
+            `https://accounts.feishu.cn/oauth/v1/device/verify?flow_id=${encodeURIComponent(args[1])}&user_code=AUTH-LINK`,
+          device_code: "device_code_must_not_leak",
+          expires_in: 600,
+          interval: 5,
+        }),
+        stderr: "",
+      };
+    });
+
+    const first = await call(ctx, "POST /api/bot/:id/permission-auth", { params: { id: "test-bot" } });
+    const second = await call(ctx, "POST /api/bot/:id/permission-auth", { params: { id: "second-bot" } });
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    expect(calls[0]).toMatchObject({ file: "lark-cli", args: ["--profile", "cli_test123", "auth", "login", "--scope", expect.any(String), "--no-wait", "--json"] });
+    expect(calls[1]).toMatchObject({ file: "lark-cli", args: ["--profile", "second-profile", "auth", "login", "--scope", expect.any(String), "--no-wait", "--json"] });
+    const requestedScopes = calls[1].args[5].split(/\s+/);
+    expect(requestedScopes).toContain("application:bot.basic_info:read");
+    expect(requestedScopes).toContain("task:tasklist:write");
+    expect(requestedScopes).toContain("wiki:node:retrieve");
+    expect(requestedScopes).toContain("offline_access");
+    expect((second.json as { authorizationUrl?: string }).authorizationUrl).toContain("second-profile");
+    expect(JSON.stringify(second.json)).not.toContain("device_code_must_not_leak");
+    expect(JSON.stringify(second.json)).not.toContain("SECOND_APP_SECRET_ENV");
+    expect(JSON.stringify(second.json)).not.toContain("--profile");
+  });
+
+  it("does not leak raw lark-cli failure details", async () => {
+    const dir = await makeLocalBotsDir();
+    const ctx = makeCtx(dir);
+    ctx.stores.hostConfig = { ...ctx.stores.hostConfig, readSecret: async () => null };
+    _setPermissionAuthExecForTest(async () => {
+      throw new Error("Command failed: lark-cli --profile cli_test123 auth login --scope raw_scope secret=raw_secret");
+    });
+
+    const res = await call(ctx, "POST /api/bot/:id/permission-auth", { params: { id: "test-bot" } });
+
+    expect(res.status).toBe(502);
+    const text = JSON.stringify(res.json);
+    expect(text).not.toContain("raw_secret");
+    expect(text).not.toContain("raw_scope");
+    expect(text).not.toContain("--profile");
   });
 });
 

--- a/src/web/api.ts
+++ b/src/web/api.ts
@@ -35,6 +35,7 @@ import {
 import { permissionItemsFromCapabilities } from "../agent/permissionPlan.js";
 import { resolveAgentWorkspacePathFromHome } from "../config/paths.js";
 import { resolveLarkwayVersion } from "../version.js";
+import { deriveLarkCliProfile, ensureLarkCliProfile } from "../lark/profileBootstrap.js";
 import {
   readStatusFile,
   classifyStatus,
@@ -70,11 +71,87 @@ export function _setEventNameResolverExecForTest(fn?: EventExecFile): void {
   eventExecFile = fn ?? (execFileAsync as EventExecFile);
 }
 
+type PermissionAuthExecFile = (
+  file: string,
+  args: string[],
+  opts: { timeout: number; maxBuffer: number },
+) => Promise<{ stdout: string; stderr: string }>;
+let permissionAuthExecFile: PermissionAuthExecFile = execFileAsync as PermissionAuthExecFile;
+
+export function _setPermissionAuthExecForTest(fn?: PermissionAuthExecFile): void {
+  permissionAuthExecFile = fn ?? (execFileAsync as PermissionAuthExecFile);
+}
+
 /**
  * Larkway 版本号 —— 读 package.json(单一源,和 main.ts 共用 resolveLarkwayVersion,
  * 避免版本号漂移)。模块加载时读一次;失败回退 "0.0.0"。
  */
 const LARKWAY_VERSION: string = resolveLarkwayVersion(import.meta.url, "0.0.0");
+
+const BOT_PERMISSION_SCOPE_GROUPS = {
+  tenant: [
+    "aily:data_asset:upload_file",
+    "application:application:self_manage",
+    "application:bot.basic_info:read",
+    "application:bot.menu:write",
+    "cardkit:card:read",
+    "cardkit:card:write",
+    "contact:contact.base:readonly",
+    "docs:document.comment:create",
+    "docs:document.comment:delete",
+    "docs:document.comment:read",
+    "docs:document.comment:update",
+    "docs:document.comment:write_only",
+    "docs:document.media:download",
+    "docs:document.media:upload",
+    "docs:document:import",
+    "docs:permission.member:create",
+    "docx:document.block:convert",
+    "docx:document:readonly",
+    "docx:document:write_only",
+    "drive:drive.metadata:readonly",
+    "drive:file:upload",
+    "im:chat.members:bot_access",
+    "im:chat:create",
+    "im:chat:read",
+    "im:chat:readonly",
+    "im:chat:update",
+    "im:message",
+    "im:message.group_at_msg.include_bot:readonly",
+    "im:message.group_at_msg:readonly",
+    "im:message.group_msg",
+    "im:message.p2p_msg:readonly",
+    "im:message.pins:read",
+    "im:message.pins:write_only",
+    "im:message.reactions:read",
+    "im:message.reactions:write_only",
+    "im:message:readonly",
+    "im:message:send_as_bot",
+    "im:message:send_multi_users",
+    "im:message:send_sys_msg",
+    "im:message:update",
+    "im:resource",
+    "task:attachment:read",
+    "task:attachment:write",
+    "task:comment",
+    "task:comment:read",
+    "task:comment:write",
+    "task:custom_field:read",
+    "task:custom_field:write",
+    "task:task",
+    "task:task:read",
+    "task:task:readonly",
+    "task:task:write",
+    "task:task:writeonly",
+    "task:tasklist.privilege:read",
+    "task:tasklist:read",
+    "task:tasklist:write",
+    "wiki:node:read",
+    "wiki:node:retrieve",
+  ],
+  user: ["offline_access"],
+} as const;
+const BOT_PERMISSION_AUTH_TIMEOUT_MS = 15_000;
 
 // ---------------------------------------------------------------------------
 // ManagementContext — the local / central abstraction
@@ -370,6 +447,131 @@ const getBot: ApiHandler = async (req) => {
     return { status: 500, json: { error: msg } };
   }
 };
+
+/**
+ * POST /api/bot/:id/permission-auth — generate a Feishu device-flow URL for
+ * this bot's own lark-cli profile. No raw command, profile, secret, or
+ * device_code is returned.
+ */
+const postBotPermissionAuth: ApiHandler = async (req) => {
+  const { ctx, params } = req;
+  const id = params.id;
+  {
+    const e = badBotId(id);
+    if (e) return e;
+  }
+  if (ctx.mode !== "local") {
+    return { status: 403, json: { error: "只支持在本机助手上下文中生成授权链接。" } };
+  }
+
+  let bot: Awaited<ReturnType<typeof botsStore.readBot>>;
+  try {
+    bot = await ctx.stores.botsStore.readBot(id);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return { status: msg.includes("not found") ? 404 : 500, json: { error: msg } };
+  }
+
+  const profile = deriveLarkCliProfile(bot.lark_cli_profile, bot.app_id);
+  const scopes = [...BOT_PERMISSION_SCOPE_GROUPS.tenant, ...BOT_PERMISSION_SCOPE_GROUPS.user];
+
+  try {
+    const appSecret = await ctx.stores.hostConfig.readSecret(bot.app_secret_env).catch(() => null);
+    if (appSecret) {
+      ensureLarkCliProfile(bot.id, profile, bot.app_id, appSecret);
+    }
+
+    const { stdout } = await permissionAuthExecFile(
+      process.env.LARK_CLI_PATH || "lark-cli",
+      ["--profile", profile, "auth", "login", "--scope", scopes.join(" "), "--no-wait", "--json"],
+      { timeout: BOT_PERMISSION_AUTH_TIMEOUT_MS, maxBuffer: 1024 * 1024 },
+    );
+    const payload = parseJsonObjectFromText(stdout);
+    const authorizationUrl = extractPermissionAuthorizationUrl(payload);
+    if (!authorizationUrl) {
+      return {
+        status: 502,
+        json: { error: "飞书授权链接生成失败: lark-cli 没有返回可打开的授权链接。" },
+      };
+    }
+
+    return {
+      status: 200,
+      json: {
+        ok: true,
+        botId: bot.id,
+        authorizationUrl,
+        expiresIn: positiveNumberField(payload, ["expires_in", "expiresIn"]),
+        intervalSeconds: positiveNumberField(payload, ["interval", "intervalSeconds"]),
+        scopeGroups: BOT_PERMISSION_SCOPE_GROUPS,
+      },
+    };
+  } catch (e) {
+    const message = permissionAuthErrorMessage(e);
+    return { status: message.status, json: { error: message.error } };
+  }
+};
+
+function parseJsonObjectFromText(text: string): Record<string, unknown> {
+  const raw = String(text || "").trim();
+  if (!raw) return {};
+  const direct = tryParseJsonObject(raw);
+  if (direct) return direct;
+
+  for (const line of raw.split("\n").map((item) => item.trim()).filter(Boolean).reverse()) {
+    const parsed = tryParseJsonObject(line);
+    if (parsed) return parsed;
+  }
+
+  const first = raw.indexOf("{");
+  const last = raw.lastIndexOf("}");
+  return first >= 0 && last > first ? tryParseJsonObject(raw.slice(first, last + 1)) ?? {} : {};
+}
+
+function tryParseJsonObject(text: string): Record<string, unknown> | null {
+  try {
+    const parsed = JSON.parse(text);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed as Record<string, unknown> : null;
+  } catch {
+    return null;
+  }
+}
+
+function extractPermissionAuthorizationUrl(payload: Record<string, unknown>): string {
+  for (const value of [
+    payload.verification_url,
+    payload.verificationUrl,
+    payload.verification_uri,
+    payload.verificationUri,
+    payload.auth_url,
+    payload.authUrl,
+  ]) {
+    const url = typeof value === "string" ? value.trim() : "";
+    if (/^https:\/\/accounts\.feishu\.cn\/oauth\/v1\/device\/verify\?/i.test(url)) {
+      return url;
+    }
+  }
+  return "";
+}
+
+function positiveNumberField(payload: Record<string, unknown>, keys: string[]): number | undefined {
+  for (const key of keys) {
+    const value = typeof payload[key] === "number" ? payload[key] : Number(String(payload[key] ?? "").trim());
+    if (Number.isFinite(value) && value > 0) return value;
+  }
+  return undefined;
+}
+
+function permissionAuthErrorMessage(error: unknown): { status: number; error: string } {
+  const text = error instanceof Error ? error.message : String(error || "");
+  if (/not[_ -]?configured|not configured|profile .*not found|profile .*missing|profile .*does not exist/i.test(text)) {
+    return { status: 409, error: "这个 bot 的 lark-cli profile 尚未配置，启动/重启 Larkway 后再试。" };
+  }
+  if (/ENOENT|command not found|no such file/i.test(text)) {
+    return { status: 502, error: "服务端未找到 lark-cli，无法生成飞书授权链接。" };
+  }
+  return { status: 502, error: "飞书授权链接生成失败，请稍后重试。" };
+}
 
 /**
  * GET /api/bot/:id/events — recent Feishu events observed by this local bridge.
@@ -1348,6 +1550,7 @@ export const ROUTES: Record<string, ApiHandler> = {
   "GET /api/context": getContext,
   "GET /api/bots": getBots,
   "GET /api/bot/:id": getBot,
+  "POST /api/bot/:id/permission-auth": postBotPermissionAuth,
   "GET /api/bot/:id/events": getBotEvents,
   "PUT /api/bot/:id": putBot,
   "DELETE /api/bot/:id": deleteBot,

--- a/src/web/public/app.js
+++ b/src/web/public/app.js
@@ -2248,6 +2248,10 @@ function buildHeroInner(id, bot, f) {
   const heroDelBtn = `<button class="btn btn-hero-del" id="btn-hero-del" type="button" title="删除助手">` +
     `<svg class="icon" viewBox="0 0 24 24" aria-hidden="true" style="width:14px;height:14px;flex-shrink:0"><path d="M3 6h18M8 6V4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v2M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6M10 11v6M14 11v6"/></svg>` +
     ` 删除</button>`;
+  const heroPermissionBtn =
+    `<button class="btn btn-primary btn-hero-auth" id="btn-permission-auth" type="button" title="申请这个助手所需的飞书权限">` +
+    ICONS.shield +
+    ` 申请全部权限</button>`;
 
   // 触点②:hero kicker 行,紧跟眉批加 backend chip(mono + vendor)
   const backendKickerChip = lkBackendChipHTML(bot.backend || LK_BACKEND_DEFAULT, { mono: true, vendor: true });
@@ -2274,6 +2278,7 @@ function buildHeroInner(id, bot, f) {
     `<span class="hero-eyebrow">${eyebrowLabel} ${num} 个</span>` +
     backendKickerChip +
     editBadge +
+    heroPermissionBtn +
     heroDelBtn +
     `</div>` +
     `<h1 class="hero-title">${esc(f.name || id)}</h1>` +
@@ -3516,8 +3521,7 @@ function wireDetailEvents(panel, id, bot) {
             repoCount: repos.length,
           },
         );
-        // re-wire hero del btn
-        heroBody.querySelector("#btn-hero-del")?.addEventListener("click", () => doDeleteBot(id));
+        wireHeroActions(heroBody, id);
       }
       // 名册行 chip 也跟着换(直接操作 DOM)
       const rosterLi = document.querySelector(`li[data-bot-id="${CSS.escape(id)}"]`);
@@ -3540,10 +3544,7 @@ function wireDetailEvents(panel, id, bot) {
   }
 
   // 详情 hero 删除按钮
-  const btnHeroDel = panel.querySelector("#btn-hero-del");
-  if (btnHeroDel) {
-    btnHeroDel.addEventListener("click", () => doDeleteBot(id));
-  }
+  wireHeroActions(panel, id);
 
 }
 
@@ -3565,9 +3566,7 @@ function acRefreshHero(panel, id, bot) {
     chatCount,
     repoCount,
   });
-  // re-wire del button(内容重建后需重绑)
-  const btnHeroDel = body.querySelector("#btn-hero-del");
-  if (btnHeroDel) btnHeroDel.addEventListener("click", () => doDeleteBot(id));
+  wireHeroActions(body, id);
   // BL-18:re-wire restart panel buttons(timeout 面板 logs/restart/rescan)
   wireRestartPanelButtons(body);
 }
@@ -3627,6 +3626,48 @@ function btnLoading(btn, loadingText) {
     btn.disabled = false;
     btn.innerHTML = original;
   };
+}
+
+function wireHeroActions(root, id) {
+  root.querySelector("#btn-hero-del")?.addEventListener("click", () => doDeleteBot(id));
+  root.querySelector("#btn-permission-auth")?.addEventListener("click", (e) => {
+    startPermissionAuthorization(id, e.currentTarget);
+  });
+}
+
+function getPermissionAuthorizationUrl(payload) {
+  const url = payload?.authorizationUrl || payload?.data?.authorizationUrl || payload?.data?.session?.authorizationUrl;
+  return typeof url === "string" ? url.trim() : "";
+}
+
+async function startPermissionAuthorization(id, triggerBtn) {
+  const authWindow = window.open("", "_blank");
+  if (authWindow) authWindow.opener = null;
+  const restore = btnLoading(triggerBtn, "生成中…");
+
+  try {
+    const res = await api("POST", `/api/bot/${encodeURIComponent(id)}/permission-auth`);
+    if (!res.ok || !res.json?.ok) {
+      throw new Error(res.json?.error || `HTTP ${res.status}`);
+    }
+
+    const url = getPermissionAuthorizationUrl(res.json);
+    if (!url) {
+      throw new Error("飞书授权链接格式不正确。");
+    }
+
+    if (authWindow) {
+      authWindow.location.href = url;
+    } else {
+      window.location.href = url;
+    }
+    toast("已打开飞书授权页", "ok");
+  } catch (e) {
+    authWindow?.close();
+    toast(`生成授权链接失败：${e instanceof Error ? e.message : String(e)}`, "error");
+  } finally {
+    restore();
+  }
 }
 
 /** 保存成功:让 indigo 主按钮闪一下(lk-saveflash)。 */

--- a/src/web/public/style.css
+++ b/src/web/public/style.css
@@ -2144,6 +2144,16 @@ textarea.input {
   cursor: not-allowed;
 }
 /* hero 区「删除」文字按钮 */
+.btn-hero-auth {
+  margin-left: auto;
+  font-size: 12.5px;
+  padding: 5px 11px;
+  border-radius: 8px;
+  gap: 5px;
+}
+.btn-hero-auth + .btn-hero-del {
+  margin-left: 0;
+}
 .btn-hero-del {
   margin-left: auto;
   font-size: 12.5px;


### PR DESCRIPTION
> 本次新增本机管理页里的「申请全部权限」按钮，用于按当前选中的 Bot 独立生成飞书权限授权链接，避免多个 Bot 混用 profile 或申请错权限。

主要改动：
- 新增 POST /api/bot/:id/permission-auth 接口
- 使用当前 Bot 自己的 lark-cli profile 生成授权链接
- 按需求申请完整 tenant/user scopes
- 前端 Bot 详情页新增「申请全部权限」按钮
- 接口返回中避免泄露 device_code、profile、secret、原始命令等敏感信息
- 补充单测覆盖多 Bot 独立 profile、完整 scope、错误信息脱敏