### PR TITLE
feat(BL-38): auto-reset a poisoned session after consecutive idle-kills

### DIFF
--- a/src/bridge/handler.test.ts
+++ b/src/bridge/handler.test.ts
@@ -4256,3 +4256,224 @@ describe("handleOne — provisioning decision tree (unified model)", () => {
     expect(worktreeAddCalls).toHaveLength(0);
   });
 });
+
+// ---------------------------------------------------------------------------
+// BL-38: poison-session self-heal (consecutive idle-kills → drop the session)
+// ---------------------------------------------------------------------------
+
+describe("BL-38: poison-session self-heal", () => {
+  const threadId = "om_msg"; // makeEvent().message_id, no root_id → thread == message id
+  const botId = "frontend";
+  const key = `${botId}:${threadId}`;
+
+  function seedStore(consecutiveStuckCount?: number) {
+    const { store, records } = makePersistentSessionStore();
+    records.set(key, {
+      threadId,
+      sessionId: "sess_prev",
+      botId,
+      createdTs: 1,
+      lastActiveTs: 2,
+      senderOpenId: "ou_seed",
+      ...(consecutiveStuckCount !== undefined ? { consecutiveStuckCount } : {}),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+    return { store, records };
+  }
+
+  function stuckCountOf(records: Map<string, unknown>): number | undefined {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return (records.get(key) as any)?.consecutiveStuckCount;
+  }
+
+  function botConfig() {
+    return {
+      id: botId,
+      name: "Frontend",
+      turn_taking_limit: 10,
+      backend: "claude" as const,
+      cot: "off" as const,
+      response_surface_prototype: {
+        enabled: true,
+        allowed_chats: [],
+        allowed_threads: [threadId],
+        kill_switch: false,
+        post_outbound_enabled: false,
+        cardkit_streaming_enabled: true,
+        allow_agent_mentions: true,
+        denied_mention_open_ids: [],
+        allowed_mention_open_ids: [],
+      },
+    };
+  }
+
+  // Runner that emits system_init then STALLS forever → idle watchdog kills it.
+  function configureIdleRunner(): void {
+    let killed = false;
+    runClaudeImpl = () => {
+      let resolveDone: (r: { exitCode: number; sessionId?: string }) => void = () => {};
+      const done = new Promise<{ exitCode: number; sessionId?: string }>((res) => {
+        resolveDone = res;
+      });
+      return {
+        events: (async function* () {
+          yield { type: "system_init", sessionId: "sess_idle", raw: {} };
+          while (!killed) await new Promise((r) => setTimeout(r, 5));
+        })(),
+        done,
+        kill: () => {
+          killed = true;
+          resolveDone({ exitCode: 143, sessionId: "sess_idle" });
+        },
+      };
+    };
+  }
+
+  // Runner that writes a fresh status=ready state.json then exits 0 (clean success).
+  function configureSuccessRunner(wt: string): void {
+    runClaudeImpl = () => ({
+      events: (async function* () {
+        yield { type: "system_init", sessionId: "sess_ok", raw: {} };
+        await writeFile(
+          stateFileMod.stateFilePathOf(wt),
+          JSON.stringify(
+            { status: "ready", last_message: "完成了", updated_at: "2026-05-29T13:00:00.000Z" },
+            null,
+            2,
+          ),
+          "utf8",
+        );
+      })(),
+      done: Promise.resolve({ exitCode: 0, sessionId: "sess_ok" }),
+      kill: () => {},
+    });
+  }
+
+  // Runner that exits non-zero without writing state.json (a real crash, NOT idle).
+  function configureCrashRunner(): void {
+    runClaudeImpl = () => ({
+      events: (async function* () {
+        yield { type: "system_init", sessionId: "sess_crash", raw: {} };
+      })(),
+      done: Promise.resolve({ exitCode: 1, sessionId: "sess_crash" }),
+      kill: () => {},
+    });
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  async function runTurn(store: any): Promise<{ cardKitCalls: any[]; acked: string[] }> {
+    const { client: cardKitClient, calls: cardKitCalls } = makeCardKitClient();
+    const { renderer } = makeCardRenderer();
+    const { client, acked } = makeClient(makeEvent());
+    const handler = new BridgeHandler({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      client: client as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      cardRenderer: renderer as any,
+      sessionStore: store,
+      conventions: makeConventions(),
+      botConfig: botConfig(),
+      cardKitClient,
+      responseSurfaceIdleTimeoutMs: 30, // tiny idle threshold → fast deterministic kill
+    });
+    await handler.run();
+    for (let i = 0; i < 400 && acked.length === 0; i++) {
+      await new Promise((r) => setTimeout(r, 10));
+    }
+    return { cardKitCalls, acked };
+  }
+
+  function finalCardText(cardKitCalls: Array<{ kind: string; elementId?: string; content?: string }>): string {
+    return cardKitCalls.find((c) => c.kind === "stream" && c.elementId === "final_md")?.content ?? "";
+  }
+
+  it("(a) increments + persists the counter on an idle-kill (below threshold → session kept, 请重试 card)", async () => {
+    const { store, records } = seedStore(0);
+    await seedWorktree(threadId);
+    await seedRepoCachePath();
+    configureIdleRunner();
+
+    const { cardKitCalls, acked } = await runTurn(store);
+
+    expect(acked).toEqual([threadId]); // turn completed (idle-interrupted)
+    expect(records.has(key)).toBe(true); // session NOT dropped below threshold
+    expect(stuckCountOf(records)).toBe(1);
+    const text = finalCardText(cardKitCalls);
+    expect(text).toContain("请重试");
+    expect(text).not.toContain("已重置本话题上下文");
+  });
+
+  it("(b) a clean success resets the counter to 0", async () => {
+    const { store, records } = seedStore(2);
+    const wt = await seedWorktree(threadId);
+    await seedRepoCachePath();
+    configureSuccessRunner(wt);
+
+    await runTurn(store);
+
+    expect(records.has(key)).toBe(true);
+    // Handler writes 0 on success; the real SessionStore then omits the field
+    // on disk (see sessionStore.test.ts "re-putting with 0 clears..."). The
+    // in-memory fake keeps it verbatim, so 0 here === cleared.
+    expect(stuckCountOf(records) ?? 0).toBe(0);
+  });
+
+  it("(c) a non-idle failure (crash, exit≠0) does NOT count and does NOT reset — counter unchanged", async () => {
+    const { store, records } = seedStore(2);
+    await seedWorktree(threadId);
+    await seedRepoCachePath();
+    configureCrashRunner();
+
+    await runTurn(store);
+
+    expect(records.has(key)).toBe(true);
+    expect(stuckCountOf(records)).toBe(2); // conservative: neither +1 nor reset
+  });
+
+  it("(d) reaching the threshold drops the session record + shows the reset card + logs an info line", async () => {
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+    const { store, records } = seedStore(2); // this turn makes it 3 == default threshold
+    await seedWorktree(threadId);
+    await seedRepoCachePath();
+    configureIdleRunner();
+
+    const { cardKitCalls } = await runTurn(store);
+
+    expect(records.has(key)).toBe(false); // poisoned session dropped
+    const text = finalCardText(cardKitCalls);
+    expect(text).toContain("已重置本话题上下文");
+    expect(text).toContain("全新开始");
+    expect(
+      infoSpy.mock.calls.some((c) => String(c[0]).includes("BL-38 stuck-session reset")),
+    ).toBe(true);
+  });
+
+  it("(e) LARKWAY_STUCK_SESSION_RESET_AFTER overrides the threshold", async () => {
+    process.env.LARKWAY_STUCK_SESSION_RESET_AFTER = "2";
+    try {
+      const { store, records } = seedStore(1); // this turn makes it 2 == overridden threshold
+      await seedWorktree(threadId);
+      await seedRepoCachePath();
+      configureIdleRunner();
+
+      const { cardKitCalls } = await runTurn(store);
+
+      expect(records.has(key)).toBe(false); // dropped at the lower threshold
+      expect(finalCardText(cardKitCalls)).toContain("已重置本话题上下文");
+    } finally {
+      delete process.env.LARKWAY_STUCK_SESSION_RESET_AFTER;
+    }
+  });
+
+  it("(f) a record predating the field (no consecutiveStuckCount) counts an idle-kill as the first (backward compatible)", async () => {
+    const { store, records } = seedStore(undefined); // old record: field absent
+    await seedWorktree(threadId);
+    await seedRepoCachePath();
+    configureIdleRunner();
+
+    await runTurn(store);
+
+    expect(records.has(key)).toBe(true);
+    expect(stuckCountOf(records)).toBe(1); // absent treated as 0 → 1
+  });
+});

--- a/src/bridge/handler.ts
+++ b/src/bridge/handler.ts
@@ -108,6 +108,26 @@ const DEFAULT_CARDKIT_IDLE_TIMEOUT_MS = 3 * 60 * 1000;
  */
 const COT_BUBBLE_CREATE_BUDGET_MS = 3_000;
 
+/**
+ * BL-38 (poison-session self-heal): after this many CONSECUTIVE turns that end
+ * by the idle watchdog (a confirmed hang — the thread keeps resuming into a
+ * session that goes silent before its first tool call), the thread's session
+ * record is dropped so the next @ starts from a fresh session. A single
+ * idle-kill is often transient (the owner just retries); only a repeated,
+ * same-session hang is the "behaviorally poisoned session" this treats — and it
+ * produces no resume error, so the stale/ghost-session purge never fires on it.
+ * Env LARKWAY_STUCK_SESSION_RESET_AFTER overrides the default (kept a module
+ * constant, not a bot-config field, to stay simple). A non-positive /
+ * unparseable override falls back to the default.
+ */
+const DEFAULT_STUCK_SESSION_RESET_AFTER = 3;
+function resolveStuckSessionResetAfter(): number {
+  const raw = process.env.LARKWAY_STUCK_SESSION_RESET_AFTER;
+  if (raw === undefined) return DEFAULT_STUCK_SESSION_RESET_AFTER;
+  const n = Number.parseInt(raw, 10);
+  return Number.isFinite(n) && n > 0 ? n : DEFAULT_STUCK_SESSION_RESET_AFTER;
+}
+
 function summarizeMentionPolicyRules(rules: string[]): string {
   const counts = new Map<string, number>();
   for (const rule of rules) {
@@ -2206,83 +2226,27 @@ export class BridgeHandler {
           // only (status=failed → fail; status=ready → success; exitCode 0 →
           // success; else → fail).
 
-          // Step 4e: session persistence (3 cases).
-          const now = Date.now();
-
-          if (sessionId !== undefined && currentExisting === undefined) {
-            // New thread — create record. rootText/chatId (v3 task-handle
-            // dispatch-time capture, docs/task-handle.md §5.2/§9.9) are
-            // captured ONLY here, and ONLY when `isTopLevel` (computed above
-            // from the absence of `root_id`) confirms THIS message truly is
-            // the topic's own root — not merely the first turn the BOT
-            // happened to see. (Adversarial-review fix: an earlier version
-            // captured unconditionally on "this bot's first completed turn
-            // in the thread," which is wrong whenever a human opens a topic
-            // and only @-mentions the bot in a LATER reply — that reply's
-            // text got stored as if it were the root, and could then exact-
-            // match an unrelated task and auto-bind the wrong pair. When
-            // `isTopLevel` is false here, rootText/chatId are simply left
-            // undefined — the same safe "no auto-bind candidate for this
-            // thread" degradation already documented for other rootText
-            // gaps; the agent-path candidate injection is unaffected.)
-            // Truncated defensively when captured; TasklistPoller's exact-
-            // match tolerates (doesn't need to recover from) a truncated
-            // value — see its own doc comment.
-            await this.deps.sessionStore.put({
-              threadId,
-              sessionId,
-              botId,
-              createdTs: now,
-              lastActiveTs: now,
-              senderOpenId,
-              ...(isTopLevel ? { rootText: parsed.text.slice(0, 200), chatId: parsed.chatId } : {}),
-            });
-          } else if (sessionId !== undefined && currentExisting !== undefined) {
-            // Existing thread — update, preserving createdTs AND rootText/
-            // chatId verbatim from whenever this thread was first created
-            // (never recomputed from a later turn's message).
-            await this.deps.sessionStore.put({
-              threadId,
-              sessionId,
-              botId,
-              createdTs: currentExisting.createdTs,
-              lastActiveTs: now,
-              senderOpenId,
-              rootText: currentExisting.rootText,
-              chatId: currentExisting.chatId,
-            });
-          } else if (currentExisting !== undefined && sessionId === undefined) {
-            // Anomaly: no system_init seen; touch to update lastActiveTs at minimum.
-            await this.deps.sessionStore.put({
-              ...currentExisting,
-              lastActiveTs: now,
-            });
-          }
-
-          // Step 4f: finalize card.
-          //
-          // Bridge does NOT interpret content — all fields come from state.json
-          // (bot writes) except the header emoji derived from success/failure.
+          // Step 4e-pre: finalize outcome + BL-38 poison-session self-heal.
+          // The success/failure truth-ordering is decided HERE (moved up from
+          // Step 4f) so the consecutive-stuck counter can be folded into the
+          // session write below and the reset decided in one place. Step 4f
+          // reuses `success` / `failureReason` / `cardKitTimeoutFailure` — it
+          // does not recompute them.
           //
           // Truth ordering (most authoritative first):
-          //   1. bot wrote `status=failed` in state.json → fail (use bot's error)
-          //   2. bot wrote `status=ready` → success (regardless of exitCode —
-          //      the runner grace-timer may SIGTERM claude when a non-detached
-          //      grandchild blocks exit, but that's an OS quirk, not a real
-          //      failure if state.json says we're done)
-          //   3. exitCode === 0 → success (bot didn't update state.json but
-          //      claude exited cleanly — likely just acknowledged the message)
-          //   4. else → fail (real crash)
-          //
-          // Card body text = bot's `last_message` (preferred, productized),
-          // falling back to streamed text only when bot didn't write one.
+          //   1. bot wrote status=failed → fail (use bot's error)
+          //   2. bot wrote status=ready → success (regardless of exitCode — the
+          //      runner grace-timer may SIGTERM claude when a non-detached
+          //      grandchild blocks exit, an OS quirk, not a real failure)
+          //   3. idle watchdog fired (real hang) → fail (已中断)
+          //   4. exitCode === 0 → success (clean exit, bot wrote no status)
+          //   5. else → fail (real crash)
           const reportedStatus = reportedState?.status;
           const reportedError = reportedState?.error;
           const cardKitTimeoutFailure =
             interruptedByIdle && reportedStatus !== "ready" && reportedStatus !== "failed";
           let success: boolean;
           let failureReason: string | undefined;
-
           if (reportedStatus === "failed") {
             success = false;
             failureReason = reportedError ?? "bot 报告 failed (无 error 字段)";
@@ -2308,6 +2272,105 @@ export class BridgeHandler {
             });
           }
 
+          // BL-38 counter: a confirmed idle-stuck turn accrues (+1); a clean
+          // success resets to 0; any OTHER failure (crash / explicit `failed`)
+          // leaves it UNCHANGED — conservative, so only a proven consecutive-
+          // hang streak triggers the reset, and an ambiguous crash neither
+          // punishes nor rescues a possibly-poisoned session.
+          const stuckResetAfter = resolveStuckSessionResetAfter();
+          const prevStuckCount = currentExisting?.consecutiveStuckCount ?? 0;
+          const nextStuckCount = cardKitTimeoutFailure
+            ? prevStuckCount + 1
+            : success
+              ? 0
+              : prevStuckCount;
+          const stuckResetTriggered = cardKitTimeoutFailure && nextStuckCount >= stuckResetAfter;
+
+          // Step 4e: session persistence (3 cases).
+          const now = Date.now();
+
+          if (stuckResetTriggered) {
+            // BL-38: this thread has ended by the idle watchdog on
+            // `stuckResetAfter` consecutive turns — the session is behaviorally
+            // poisoned (resume keeps producing the same silent hang). Drop the
+            // record entirely (same delete semantics as the stale/ghost purge)
+            // so the next @ on this thread starts a brand-new session. The
+            // failure card below (Step 4f) tells the user it was reset.
+            await this.deps.sessionStore.delete(threadId, botId);
+            console.info(
+              `[bridge.handler] BL-38 stuck-session reset: thread=${threadId} bot=${botId} ` +
+                `consecutiveStuckCount=${nextStuckCount} (>= ${stuckResetAfter}) — dropped session ` +
+                `record; next @ starts fresh`,
+            );
+          } else if (sessionId !== undefined && currentExisting === undefined) {
+            // New thread — create record. rootText/chatId (v3 task-handle
+            // dispatch-time capture, docs/task-handle.md §5.2/§9.9) are
+            // captured ONLY here, and ONLY when `isTopLevel` (computed above
+            // from the absence of `root_id`) confirms THIS message truly is
+            // the topic's own root — not merely the first turn the BOT
+            // happened to see. (Adversarial-review fix: an earlier version
+            // captured unconditionally on "this bot's first completed turn
+            // in the thread," which is wrong whenever a human opens a topic
+            // and only @-mentions the bot in a LATER reply — that reply's
+            // text got stored as if it were the root, and could then exact-
+            // match an unrelated task and auto-bind the wrong pair. When
+            // `isTopLevel` is false here, rootText/chatId are simply left
+            // undefined — the same safe "no auto-bind candidate for this
+            // thread" degradation already documented for other rootText
+            // gaps; the agent-path candidate injection is unaffected.)
+            // Truncated defensively when captured; TasklistPoller's exact-
+            // match tolerates (doesn't need to recover from) a truncated
+            // value — see its own doc comment.
+            await this.deps.sessionStore.put({
+              threadId,
+              sessionId,
+              botId,
+              createdTs: now,
+              lastActiveTs: now,
+              senderOpenId,
+              // BL-38: a brand-new thread that idle-killed on its very first turn
+              // starts the counter at 1 (0 when clean; only persisted when > 0).
+              consecutiveStuckCount: nextStuckCount,
+              ...(isTopLevel ? { rootText: parsed.text.slice(0, 200), chatId: parsed.chatId } : {}),
+            });
+          } else if (sessionId !== undefined && currentExisting !== undefined) {
+            // Existing thread — update, preserving createdTs AND rootText/
+            // chatId verbatim from whenever this thread was first created
+            // (never recomputed from a later turn's message).
+            await this.deps.sessionStore.put({
+              threadId,
+              sessionId,
+              botId,
+              createdTs: currentExisting.createdTs,
+              lastActiveTs: now,
+              senderOpenId,
+              rootText: currentExisting.rootText,
+              chatId: currentExisting.chatId,
+              // BL-38: +1 on an idle-stuck turn, 0 (cleared) on any clean turn.
+              consecutiveStuckCount: nextStuckCount,
+            });
+          } else if (currentExisting !== undefined && sessionId === undefined) {
+            // Anomaly: no system_init seen; touch to update lastActiveTs at minimum.
+            // BL-38: still update the counter — the spread carries the OLD value,
+            // so set it explicitly AFTER the spread (0 clears it, +1 accrues it).
+            await this.deps.sessionStore.put({
+              ...currentExisting,
+              lastActiveTs: now,
+              consecutiveStuckCount: nextStuckCount,
+            });
+          }
+
+          // Step 4f: finalize card.
+          //
+          // Bridge does NOT interpret content — all fields come from state.json
+          // (bot writes) except the header emoji derived from success/failure.
+          // The success/failure decision (truth ordering) + its event logging
+          // were made in Step 4e-pre (BL-38); `success` / `failureReason` /
+          // `cardKitTimeoutFailure` are reused here, not recomputed.
+          //
+          // Card body text = bot's `last_message` (preferred, productized),
+          // falling back to streamed text only when bot didn't write one.
+
           // reportedState is null when the bot didn't rewrite state.json this
           // turn (stale-guard above), so this falls back to the agent's fresh
           // trusted answer-channel text instead of repeating the previous reply.
@@ -2329,13 +2392,19 @@ export class BridgeHandler {
               : "") +
             "下一步：换个说法重试，或新开一个话题继续；若反复如此，请让维护者查看该 session 日志。";
           const cardBody =
-            cardKitTimeoutFailure
-              // PRB-9/§12.2: idle-stuck → unified explicit-failure sink, never a
-              // passive wait. 批A does NOT auto-replay it — the owner retries
-              // manually (safe auto-replay + idempotency is 批B §11.6).
-              ? "⚠️ 本轮被中断（长时间无活性，判定卡死），未完成。请重试。"
-              : reportedState?.last_message ??
-                (fallbackAnswer ? fallbackAnswer : noOutputFallback);
+            stuckResetTriggered
+              // BL-38: crossed the consecutive-idle-kill threshold — we just
+              // dropped the poisoned session (Step 4e), so tell the user this
+              // topic was reset and the next @ starts clean. Distinct from the
+              // single-idle-kill "请重试" below, which keeps the session.
+              ? "⚠️ 本轮被中断（长时间无活性，判定卡死）。连续多次卡死，已重置本话题上下文 —— 下次 @ 我将全新开始，请把需求重新说一遍。"
+              : cardKitTimeoutFailure
+                // PRB-9/§12.2: idle-stuck → unified explicit-failure sink, never a
+                // passive wait. 批A does NOT auto-replay it — the owner retries
+                // manually (safe auto-replay + idempotency is 批B §11.6).
+                ? "⚠️ 本轮被中断（长时间无活性，判定卡死），未完成。请重试。"
+                : reportedState?.last_message ??
+                  (fallbackAnswer ? fallbackAnswer : noOutputFallback);
 
           // When the agent didn't report status this turn (reportedState null,
           // per stale-guard) but exited cleanly, don't let the card default to

--- a/src/claude/sessionStore.test.ts
+++ b/src/claude/sessionStore.test.ts
@@ -355,3 +355,81 @@ describe("rootText / chatId (v3 task-handle dispatch-time capture)", () => {
     expect(rec?.rootText).toBeUndefined();
   });
 });
+
+// ---------------------------------------------------------------------------
+// BL-38: consecutiveStuckCount persistence
+// ---------------------------------------------------------------------------
+
+describe("BL-38 consecutiveStuckCount", () => {
+  it("persists a positive count and round-trips it via get", async () => {
+    const store = await SessionStore.load(sessionsPath);
+    await store.put({
+      threadId: "om_stuck",
+      sessionId: "sess-1",
+      botId: "bot-a",
+      createdTs: 1,
+      lastActiveTs: 2,
+      consecutiveStuckCount: 2,
+    });
+    expect(store.get("om_stuck", "bot-a")?.consecutiveStuckCount).toBe(2);
+
+    // Survives a reload from disk.
+    const reloaded = await SessionStore.load(sessionsPath);
+    expect(reloaded.get("om_stuck", "bot-a")?.consecutiveStuckCount).toBe(2);
+  });
+
+  it("omits the field when the count is 0 or undefined (a clean thread stays clean on disk)", async () => {
+    const store = await SessionStore.load(sessionsPath);
+    await store.put({
+      threadId: "om_zero",
+      sessionId: "sess-1",
+      botId: "bot-a",
+      createdTs: 1,
+      lastActiveTs: 2,
+      consecutiveStuckCount: 0,
+    });
+    await store.put({
+      threadId: "om_absent",
+      sessionId: "sess-2",
+      botId: "bot-a",
+      createdTs: 1,
+      lastActiveTs: 2,
+    });
+    expect(store.get("om_zero", "bot-a")?.consecutiveStuckCount).toBeUndefined();
+    expect(store.get("om_absent", "bot-a")?.consecutiveStuckCount).toBeUndefined();
+    // Not merely undefined in memory — the key is absent on disk.
+    const onDisk = await readCurrentFile();
+    expect(onDisk.records).not.toHaveProperty(["bot-a:om_zero", "consecutiveStuckCount"]);
+  });
+
+  it("re-putting with 0 clears a previously-persisted positive count", async () => {
+    const store = await SessionStore.load(sessionsPath);
+    const base = { threadId: "om_reset", sessionId: "sess-1", botId: "bot-a", createdTs: 1, lastActiveTs: 2 };
+    await store.put({ ...base, consecutiveStuckCount: 3 });
+    expect(store.get("om_reset", "bot-a")?.consecutiveStuckCount).toBe(3);
+    await store.put({ ...base, consecutiveStuckCount: 0 });
+    expect(store.get("om_reset", "bot-a")?.consecutiveStuckCount).toBeUndefined();
+  });
+
+  it("touch preserves the count (does not clobber it while updating lastActiveTs)", async () => {
+    const store = await SessionStore.load(sessionsPath);
+    await store.put({
+      threadId: "om_touch",
+      sessionId: "sess-1",
+      botId: "bot-a",
+      createdTs: 1,
+      lastActiveTs: 2,
+      consecutiveStuckCount: 2,
+    });
+    await store.touch("om_touch", "bot-a");
+    expect(store.get("om_touch", "bot-a")?.consecutiveStuckCount).toBe(2);
+  });
+
+  it("a record predating the field reads as undefined (backward compatible)", async () => {
+    await writeV2Fixture({
+      "bot-a:om_old": { threadId: "om_old", sessionId: "s", botId: "bot-a", createdTs: 1, lastActiveTs: 2 },
+    });
+    const store = await SessionStore.load(sessionsPath);
+    expect(store.get("om_old", "bot-a")?.consecutiveStuckCount).toBeUndefined();
+  });
+});

--- a/src/claude/sessionStore.ts
+++ b/src/claude/sessionStore.ts
@@ -91,6 +91,18 @@ export interface SessionRecord {
    * mapping independent of a live in-flight turn.
    */
   chatId?: string;
+  /**
+   * BL-38 (poison-session self-heal): count of CONSECUTIVE turns on this thread
+   * that ended by the idle watchdog (a confirmed hang). Incremented on each
+   * such turn, reset to 0 by any clean-completing turn. When it reaches the
+   * threshold (handler.ts STUCK_SESSION_RESET_AFTER) the bridge drops this
+   * record so the next @ starts from a fresh session — the fix for a
+   * behaviorally-poisoned session that keeps resuming into the same silent
+   * hang (idle-kill produces no resume error, so the ghost-session purge never
+   * fires on it). Absent on records written before this field existed / on any
+   * non-stuck thread = 0 (backward compatible; only persisted when > 0).
+   */
+  consecutiveStuckCount?: number;
 }
 
 /** The shape actually persisted to disk — botId required. */
@@ -103,6 +115,7 @@ interface StoredRecord {
   senderOpenId?: string;
   rootText?: string;
   chatId?: string;
+  consecutiveStuckCount?: number;
 }
 
 interface StoreFile {
@@ -359,6 +372,9 @@ export class SessionStore {
       ...(record.senderOpenId !== undefined ? { senderOpenId: record.senderOpenId } : {}),
       ...(record.rootText !== undefined ? { rootText: record.rootText } : {}),
       ...(record.chatId !== undefined ? { chatId: record.chatId } : {}),
+      // BL-38: only persist when > 0 — a 0/undefined counter is a clean thread,
+      // so passing consecutiveStuckCount: 0 naturally clears the field on reset.
+      ...(record.consecutiveStuckCount ? { consecutiveStuckCount: record.consecutiveStuckCount } : {}),
     };
     this.#map.set(key, stored);
     await this.#flush();


### PR DESCRIPTION
## Problem (BL-38)

A topic's session can become **behaviorally poisoned** after repeated interrupt+retry: every resume produces a session that emits one line ("我继续推进") then goes silent *before its first tool call*, and the idle watchdog kills it — 5+ turns in a row on the real machine, same resume id. The existing stale/ghost-session purge (`handler.ts`) only clears sessions whose **resume** errors (`No conversation found` / `no rollout found`); an idle-kill produces **no resume error**, so the poisoned session is never dropped and the user's only escape is to open a new topic.

## Fix

Count consecutive idle-kills per thread; after a threshold (default **3**, env `LARKWAY_STUCK_SESSION_RESET_AFTER`) drop the session record so the next `@` starts fresh, and say so on the failure card.

- **`SessionRecord` / `StoredRecord`**: new optional `consecutiveStuckCount`, persisted only when `> 0` (absent === 0, backward compatible; a `0` write clears it).
- **handler finalize**: the success/failure truth-ordering is hoisted to **Step 4e-pre** (one source of `success` / `cardKitTimeoutFailure`, reused by the card finalize — no second copy) so the counter can be folded into the session write. Rules:
  - idle-kill turn → **+1**
  - clean success → **reset 0**
  - any OTHER failure (crash / explicit `failed`) → **unchanged** (conservative — only a proven consecutive-hang streak triggers the reset; an ambiguous crash neither punishes nor rescues a possibly-poisoned session)
- **At the threshold**: `sessionStore.delete` the record (same semantics as the ghost purge), swap the failure card to an explicit `⚠️ …已重置本话题上下文 —— 下次 @ 我将全新开始，请把需求重新说一遍。` variant, and log one `info` line (`thread`/`bot`/`count`) for triage.

## Tests (11 new, full suite 1405 green)

- `sessionStore.test.ts`: positive round-trip + reload; `0`/undefined omitted on disk; re-put `0` clears a prior positive; `touch` preserves; pre-field record reads undefined (backward compat).
- `handler.test.ts` (BL-38 describe): idle-kill increments & **keeps** the session with the `请重试` card; success resets; crash **neither counts nor resets**; threshold **drops the record** + reset card + info log; env override lowers the threshold; a pre-field record counts an idle-kill as the first.

Verification: `pnpm typecheck` / `pnpm test` (1405) / `pnpm build` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)